### PR TITLE
Crush: Automatically eta-expand theorems used in `simp prems/concls`

### DIFF
--- a/Crush/base.ML
+++ b/Crush/base.ML
@@ -65,6 +65,10 @@ sig
  val force_meta_eq : thm -> thm
  val force_meta_eqs : thm list -> thm list
 
+ \<comment>\<open>Eta expand definitional theorem so there's no toplevel \<^verbatim>\<open>\<lambda>x. _\<close> on the RHS\<close>
+ val eta_expand: thm -> thm 
+ val eta_expands: thm list -> thm list  
+
  val intro_tac : thm list -> Proof.context -> int -> tactic
  val elim_tac : thm list -> Proof.context -> int -> tactic
 
@@ -424,6 +428,20 @@ struct
   fun force_meta_eq (t : thm): thm = t RS eq_reflection handle THM _ => t
   val force_meta_eqs : thm list -> thm list = List.map force_meta_eq
 
+  fun eta_expand thm =
+    let
+      val num_abs = thm 
+        |> Thm.prop_of 
+        |> Logic.dest_equals 
+        |> snd 
+        |> Term.strip_abs 
+        |> fst 
+        |> length      
+    in
+      funpow num_abs (fn t => t RS @{thm meta_fun_cong}) thm
+    end
+  val eta_expands : thm list -> thm list = List.map eta_expand
+
   fun filter_to_conv (f : cterm -> bool) : conv = fn t =>
      if f t then Conv.all_conv t else Conv.no_conv t
 
@@ -532,6 +550,9 @@ local
 
   val _ = Theory.setup (Attrib.setup @{binding "meta_all_intro"}
                        (Thm.rule_attribute [] (K Thm.forall_intr_vars) |> Scan.succeed) "")
+
+  val _ = Theory.setup (Attrib.setup @{binding "unabs_def"}
+                       (Thm.rule_attribute [] (K Crush_Base.eta_expand) |> Scan.succeed) "")
 
   fun all_intro ctxt thm = 
      let val ctxt = Context.proof_of ctxt

--- a/Crush/config.ML
+++ b/Crush/config.ML
@@ -62,6 +62,9 @@ sig
   val enable_schematics : bool Config.T
   val enable_branch_split : bool Config.T
 
+  val enable_base_simps_detect_aentails_contradiction : bool Config.T
+  val enable_base_simps_early_unfold : bool Config.T
+
   val enable_urust_split_branch : bool Config.T
   val enable_urust_determine_branch : bool Config.T
 
@@ -142,6 +145,9 @@ struct
   val step_time_bound_ms = Attrib.setup_config_int @{binding "crush_time_step_bound_ms"} (K 10000)
 
   val fail_on_bad_schematic = Attrib.setup_config_bool @{binding "crush_fail_on_bad_schematic"} (K true)
+
+  val enable_base_simps_early_unfold = Attrib.setup_config_bool @{binding "crush_enable_early_unfold"} (K true)
+  val enable_base_simps_detect_aentails_contradiction = Attrib.setup_config_bool @{binding "crush_enable_contradiction_detection"} (K true)
 
   val relevance_filter_max_facts = Attrib.setup_config_int @{binding "crush_relevance_filter_max_facts"} (K 20)
 

--- a/Crush/crush.ML
+++ b/Crush/crush.ML
@@ -134,17 +134,24 @@ struct
     |> simpset_map (Context.proof_of ctxt)
     |> URustContractSimps.map)
 
