### PR TITLE
Export complete `browser_info` folder to github pages, to fix broken links to HOL definitions

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -42,7 +42,7 @@ jobs:
       - name: Upload documentation as pages artifact
         uses: actions/upload-pages-artifact@v3
         with:
-          path: ${{ env.ISABELLE_HOME_USER}}/browser_info/Unsorted/AutoCorrode
+          path: ${{ env.ISABELLE_HOME_USER}}/browser_info
 
   # Single deploy job since we're just deploying
   deploy:


### PR DESCRIPTION
Links to HOL definitions are currently broken in the documentation, see e.g. [here](https://awslabs.github.io/AutoCorrode/HOL-Library.Word.html#Word.word|type) and try clicking on `take_bit`

This fixes that by exporting the complete `browser_info` folder. URLs will become uglier, requiring an additional `Unsorted/AutoCorrode/` in the path to reach. These path changes will break some links after deployment, will need to follow up with another PR to fix that.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
