### PR TITLE
Reworked Rust range material to bring it closer to Rust standard library

### DIFF
--- a/Micro_Rust_Examples/Linked_List.thy
+++ b/Micro_Rust_Examples/Linked_List.thy
@@ -124,7 +124,7 @@ ucincl_proof reverse_unlink_contract
 
 lemma reverse_unlink_spec[crush_specs]:
   shows \<open>\<Gamma>; reverse_unlink n ll tmp0 tmp1 \<Turnstile>\<^sub>F reverse_unlink_contract n ll tmp0 tmp1 ts rem\<close>
-  apply (crush_boot f:reverse_unlink_def contract: reverse_unlink_contract_def)
+  apply (crush_boot f: reverse_unlink_def contract: reverse_unlink_contract_def)
   apply crush_base
   apply (ucincl_discharge\<open>
     rule_tac INV=\<open>\<lambda>_ i.

--- a/Micro_Rust_Std_Lib/ROOT
+++ b/Micro_Rust_Std_Lib/ROOT
@@ -18,6 +18,7 @@ session Micro_Rust_Std_Lib = HOL +
     StdLib_Option
     StdLib_Ordering
     StdLib_Slice
+    StdLib_Range
     StdLib_References
     StdLib_Result
     StdLib_Tuple

--- a/Micro_Rust_Std_Lib/StdLib_All.thy
+++ b/Micro_Rust_Std_Lib/StdLib_All.thy
@@ -9,6 +9,7 @@ theory StdLib_All
     StdLib_Iterators
     StdLib_Logging
     StdLib_Option
+    StdLib_Range
     StdLib_References
     StdLib_Result
     StdLib_Slice

--- a/Micro_Rust_Std_Lib/StdLib_Option.thy
+++ b/Micro_Rust_Std_Lib/StdLib_Option.thy
@@ -83,7 +83,8 @@ notation_nano_rust_function urust_func_option_is_some ("is_some")
 definition option_is_some_contract :: 
   \<open>'a option \<Rightarrow> ('s::{sepalg}, bool, 'abort) function_contract\<close>
   where [crush_contracts]: \<open>option_is_some_contract res \<equiv>
-    let pre = UNIV; post = \<lambda>r. \<langle>r = Not (Option.is_none res)\<rangle>
+    let pre  = UNIV;
+        post = \<lambda>r. \<langle>r \<longleftrightarrow> \<not>Option.is_none res\<rangle>
     in make_function_contract pre post\<close>
 ucincl_auto option_is_some_contract
 

--- a/Micro_Rust_Std_Lib/StdLib_Range.thy
+++ b/Micro_Rust_Std_Lib/StdLib_Range.thy
@@ -1,0 +1,38 @@
+(* Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+   SPDX-License-Identifier: MIT *)
+
+(*<*)
+theory StdLib_Range                            
+  imports Crush.Crush Shallow_Micro_Rust.Range_Type
+begin
+(*>*)
+
+definition is_empty_contract :: \<open>'a::{ord} range \<Rightarrow> ('machine::{sepalg}, bool, 'abort) function_contract\<close> where
+  [crush_contracts]: \<open>is_empty_contract r \<equiv>
+    let pre  = \<top>;
+        post = \<lambda>res. \<langle>res \<longleftrightarrow> \<not>start r < end r\<rangle>
+     in make_function_contract pre post\<close>
+ucincl_auto is_empty_contract
+
+lemma is_empty_spec [crush_specs]:
+  shows \<open>\<Gamma> ; is_empty r \<Turnstile>\<^sub>F is_empty_contract r\<close>
+by (contract f: is_empty_def contract: is_empty_contract_def) crush_base
+
+definition contains_contract :: \<open>'a::{ord} range \<Rightarrow> 'a \<Rightarrow> ('machine::{sepalg}, bool, 'abort) function_contract\<close> where
+  [crush_contracts]: \<open>contains_contract r e \<equiv>
+    let pre  = \<top>;
+        post = \<lambda>res. \<langle>res \<longleftrightarrow> start r \<le> e \<and> e < end r\<rangle>
+     in make_function_contract pre post\<close>
+ucincl_auto contains_contract
+
+lemma contains_spec [crush_specs]:  
+  shows \<open>\<Gamma> ; contains r e \<Turnstile>\<^sub>F contains_contract r e\<close>
+by (contract f: contains_def contract: contains_contract_def) crush_base
+
+lemma range_into_list_make_range [micro_rust_simps]:
+  shows \<open>range_into_list (make_range s e) = list.map word_of_nat [unat s..<unat e]\<close>
+by (clarsimp simp add: range_into_list_def)
+
+(*<*)
+end
+(*>*)

--- a/Shallow_Micro_Rust/Range_Type.thy
+++ b/Shallow_Micro_Rust/Range_Type.thy
@@ -3,47 +3,36 @@
 
 (*<*)
 theory Range_Type
-  imports Core_Expression Rust_Iterator
+  imports Core_Expression Rust_Iterator "HOL-Library.Datatype_Records"
 begin
 (*>*)
 
 section\<open>The \<^emph>\<open>Range\<close> type\<close>
 
-datatype 'a range
-  = Range   \<open>'a\<close> \<open>'a\<close> \<comment> \<open>Beginning, end of range, exclusive\<close>
-  | RangeEq \<open>'a\<close> \<open>'a\<close> \<comment> \<open>Beginning, end or range, inclusive\<close>
+datatype_record 'a range =
+  start :: \<open>'a\<close>
+  "end"  :: \<open>'a\<close>
 
-text\<open>The range \<^term>\<open>Range start end\<close> contains all values with \<^term>\<open>start \<le> x \<and> x < end\<close>.
-It is empty if \<^term>\<open>start \<ge> end\<close>. The range \<^term>\<open>RangeEq start end\<close> contains all
-values with \<^term>\<open>start \<le> x \<and> x \<le> end\<close> and is empty if \<^term>\<open>start > end\<close>.\<close>
-
-subsection\<open>Syntax for the \<^emph>\<open>Range\<close> type\<close>
+text\<open>A range contains all values with \<^term>\<open>start \<le> x \<and> x < end\<close>.  It is empty if \<^term>\<open>start \<ge> end\<close>.\<close>
 
 subsection\<open>Core material related to the \<^emph>\<open>Range\<close> type\<close>
 
 definition is_empty :: \<open>'a::{ord} range \<Rightarrow> ('s, bool, 'abort, 'i, 'o) function_body\<close>  where
-  \<open>is_empty r \<equiv> FunctionBody
-    (case r of
-       Range s e   \<Rightarrow> literal (s \<ge> e)
-     | RangeEq s e \<Rightarrow> literal (s > e))\<close>
+  \<open>is_empty r \<equiv> FunctionBody (literal (\<not> (start r < end r)))\<close>
 
 definition contains :: \<open>'a::ord range \<Rightarrow> 'a \<Rightarrow> ('s, bool, 'abort, 'i, 'o) function_body\<close> where
-  \<open>contains r x \<equiv> FunctionBody
-    (case r of
-       Range s e   \<Rightarrow> literal (s \<le> x \<and> x < e)
-     | RangeEq s e \<Rightarrow> literal (s \<le> x \<and> x \<le> e))\<close>
+  \<open>contains r x \<equiv> FunctionBody (literal (start r \<le> x \<and> x < end r))\<close>
 
 definition range_new :: \<open>'a \<Rightarrow> 'a \<Rightarrow> ('s, 'a range, 'abort, 'i, 'o) function_body\<close> where
-  \<open>range_new \<equiv> lift_fun2 Range\<close>
+  \<open>range_new \<equiv> lift_fun2 make_range\<close>
 
-definition range_eq_new :: \<open>'a \<Rightarrow> 'a \<Rightarrow> ('s, 'a range, 'abort, 'i, 'o) function_body\<close> where
-  \<open>range_eq_new \<equiv> lift_fun2 RangeEq\<close>
+definition range_eq_new :: \<open>'a::{one, plus} \<Rightarrow> 'a \<Rightarrow> ('s, 'a range, 'abort, 'i, 'o) function_body\<close> where
+  \<open>range_eq_new \<equiv> lift_fun2 (\<lambda>x y. make_range x (y + 1))\<close>
 
 text\<open>Iterator for a range\<close>
 
-fun range_into_list :: \<open>'a::len word range \<Rightarrow> 'a word list\<close> where
-   \<open>range_into_list (Range s e) = List.map of_nat [unat s..<(unat e)]\<close> 
- | \<open>range_into_list (RangeEq s e) = List.map of_nat [unat s..<(unat e+1)]\<close>
+definition range_into_list :: \<open>'a::{len} word range \<Rightarrow> 'a word list\<close> where
+  \<open>range_into_list r \<equiv> List.map of_nat [unat (start r) ..< unat (end r)]\<close>
 
 definition make_iterator_from_range :: \<open>'b::{len} word range \<Rightarrow> ('a, 'b word, 'abort, 'i, 'o) iterator\<close> where
   [micro_rust_simps]: \<open>make_iterator_from_range r \<equiv> make_iterator_from_list (range_into_list r)\<close>
@@ -58,45 +47,35 @@ subsection\<open>Slice-like behavior from lists\<close>
 definition len :: \<open>'a list \<Rightarrow> ('s, 64 word, 'abort, 'i, 'o) function_body\<close> where
   \<open>len xs \<equiv> FunctionBody (literal (of_nat (length xs)))\<close>
 
-definition list_index :: \<open>'a list \<Rightarrow> 'w::len word \<Rightarrow> ('s,'a, 'abort, 'i, 'o) function_body\<close> where
+definition list_index :: \<open>'a list \<Rightarrow> 'w::len word \<Rightarrow> ('s, 'a, 'abort, 'i, 'o) function_body\<close> where
   \<open>list_index xs idx \<equiv> FunctionBody (
      case nth_opt (unat idx) xs of
        None \<Rightarrow> abort DanglingPointer
      | Some x \<Rightarrow> literal x)\<close>
 
-definition array_index :: \<open>('a, 'l::{len}) array \<Rightarrow> 'w::len word \<Rightarrow> ('s, 'a, 'abort, 'i, 'o) function_body\<close> where
+definition array_index :: \<open>('a, 'l::{len}) array \<Rightarrow> 'w::{len} word \<Rightarrow> ('s, 'a, 'abort, 'i, 'o) function_body\<close> where
   \<open>array_index xs idx \<equiv> FunctionBody (
      if unat idx < array_len xs then
        literal (array_nth xs (unat idx))
      else
        abort DanglingPointer)\<close>
  
-definition vector_index :: \<open>('a, 'l::{len}) vector \<Rightarrow> 'w::len word \<Rightarrow> ('s, 'a, 'abort, 'i, 'o) function_body\<close> where
+definition vector_index :: \<open>('a, 'l::{len}) vector \<Rightarrow> 'w::{len} word \<Rightarrow> ('s, 'a, 'abort, 'i, 'o) function_body\<close> where
   \<open>vector_index xs idx \<equiv> FunctionBody (
      if unat idx < vector_len xs then
        literal (vector_nth xs (unat idx))
      else
        abort DanglingPointer)\<close>
 
-definition list_index_range :: \<open>'a list \<Rightarrow> 'w::len word range \<Rightarrow> ('s,'a list, 'abort, 'i, 'o) function_body\<close> where
+definition list_index_range :: \<open>'a list \<Rightarrow> 'w::{len} word range \<Rightarrow> ('s,'a list, 'abort, 'i, 'o) function_body\<close> where
   \<open>list_index_range xs rng \<equiv> FunctionBody (
-    case rng of
-      Range s e \<Rightarrow>
-        if s \<ge> e then
-          literal []
-        else
-          if unat e \<le> length xs then
-            literal (take (unat (e-s)) (drop (unat s) xs))
-          else
-            abort DanglingPointer
-    | RangeEq s e \<Rightarrow>
-        if s > e then
-          literal []
-        else
-          if unat e < length xs then
-            literal (take (1 + unat (e-s)) (drop (unat s) xs))
-          else
-            abort DanglingPointer)\<close>
+    if start rng \<ge> end rng then
+      literal []
+    else
+      if unat (end rng) \<le> length xs then
+        literal (take (unat ((end rng) - (start rng))) (drop (unat (start rng)) xs))
+      else
+        abort DanglingPointer)\<close>
 
 definition array_index_range :: \<open>('a, 'l::{len}) array \<Rightarrow> 'w::{len} word range \<Rightarrow>
       ('s, 'a list, 'abort, 'i, 'o) function_body\<close> where

--- a/Shallow_Separation_Logic/Weakest_Precondition.thy
+++ b/Shallow_Separation_Logic/Weakest_Precondition.thy
@@ -676,13 +676,8 @@ lemma wp_funliteral:
 
 lemma wp_range_new [micro_rust_wp_simps]:
   assumes \<open>\<And>r. ucincl (\<phi> r)\<close>
-    shows \<open>\<W>\<P> \<Gamma> (\<langle>\<up>b\<dots>\<up>e\<rangle>) \<phi> \<rho> \<theta> = \<phi> (Range b e)\<close>
+    shows \<open>\<W>\<P> \<Gamma> (\<langle>\<up>b\<dots>\<up>e\<rangle>) \<phi> \<rho> \<theta> = \<phi> (make_range b e)\<close>
 using assms by (clarsimp simp add: range_new_def wp_funliteral)
-
-lemma wp_range_eq_new [micro_rust_wp_simps]:
-  assumes \<open>\<And>r. ucincl (\<phi> r)\<close>
-    shows \<open>\<W>\<P> \<Gamma> (\<langle>\<up>b\<dots>=\<up>e\<rangle>) \<phi> \<rho> \<theta> = \<phi> (RangeEq b e)\<close>
-using assms by (clarsimp simp add: range_eq_new_def wp_funliteral)
 
 lemma wp_op_eq [micro_rust_wp_simps]:
   assumes \<open>\<And>r. ucincl (\<psi> r)\<close>


### PR DESCRIPTION
*Description of changes:*

- Modelled the range type as a datatype record (structure) containing two fields marking the start and end of a range.
- Removed previous distinction between an open and a closed range, as two distinct datatype constructors.  This is now handled via the `new_` functions which create ranges.
- Added new `StdLib_Range` theory file, worked it into the existing Micro Rust standard library theory hierarchy.
- Added explicit contracts and specification lemmas for functionality associated with the range type.
- Minor adjustments of existing proofs, here-and-there, to work this new material in.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