+  fun extract_contract_components ctxt t =
+    List.map
+      (rewrite_rule ctxt @{thms Let_def function_contract.sel}
+         #> simplify ctxt #> (fn t => t RS meta_eq_to_obj_eq))
+      [ (eta_expand t) RS @{thm meta_cong[where f=\<open>function_contract_pre\<close>]},
+        (eta_expand t) RS @{thm meta_cong[where f=\<open>function_contract_post\<close>]},
+        (eta_expand t) RS @{thm meta_cong[where f=\<open>function_contract_abort\<close>]} ]
+
   fun crush_register_contract_attrib (del : bool) = Thm.declaration_attribute (fn t => fn ctxt =>
-    let val t' = rewrite_rule (Context.proof_of ctxt) [@{thm Let_def}] t in ctxt |> (
+    let val t' = extract_contract_components (Context.proof_of ctxt) t in
     if del then
-      unregister_contracts [t']
-      #> Named_Theorems.del_thm @{named_theorems "crush_contract_defs"} t
-      #> Named_Theorems.del_thm @{named_theorems "no_atp"} t
+         unregister_contracts t' ctxt
+      |> List.foldl (op o) I (List.map (Named_Theorems.del_thm @{named_theorems "crush_contract_defs"}) t')
+      |> List.foldl (op o) I (List.map (Named_Theorems.del_thm @{named_theorems "no_atp"}) t')
     else
-      register_contracts [t']
-      #> Named_Theorems.add_thm @{named_theorems "crush_contract_defs"} t
-      #> Named_Theorems.add_thm @{named_theorems "no_atp"} t
-    )
+      register_contracts t' ctxt
+      |> List.foldl (op o) I (List.map (Named_Theorems.add_thm @{named_theorems "crush_contract_defs"}) t')
+      |> List.foldl (op o) I (List.map (Named_Theorems.add_thm @{named_theorems "no_atp"}) t')
     end
   )
 
@@ -173,7 +180,7 @@ struct
 
   val crush_branch_base_simps_early_unfold : Proof.context -> int -> tactic = fn ctxt =>
     let val early_simps = Named_Theorems.get ctxt @{named_theorems crush_early_simps}
-      val congs = Named_Theorems.get ctxt @{named_theorems "crush_cong"}      
+      val congs = Named_Theorems.get ctxt @{named_theorems "crush_cong"}
     in
       if Config.get ctxt Crush_Config.enable_base_simps_early_unfold then
         safe_unfold_tac' ctxt congs early_simps
@@ -263,8 +270,12 @@ struct
     fun TIME_IT msg = time_and_report ctxt msg (Config.get ctxt Crush_Config.time_calls)
     val specs = TIME_IT "crush_branch_call_init_get_specs" (fn _ => crush_get_specs ctxt with_schematics eager)
     val unfold_contract_tac = TIME "crush_branch_call_intro_find_contract" unfold_contract_tac
+
+    val contract_simps = Named_Theorems.get ctxt @{named_theorems "crush_contract_defs"}
     val confirm_no_abort_tac = TIME "crush_branch_call_confirm_no_abort" (
-           (SOLVED' (TRY o unfold_contract_tac THEN' safe_asm_simp_tac (ctxt addsimps @{thms Let_def}))) ORELSE'
+           (SOLVED' (resolve_tac ctxt contract_simps
+             ORELSE' (TRY o unfold_contract_tac THEN' safe_asm_simp_tac (ctxt addsimps @{thms Let_def}))))
+            ORELSE'
            (LOG ("Failed to show that " ^ func_name ^ " has trivial abort-postcondition") THEN' K no_tac))
 
     val post_call_simp = TIME "crush_branch_post_call_simp" (TIME_IT "crush_branch_call_init_post_call_simp"

--- a/Crush/crush.ML
+++ b/Crush/crush.ML
@@ -173,17 +173,23 @@ struct
 
   val crush_branch_base_simps_early_unfold : Proof.context -> int -> tactic = fn ctxt =>
     let val early_simps = Named_Theorems.get ctxt @{named_theorems crush_early_simps}
-      val congs = Named_Theorems.get ctxt @{named_theorems "crush_cong"}
+      val congs = Named_Theorems.get ctxt @{named_theorems "crush_cong"}      
     in
-      safe_unfold_tac' ctxt congs early_simps
+      if Config.get ctxt Crush_Config.enable_base_simps_early_unfold then
+        safe_unfold_tac' ctxt congs early_simps
+      else
+        K no_tac
     end
 
   val crush_branch_base_detect_aentails_contradiction: Proof.context -> int -> tactic = fn ctxt =>
-    IF' Separation_Logic_Tactics.is_entailment (
-      let val congs = Named_Theorems.get ctxt @{named_theorems "crush_cong"} in
-      CHANGED_PROP o (safe_simp_no_asm_only_tac' ctxt congs @{thms asepconj_bot_zero asepconj_bot_zero2})
-      THEN' TRY o resolve_tac ctxt @{thms bot_aentails_all} end
-    )
+    if Config.get ctxt Crush_Config.enable_base_simps_detect_aentails_contradiction then
+      IF' Separation_Logic_Tactics.is_entailment (
+        let val congs = Named_Theorems.get ctxt @{named_theorems "crush_cong"} in
+        CHANGED_PROP o (safe_simp_no_asm_only_tac' ctxt congs @{thms asepconj_bot_zero asepconj_bot_zero2})
+        THEN' TRY o resolve_tac ctxt @{thms bot_aentails_all} end
+      )
+    else
+      K no_tac
 
   val crush_branch_base_simps_tac : Proof.context -> int -> tactic = fn ctxt =>
     let val crush_intros = Named_Theorems.get ctxt @{named_theorems crush_intros}

--- a/Crush/seplog.ML
+++ b/Crush/seplog.ML
@@ -1476,10 +1476,10 @@ struct
      #> Conv.changed_conv
 
   fun aentails_simp_prems_conv (thms : thm list) : Proof.context -> conv =
-     (aentails_prems_concls_conv (thms |> force_meta_eqs |> Conv.rewrs_conv |> maybe_prop_conv |> K) (K Conv.all_conv))
+     (aentails_prems_concls_conv (thms |> force_meta_eqs |> eta_expands |> Conv.rewrs_conv |> maybe_prop_conv |> K) (K Conv.all_conv))
      #> Conv.changed_conv
   fun aentails_simp_concls_conv (thms : thm list) : Proof.context -> conv =
-     (aentails_prems_concls_conv (K Conv.all_conv) (thms |> force_meta_eqs |> Conv.rewrs_conv |> maybe_prop_conv |> K))
+     (aentails_prems_concls_conv (K Conv.all_conv) (thms |> force_meta_eqs |> eta_expands |> Conv.rewrs_conv |> maybe_prop_conv |> K))
      #> Conv.changed_conv
 
   fun simp_prems_tac (thms : thm list) (ctxt : Proof.context) : int -> tactic =

--- a/Crush/unfold_prems.ML
+++ b/Crush/unfold_prems.ML
@@ -39,7 +39,7 @@ struct
 
   \<comment>\<open>Safe saturating unfolding of pure premises\<close>
   fun sat_unfold_tac (ts : thm list) (ctxt : Proof.context) : int -> tactic =
-    let val ts_meta = force_meta_eqs ts
+    let val ts_meta = ts |> force_meta_eqs |> eta_expands
         val ts_elims = pure_eq_thms_to_unfold_elim ts_meta in
       elim_tac ts_elims ctxt
     end

--- a/Micro_Rust_Examples/Crush_Examples.thy
+++ b/Micro_Rust_Examples/Crush_Examples.thy
@@ -190,6 +190,13 @@ begin
     apply (crush_base_step simp prems add: Some_Ex_def)  \<comment>\<open>Introducing existential for Q ?x\<close>
     apply (rule PQ)
     done
+
+  text\<open>\<^verbatim>\<open>simp prems/concls\<close> should automatically eta expand definitions:\<close>
+  definition not_eta_expanded where \<open>not_eta_expanded \<equiv> \<lambda>x f. f x\<close>  
+  lemma \<open>\<And>foo. not_eta_expanded f t \<longlongrightarrow> foo\<close>
+    apply (crush_base simp prems add: not_eta_expanded_def) 
+    oops
+
 end
 
 text\<open>There is also \<^verbatim>\<open>simp concls add: ...\<close> for unfolding pure or spatial \<^emph>\<open>conclusions\<close>. In contrast


### PR DESCRIPTION
Previously, `crush simp prems add: some_def` would only work for eta expanded definitional theorems, excluding definition of the form `some_def \equiv \lambda x. ...`.

This commit fixes this by automatically eta expanding definitions passed to `simp prems add/del: ...` and `crush simp concls add/del: ...`.
