### PR TITLE
Create 'setup-isabelle-action' as shorthand for setting up Isabelle

### DIFF
--- a/.github/actions/setup-isabelle-action/action.yml
+++ b/.github/actions/setup-isabelle-action/action.yml
@@ -1,0 +1,33 @@
+# Composite action to setup Isabelle
+# NOTE: Needs to be run under the makarius/isabelle:Isabelle2025 container
+name: Setup Isabelle
+description: 'Setup Isabelle: checkout the AFP, set environment variables, cache heap images'
+runs:
+  using: "composite"
+  steps:
+    - name: Checkout AFP
+      uses: actions/checkout@v3
+      with:
+        repository: isabelle-prover/mirror-afp-2025
+        path: afp
+
+    - name: Set afp component base
+      shell: bash
+      run: |
+        echo "AFP_COMPONENT_BASE=afp/thys" >> $GITHUB_ENV
+
+    - name: Set isabelle home 
+      shell: bash
+      run: |
+        echo "$(/home/isabelle/Isabelle/bin/isabelle getenv ISABELLE_HOME)" >> $GITHUB_ENV
+
+    - name: Set isabelle home user
+      shell: bash
+      run: |
+        echo "$($ISABELLE_HOME/bin/isabelle getenv ISABELLE_HOME_USER)" >> $GITHUB_ENV
+
+    - name: Cache heap images
+      uses: actions/cache@v3
+      with:
+        path: ${{ env.ISABELLE_HOME_USER }}/heaps/
+        key: heap-images-${{ github.ref_name }}

--- a/.github/workflows/dev.workflow.yml
+++ b/.github/workflows/dev.workflow.yml
@@ -20,27 +20,10 @@ jobs:
       - name: Checkout AutoCorrode
         uses: actions/checkout@v3
       
-      - name: Checkout AFP
-        uses: actions/checkout@v3
-        with:
-          repository: isabelle-prover/mirror-afp-2025
-          path: afp
-
-      - name: Set isabelle home 
-        run: |
-          echo "$(/home/isabelle/Isabelle/bin/isabelle getenv ISABELLE_HOME)" >> $GITHUB_ENV
-
-      - name: Set isabelle home user
-        run: |
-          echo "$($ISABELLE_HOME/bin/isabelle getenv ISABELLE_HOME_USER)" >> $GITHUB_ENV
-
-      - name: Cache heap images
-        uses: actions/cache@v3
-        with:
-          path: ${{ env.ISABELLE_HOME_USER }}/heaps/
-          key: heap-images-${{ github.ref_name }}
+      - name: Setup Isabelle
+        uses: ./.github/actions/setup-isabelle-action
 
       # Build with HTML documentation, to make sure we can deploy to pages on merge
       - name: Build AutoCorrode
         run: |
-          $ISABELLE_HOME/bin/isabelle build -v -d . -o browser_info -d afp/thys/Word_Lib AutoCorrode
+          $ISABELLE_HOME/bin/isabelle build -v -b -d . -o browser_info -d $AFP_COMPONENT_BASE/Word_Lib AutoCorrode


### PR DESCRIPTION
Issue #3

Add a `setup-isabelle-action` github action, and use that in the build action. Tweak the build options to export heap images, and stop using hardcoded paths to the AFP clone.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
