### PR TITLE
Crush improvements: add wp split rules, automatic eta-expansion, more branch control

### DIFF
--- a/Crush/Examples.thy
+++ b/Crush/Examples.thy
@@ -646,6 +646,19 @@ lemma
   irrelevant premises:\<close>
   apply (tactic \<open>MePo_Prem.drop_irrelevant_prems_tac @{context} 2 1\<close>)
   oops
+
+\<comment>\<open>The MePo filter never drops premises wrapped as \<^verbatim>\<open>ASSUMPTION\<close>:\<close>
+lemma 
+  assumes \<open>x < 42\<close>
+      and \<open>ASSUMPTION (g (g (f t0)) = s0)\<close>
+      and \<open>g (f t1) = s1\<close>
+      and \<open>x + y < 10*z\<close>
+    shows \<open>10*z < 20\<close>
+  using assms apply -
+  \<comment>\<open>Keeps \<^verbatim>\<open>(g (g (f t0)) = s0)\<close> which would otherwise have been thrown out.\<close>
+  apply (tactic \<open>MePo_Prem.ignore_irrelevant_prems_tac @{context} 2 1\<close>)
+  oops
+
 end
 
 subsubsection\<open>Conversions\<close>

--- a/Crush/Separation_Logic_Tactics.thy
+++ b/Crush/Separation_Logic_Tactics.thy
@@ -29,6 +29,7 @@ ML\<open>
    val _ =  Theory.setup (Named_Theorems.declare @{binding "crush_concls_simps"}      "" #> snd |> Named_Target.theory_map)
    val _ =  Theory.setup (Named_Theorems.declare @{binding "crush_aentails_rules"}    "" #> snd |> Named_Target.theory_map)
    val _ =  Theory.setup (Named_Theorems.declare @{binding "crush_aentails_drules"}   "" #> snd |> Named_Target.theory_map)
+   val _ =  Theory.setup (Named_Theorems.declare @{binding "crush_wp_split_simps"}    "" #> snd |> Named_Target.theory_map)
    val _ =  Theory.setup (Named_Theorems.declare @{binding "crush_aentails_crules"}   "" #> snd |> Named_Target.theory_map)
    val _ =  Theory.setup (Named_Theorems.declare @{binding "crush_asepconj_simp"}     "" #> snd |> Named_Target.theory_map)
    val _ =  Theory.setup (Named_Theorems.declare @{binding "crush_specs_eager"}       "" #> snd |> Named_Target.theory_map)

--- a/Crush/base.ML
+++ b/Crush/base.ML
@@ -65,6 +65,10 @@ sig
  val force_meta_eq : thm -> thm
  val force_meta_eqs : thm list -> thm list
 
+ \<comment>\<open>Eta expand definitional theorem so there's no toplevel \<^verbatim>\<open>\<lambda>x. _\<close> on the RHS\<close>
+ val eta_expand: thm -> thm 
+ val eta_expands: thm list -> thm list  
+
  val intro_tac : thm list -> Proof.context -> int -> tactic
  val elim_tac : thm list -> Proof.context -> int -> tactic
 
@@ -424,6 +428,20 @@ struct
   fun force_meta_eq (t : thm): thm = t RS eq_reflection handle THM _ => t
   val force_meta_eqs : thm list -> thm list = List.map force_meta_eq
 
+  fun eta_expand thm =
+    let
+      val num_abs = thm 
+        |> Thm.prop_of 
+        |> Logic.dest_equals 
+        |> snd 
+        |> Term.strip_abs 
+        |> fst 
+        |> length      
+    in
+      funpow num_abs (fn t => t RS @{thm meta_fun_cong}) thm
+    end
+  val eta_expands : thm list -> thm list = List.map eta_expand
+
   fun filter_to_conv (f : cterm -> bool) : conv = fn t =>
      if f t then Conv.all_conv t else Conv.no_conv t
 
@@ -532,6 +550,9 @@ local
 
   val _ = Theory.setup (Attrib.setup @{binding "meta_all_intro"}
                        (Thm.rule_attribute [] (K Thm.forall_intr_vars) |> Scan.succeed) "")
+
+  val _ = Theory.setup (Attrib.setup @{binding "unabs_def"}
+                       (Thm.rule_attribute [] (K Crush_Base.eta_expand) |> Scan.succeed) "")
 
   fun all_intro ctxt thm = 
      let val ctxt = Context.proof_of ctxt

--- a/Crush/config.ML
+++ b/Crush/config.ML
@@ -57,10 +57,15 @@ sig
 
   val enable_branch_safe : bool Config.T
   val enable_branch_clarsimp : bool Config.T
+  val enable_branch_clarsimp_warn_at_success : bool Config.T
+  val enable_branch_clarsimp_stop_at_success : bool Config.T
   val enable_branch_filtered_clarsimp : bool Config.T
   val enable_branch_reduced_clarsimp : bool Config.T
   val enable_schematics : bool Config.T
   val enable_branch_split : bool Config.T
+
+  val enable_base_simps_detect_aentails_contradiction : bool Config.T
+  val enable_base_simps_early_unfold : bool Config.T
 
   val enable_urust_split_branch : bool Config.T
   val enable_urust_determine_branch : bool Config.T
@@ -118,6 +123,8 @@ struct
 
   val enable_branch_safe = Attrib.setup_config_bool @{binding "use_safe"} (K true)
   val enable_branch_clarsimp = Attrib.setup_config_bool @{binding "crush_use_clarsimp"} (K true)
+  val enable_branch_clarsimp_stop_at_success = Attrib.setup_config_bool @{binding "crush_stop_at_full_blown_clarsimp"} (K false)
+  val enable_branch_clarsimp_warn_at_success = Attrib.setup_config_bool @{binding "crush_warn_at_full_blown_clarsimp"} (K true)
   (* TODO: Consider enabling this by default *)
   val enable_branch_filtered_clarsimp = Attrib.setup_config_bool @{binding "crush_use_filtered_clarsimp"} (K false)
   (* TODO: Consider enabling this by default *)
@@ -142,6 +149,9 @@ struct
   val step_time_bound_ms = Attrib.setup_config_int @{binding "crush_time_step_bound_ms"} (K 10000)
 
   val fail_on_bad_schematic = Attrib.setup_config_bool @{binding "crush_fail_on_bad_schematic"} (K true)
+
+  val enable_base_simps_early_unfold = Attrib.setup_config_bool @{binding "crush_enable_early_unfold"} (K true)
+  val enable_base_simps_detect_aentails_contradiction = Attrib.setup_config_bool @{binding "crush_enable_contradiction_detection"} (K true)
 
   val relevance_filter_max_facts = Attrib.setup_config_int @{binding "crush_relevance_filter_max_facts"} (K 20)
 

--- a/Crush/crush.ML
+++ b/Crush/crush.ML
@@ -150,6 +150,13 @@ struct
 
   val get_urust_contract_simpset = Context.Proof #> URustContractSimps.get
 
+  val crush_register_wp_split_attrib = Thm.declaration_attribute (fn t => fn ctxt =>
+    let val t' = Separation_Logic_Tactics.specialize_split_rule_to_wp_single
+                   (Context.proof_of ctxt) t
+    in ctxt |> Named_Theorems.add_thm @{named_theorems "crush_wp_split_simps"} t'
+    end
+  )  
+
   val simp_focus_basic_tac : Proof.context -> int -> tactic = fn ctxt =>
     let val focus_intros =
       Named_Theorems.get ctxt @{named_theorems focus_intros} @
@@ -173,17 +180,23 @@ struct
 
   val crush_branch_base_simps_early_unfold : Proof.context -> int -> tactic = fn ctxt =>
     let val early_simps = Named_Theorems.get ctxt @{named_theorems crush_early_simps}
-      val congs = Named_Theorems.get ctxt @{named_theorems "crush_cong"}
+      val congs = Named_Theorems.get ctxt @{named_theorems "crush_cong"}      
     in
-      safe_unfold_tac' ctxt congs early_simps
+      if Config.get ctxt Crush_Config.enable_base_simps_early_unfold then
+        safe_unfold_tac' ctxt congs early_simps
+      else
+        K no_tac
     end
 
   val crush_branch_base_detect_aentails_contradiction: Proof.context -> int -> tactic = fn ctxt =>
-    IF' Separation_Logic_Tactics.is_entailment (
-      let val congs = Named_Theorems.get ctxt @{named_theorems "crush_cong"} in
-      CHANGED_PROP o (safe_simp_no_asm_only_tac' ctxt congs @{thms asepconj_bot_zero asepconj_bot_zero2})
-      THEN' TRY o resolve_tac ctxt @{thms bot_aentails_all} end
-    )
+    if Config.get ctxt Crush_Config.enable_base_simps_detect_aentails_contradiction then
+      IF' Separation_Logic_Tactics.is_entailment (
+        let val congs = Named_Theorems.get ctxt @{named_theorems "crush_cong"} in
+        CHANGED_PROP o (safe_simp_no_asm_only_tac' ctxt congs @{thms asepconj_bot_zero asepconj_bot_zero2})
+        THEN' TRY o resolve_tac ctxt @{thms bot_aentails_all} end
+      )
+    else
+      K no_tac
 
   val crush_branch_base_simps_tac : Proof.context -> int -> tactic = fn ctxt =>
     let val crush_intros = Named_Theorems.get ctxt @{named_theorems crush_intros}
@@ -219,9 +232,12 @@ struct
 
   val crush_branch_wp_case_split_tac_core : Proof.context -> int -> tactic = fn ctxt =>
     if not (Config.get ctxt Crush_Config.enable_urust_split_branch) then K no_tac else
-    let val wp_intros = Named_Theorems.get ctxt @{named_theorems micro_rust_wp_case_splits}
+    let val wp_split_intros = Named_Theorems.get ctxt @{named_theorems micro_rust_wp_case_splits}
+      val wp_split_simps = Named_Theorems.get ctxt @{named_theorems crush_wp_split_simps}
+        |> force_meta_eqs
     in
-      intro_tac wp_intros ctxt
+      intro_tac wp_split_intros ctxt ORELSE' 
+      CONVERSION (Conv.params_conv ~1 (fn _ => (Conv.concl_conv ~1 (prop_conv (Conv.rewrs_conv wp_split_simps)))) ctxt)
     end
 
   val crush_branch_wp_case_split_tac : Proof.context -> int -> tactic = fn ctxt =>
@@ -392,9 +408,33 @@ struct
     end
 
   val crush_branch_clarsimp_fallback_tac = fn ctxt =>
-   if Config.get ctxt Crush_Config.enable_branch_clarsimp then
-     CHANGED_PROP o clarsimp_tac ctxt
-   else K no_tac
+   let fun log_before_after old_goal new_goal_opt =
+      (let val old_txt = 
+             [Pretty.str "Needed to apply full-blown clarsimp to progress the following pure goal:", Pretty.brk 1,
+              Syntax.pretty_term ctxt old_goal, Pretty.fbrk] in
+       if Config.get ctxt Crush_Config.enable_branch_clarsimp_stop_at_success then
+         ((old_txt @ [Pretty.fbrk, Pretty.str "Aborting as requested by `crush_stop_at_full_blown_clarsimp` option"]
+          |> Pretty.block |> Pretty.string_of |> Output.warning);
+          raise SMART "Stopping after successful clarsimp -- consider debugging why MePo-filtered clarsimp didn't work!")
+       else if old_goal |> Separation_Logic_Tactics.is_entailment |> not
+         andalso Config.get ctxt Crush_Config.enable_branch_clarsimp_warn_at_success then 
+         let 
+           val new_txt = case new_goal_opt of 
+              NONE => [Pretty.str "Goal was solved"]
+            | SOME new_goal => [Pretty.str "New goal: ", Pretty.fbrk,
+                                Syntax.pretty_term ctxt new_goal]
+         in
+           old_txt @ new_txt @ 
+            [Pretty.fbrk, Pretty.str "Consider debugging why MePo-filtered clarsimp is not successful here.", Pretty.fbrk,
+             Pretty.str "If you want to stop `crush` at this point, set `crush_stop_at_full_blown_clarsimp=true` and `crush_do_big_steps=false`"]
+           |> Pretty.block |> Pretty.string_of |> Output.warning
+         end
+      else () end)
+   in
+     if Config.get ctxt Crush_Config.enable_branch_clarsimp then
+       DEBUG_BEFORE_AFTER' log_before_after (CHANGED_PROP o clarsimp_tac ctxt)
+     else K no_tac
+   end
 
   val crush_branch_misc_tac : Proof.context -> int -> tactic = fn ctxt =>
              intro_tac @{thms mset_sub_drop_nth word_unat_lt} ctxt
@@ -731,6 +771,7 @@ struct
      make_del_parser "intro"     @{named_theorems crush_intros} \<^here>,
      make_add_parser "specs"     @{named_theorems crush_specs} \<^here>,
      make_del_parser "specs"     @{named_theorems crush_specs} \<^here>,
+     make_attrib_parser (Args.$$$ "wp" -- Args.$$$ "split") \<^here> (K crush_register_wp_split_attrib),
      make_attrib_parser (Args.$$$ "contracts" -- Args.add) \<^here> (K (crush_register_contract_attrib false)),
      make_attrib_parser (Args.$$$ "contracts" -- Args.del) \<^here> (K (crush_register_contract_attrib true)),
      make_add_parser "cong"     @{named_theorems crush_cong} \<^here>,

--- a/Crush/mepo_prem.ML
+++ b/Crush/mepo_prem.ML
@@ -33,6 +33,8 @@ sig
  (* reverse the action of ignore_tac_idxs_xxx *)
  val unignore_tac : Proof.context -> int -> tactic
 
+ val matching_prems : Proof.context -> thm -> (term -> bool) -> int -> int list
+
  val relevant_prems_core : Proof.context -> int ->
     relevance_fudge option -> term -> (int * term) list -> (int * term) list
 
@@ -56,6 +58,22 @@ end;
 
 structure MePo_Prem: MEPO_PREM =
 struct
+
+  fun enumerate ls =
+    let
+      fun aux _ acc [] = List.rev acc
+        | aux base acc (x :: xs) = aux (base + 1) ((base, x) :: acc) xs
+    in
+      aux 0 [] ls
+    end
+
+  fun matching_prems (_: Proof.context) (thm: thm) (prem_filter: term -> bool) i =
+    let
+      val subgoal = Thm.cprem_of thm i |> Thm.term_of
+      val prems = Logic.strip_imp_prems subgoal
+    in
+      prems |> enumerate |> filter (snd #> prem_filter) |> map fst
+    end
 
   val ignore_tac0 : Proof.context -> int -> tactic = fn ctxt =>
     DETERM o (eresolve_tac ctxt [@{thm IGNORE_imp_ignoreE}])
@@ -189,11 +207,20 @@ fun add_pconst_to_table (s, p) = Symtab.map_default (s, [p]) (insert ptype_eq p)
    more or less as if they were built-in but add their axiomatization at the end. *)
 val set_consts = [\<^const_name>\<open>Collect\<close>, \<^const_name>\<open>Set.member\<close>]
 
+val ignore_consts = [\<^const_name>\<open>ASSUMPTION\<close>]
+
+fun mepo_keep_premise_filter t = (case t of 
+   \<^Const_>\<open>Trueprop for t1\<close> => mepo_keep_premise_filter t1
+ | \<^Const_>\<open>ASSUMPTION for _\<close> => true
+ | _ => false)
+
 fun add_pconsts_in_term thy =
   let
     fun do_const const (x as (s, _)) ts =
       if member (op =) set_consts s then
         fold (do_term false) ts
+      else if member (op =) ignore_consts s then
+        I
       else
         (not (is_irrelevant_const s) ? add_pconst_to_table (rich_pconst thy const x))
         #> fold (do_term false) ts
@@ -255,6 +282,7 @@ fun pconsts_in_fact thy t =
     []
 
 fun pair_consts_fact' thy term_of_fact fact =
+  if mepo_keep_premise_filter (fact |> term_of_fact) then NONE else
   (case fact |> term_of_fact |> pconsts_in_fact thy of
     [] => NONE
   | consts => SOME ((fact, consts), NONE))
@@ -517,14 +545,6 @@ fun relevance_filter_generic ctxt thres0 decay max_facts (term_of_fact: 'a -> te
        relevance_filter' ctxt thres0 decay max_facts fudge facts concl_t)
   end
 
-  fun enumerate ls =
-    let
-      fun aux _ acc [] = List.rev acc
-        | aux base acc (x :: xs) = aux (base + 1) ((base, x) :: acc) xs
-    in
-      aux 0 [] ls
-    end
-
   fun subst_abs_constify v b = subst_bound (v |> apfst wrap_bound_name |> Const, b);
 
   fun dest_abs_constify t =
@@ -582,11 +602,15 @@ fun relevance_filter_generic ctxt thres0 decay max_facts (term_of_fact: 'a -> te
       aux a b [] exclude
     end
 
+  fun sorted_union (a : int list) (b : int list) : int list = a @ b |> sort int_ord
+
   fun irrelevant_prems_in_goal ctxt max_facts fudge i thm =
     let
       val (nprems, relevant_prems_idxs) = relevant_prems_in_goal ctxt max_facts fudge i thm
+      val force_relevant_idxs = matching_prems ctxt thm mepo_keep_premise_filter i
+      val all_relevant_prems = sorted_union relevant_prems_idxs force_relevant_idxs
     in
-      (nprems, upto_without 0 (nprems - 1) relevant_prems_idxs)
+      (nprems, upto_without 0 (nprems - 1) all_relevant_prems)
     end
     handle THM _ => (0, [])
 

--- a/Crush/seplog.ML
+++ b/Crush/seplog.ML
@@ -38,6 +38,10 @@ sig
      of assertions.\<close>
   val dest_asepconj_multi_mapped : term -> (term * term)
 
+  val specialize_split_rule_to_wp_single: Proof.context -> thm -> thm
+  val specialize_split_rule_to_wp: Proof.context -> thm list -> thm list
+  val specialize_split_rule_to_wp_attribute : attribute
+
   \<comment> \<open>Basic transformation tactics for separating entailments\<close>
 
   \<comment> \<open>Rotate the components of separating conjunction appearing in a goal's assumptions\<close>
@@ -367,6 +371,18 @@ end
 structure Separation_Logic_Tactics : SEPARATION_LOGIC_TACTICS =
 struct
 
+  fun specialize_split_rule_to_wp_single ctxt t =
+     Rule_Insts.of_rule ctxt ([SOME "\<lambda>e. _ \<longlongrightarrow> \<W>\<P> _ e _ _ _"], []) [] t
+     handle ERROR _ =>
+       ([Pretty.str "Theorem ", Syntax.pretty_term ctxt (Thm.prop_of t),
+        Pretty.str " not of the expected format. Ignoring."] |> Pretty.block |>
+        Pretty.string_of |> Output.warning; t)
+
+  fun specialize_split_rule_to_wp ctxt = List.map (specialize_split_rule_to_wp_single ctxt)
+
+  val specialize_split_rule_to_wp_attribute =
+     Thm.rule_attribute [] (fn context => specialize_split_rule_to_wp_single (Context.proof_of context))
+
   val aentails_prem_cong : thm = @{lemma \<open>\<phi> = \<phi>' \<Longrightarrow> \<phi> \<longlongrightarrow> \<xi> \<Longrightarrow> \<phi>' \<longlongrightarrow> \<xi>\<close> by simp}
   val aentails_concl_cong: thm = @{lemma \<open>\<phi> = \<phi>' \<Longrightarrow> \<xi> \<longlongrightarrow> \<phi> \<Longrightarrow> \<xi> \<longlongrightarrow> \<phi>'\<close> by simp}
 
@@ -379,9 +395,9 @@ struct
   val aentails_rule_core0 : thm = @{lemma \<open>\<alpha> \<longlongrightarrow> \<beta> \<Longrightarrow> \<phi> \<longlongrightarrow> \<alpha> \<Longrightarrow> \<phi> \<longlongrightarrow> \<beta>\<close>
     by (blast intro: aentails_intro asepconj_mono2)}
 
-  val aentails_crule_core : thm = @{thm asepconj_mono4} 
-  val aentails_crule_coreL : thm = @{thm asepconj_mono6} 
-  val aentails_crule_coreR : thm = @{thm asepconj_mono7} 
+  val aentails_crule_core : thm = @{thm asepconj_mono4}
+  val aentails_crule_coreL : thm = @{thm asepconj_mono6}
+  val aentails_crule_coreR : thm = @{thm asepconj_mono7}
 
   (* Some lemmas *)
   exception SeparationLogic of string
@@ -604,21 +620,21 @@ struct
    \<comment> \<open>Automated/assisted discharge of \<^verbatim>\<open>ucincl\<close> conditions.\<close>
    exception LOOKUP of string
 
-   fun lookup_thm_core ctxt thm_name = 
+   fun lookup_thm_core ctxt thm_name =
      let val thm_opt = Facts.lookup (Context.Proof ctxt)
                                     (Proof_Context.facts_of ctxt)
                                     thm_name in
         case thm_opt of
             SOME thm => thm |> #thms |> List.hd
           | _ => raise LOOKUP thm_name
-        end      
+        end
 
    fun lookup_thm ctxt thm_name =
     let val thm_name_local = "local." ^ thm_name in
       lookup_thm_core ctxt thm_name_local
     end
 
-   fun get_global_const_name ctxt name = 
+   fun get_global_const_name ctxt name =
      name |> Syntax.read_term ctxt |> Term.head_of |> Term.dest_Const |> fst
 
    fun get_local_const_name _ name = "local." ^ name
@@ -644,7 +660,7 @@ struct
        val body_schematics = Term.add_var_names body [] |> List.map fst
        val contract_schematics = Term.add_var_names contract [] |> List.map fst
    in
-     List.exists (member (op =) body_schematics #> not) contract_schematics 
+     List.exists (member (op =) body_schematics #> not) contract_schematics
    end
 
   val dest_spec_fun_str =
@@ -986,7 +1002,7 @@ struct
     (asepconj_pick_conv ctxt (i+1) i) then_conv (Conv.rewr_conv (@{thm asepconj_comm} RS eq_reflection))
   \<comment>\<open>Convenience wrapper inferring the number \<^verbatim>\<open>n\<close> of separating components.\<close>
   fun asepconj_joinfirst_conv' ctxt i: conv = fn ct =>
-    let val n = ct |> Thm.term_of |> split_asepconj |> length in 
+    let val n = ct |> Thm.term_of |> split_asepconj |> length in
     asepconj_joinfirst_conv ctxt n i ct end
 
   fun aentails_joinfirst_assm_conv ctxt n i: conv = aentails_conv' (asepconj_joinfirst_conv ctxt n i) Conv.all_conv ctxt
@@ -1128,7 +1144,7 @@ struct
   val aentails_float_points_to_raw_concls_tac = aentails_pick_concls_tac'' is_points_to_raw
   val aentails_float_points_to_concls_tac'     = aentails_pick_concls_tac' is_points_to
   val aentails_float_points_to_raw_concls_tac' = aentails_pick_concls_tac' is_points_to_raw
-                                                        
+
   val aentails_float_multi_assms_tac  = aentails_pick_assms_tac''  is_asepconj_multi
   val aentails_float_multi_concls_tac = aentails_pick_concls_tac'' is_asepconj_multi
 
@@ -1200,7 +1216,7 @@ struct
      ))
      THEN_LAST (TRY o (aentails_normalize_assoc_concls_tac ctxt))
 
-  fun aentails_float_crule_tac (thm : thm) (ctxt : Proof.context) = 
+  fun aentails_float_crule_tac (thm : thm) (ctxt : Proof.context) =
            aentails_float_rule_concls_tac thm ctxt
      THEN' aentails_float_drule_assms_tac thm ctxt
 
@@ -1209,7 +1225,7 @@ struct
      THEN' (
          resolve_tac ctxt [aentails_crule_core OF [thm],
                            aentails_crule_coreL OF [thm],
-                           aentails_crule_coreR OF [thm], thm] 
+                           aentails_crule_coreR OF [thm], thm]
             handle THM _ => K no_tac
      ))
      THEN_LAST (TRY o (aentails_normalize_assoc_concls_tac ctxt))
@@ -1476,10 +1492,10 @@ struct
      #> Conv.changed_conv
 
   fun aentails_simp_prems_conv (thms : thm list) : Proof.context -> conv =
-     (aentails_prems_concls_conv (thms |> force_meta_eqs |> Conv.rewrs_conv |> maybe_prop_conv |> K) (K Conv.all_conv))
+     (aentails_prems_concls_conv (thms |> force_meta_eqs |> eta_expands |> Conv.rewrs_conv |> maybe_prop_conv |> K) (K Conv.all_conv))
      #> Conv.changed_conv
   fun aentails_simp_concls_conv (thms : thm list) : Proof.context -> conv =
-     (aentails_prems_concls_conv (K Conv.all_conv) (thms |> force_meta_eqs |> Conv.rewrs_conv |> maybe_prop_conv |> K))
+     (aentails_prems_concls_conv (K Conv.all_conv) (thms |> force_meta_eqs |> eta_expands |> Conv.rewrs_conv |> maybe_prop_conv |> K))
      #> Conv.changed_conv
 
   fun simp_prems_tac (thms : thm list) (ctxt : Proof.context) : int -> tactic =
@@ -1505,14 +1521,17 @@ struct
     eresolve_tac ctxt @{thms apure_entailsR0_revE}
 
   fun aentails_wp_ssa_normalize_tac (ctxt : Proof.context) : int -> tactic =
-    let 
+    let
       val micro_rust_simps = Named_Theorems.get ctxt @{named_theorems "micro_rust_simps"}
       val micro_rust_ssa = Named_Theorems.get ctxt @{named_theorems "micro_rust_ssa"}
     in
-      aentails_wp_rewrite_tac @{thm MICRO_RUST_SSA_CONTROL_def[symmetric]} ctxt
-      THEN' (TRY o safe_simp_only_tac ctxt micro_rust_simps)
-      THEN' (TRY o safe_simp_only_tac ctxt micro_rust_ssa)
-      THEN' (TRY o safe_simp_only_tac ctxt @{thms MICRO_RUST_SSA_CONTROL_def})
+      CONVERSION (
+     Conv.bottom_conv (K (Conv.try_conv (
+                  (Conv.rewr_conv @{thm MICRO_RUST_SSA_CONTROL_def[symmetric]})
+        then_conv (Conv.try_conv (Conv.rewrs_conv (micro_rust_ssa |> force_meta_eqs)))
+     ))) ctxt
+     then_conv Conv.bottom_conv (K (
+         Conv.try_conv (Conv.rewr_conv @{thm MICRO_RUST_SSA_CONTROL_def}))) ctxt)
       THEN' (TRY o safe_simp_only_tac ctxt micro_rust_simps)
     end
 
@@ -1596,5 +1615,8 @@ local
 
   val _ = Theory.setup (Method.setup @{binding "micro_rust_ssa_wp_normalize"}
           (Scan.succeed (SIMPLE_METHOD' o Separation_Logic_Tactics.aentails_wp_ssa_normalize_tac)) "")
+
+  val _ = Theory.setup (Attrib.setup @{binding "wp_split"}
+                       (Separation_Logic_Tactics.specialize_split_rule_to_wp_attribute |> Scan.succeed) "")
 
 in end

--- a/Crush/tacticals.ML
+++ b/Crush/tacticals.ML
@@ -20,6 +20,9 @@ sig
   val LOG : Proof.context -> bool -> string -> tactic -> tactic
   val LOG' : Proof.context -> bool -> string -> (int -> tactic) -> (int -> tactic)
 
+  val DEBUG_BEFORE_AFTER : (thm -> thm -> unit) -> tactic -> tactic
+  val DEBUG_BEFORE_AFTER' : (term -> term option -> unit) -> (int -> tactic) -> (int -> tactic)
+
   val LOG_pos : Proof.context -> Position.T -> bool -> string -> logger -> tactic -> tactic
   val LOG_pos' : Proof.context -> Position.T -> bool -> string -> logger -> (int -> tactic) -> (int -> tactic)
 
@@ -41,6 +44,10 @@ sig
 
   (* Tactic printing a string but doing nothing else *)
   val log_tac : string -> tactic
+
+  (* all_tac, but allows to run an arbitrary function on the goal
+     state, e.g. for printing *)
+  val all_tac': (term -> unit) -> int -> tactic
 
   (* Guard method by goal predicate *)
   val guard_method : (Proof.context -> term -> bool) -> Method.method -> Method.method
@@ -89,7 +96,23 @@ struct
 
   val log_tac : string -> tactic = fn msg => fn st =>
     ((msg |> tracing); Seq.single st)
- 
+
+  val all_tac' : (term -> unit) -> int -> tactic = fn f =>
+    SUBGOAL (fn (goal, _) => ((f goal); all_tac))
+
+  fun DEBUG_BEFORE_AFTER (f: thm -> thm -> unit) (tac : tactic) st =
+     Seq.map (fn st' => (f st st'; st')) (tac st)
+  
+  fun DEBUG_BEFORE_AFTER' (f: term -> term option -> unit) (tac: int -> tactic) (i: int) =
+     DEBUG_BEFORE_AFTER (fn st => fn st' => let
+       val goal_old = Thm.prem_of st i
+       val goal_new = 
+          if Thm.nprems_of st' < Thm.nprems_of st then NONE else
+          SOME (Thm.prem_of st' i)
+     in
+       f goal_old goal_new
+     end) (tac i)
+
   val time_to_str = fn t => (t |> #elapsed |> Time.fmt 6) ^ "s"
 
   fun LOG_pos (ctxt : Proof.context) (pos : Position.T) (enable : bool) 

--- a/Crush/unfold_prems.ML
+++ b/Crush/unfold_prems.ML
@@ -39,7 +39,7 @@ struct
 
   \<comment>\<open>Safe saturating unfolding of pure premises\<close>
   fun sat_unfold_tac (ts : thm list) (ctxt : Proof.context) : int -> tactic =
-    let val ts_meta = force_meta_eqs ts
+    let val ts_meta = ts |> force_meta_eqs |> eta_expands
         val ts_elims = pure_eq_thms_to_unfold_elim ts_meta in
       elim_tac ts_elims ctxt
     end

--- a/Micro_Rust_Examples/Crush_Examples.thy
+++ b/Micro_Rust_Examples/Crush_Examples.thy
@@ -190,6 +190,13 @@ begin
     apply (crush_base_step simp prems add: Some_Ex_def)  \<comment>\<open>Introducing existential for Q ?x\<close>
     apply (rule PQ)
     done
+
+  text\<open>\<^verbatim>\<open>simp prems/concls\<close> should automatically eta expand definitions:\<close>
+  definition not_eta_expanded where \<open>not_eta_expanded \<equiv> \<lambda>x f. f x\<close>  
+  lemma \<open>\<And>foo. not_eta_expanded f t \<longlongrightarrow> foo\<close>
+    apply (crush_base simp prems add: not_eta_expanded_def) 
+    oops
+
 end
 
 text\<open>There is also \<^verbatim>\<open>simp concls add: ...\<close> for unfolding pure or spatial \<^emph>\<open>conclusions\<close>. In contrast
@@ -647,6 +654,27 @@ begin
                                   goal |> Syntax.pretty_term ctxt] |> Pretty.writeln
         in not (Separation_Logic_Tactics.is_entailment goal) end\<close>)
     oops
+end
+
+paragraph\<open>Case splitting\<close>
+
+experiment
+begin
+lemma \<open>(case y of Some t \<Rightarrow> True | None \<Rightarrow> True) \<Longrightarrow> \<alpha> \<longlongrightarrow> \<W>\<P> \<Gamma> \<lbrakk> match x { Some(y) \<Rightarrow> f(), None \<Rightarrow> g() } \<rbrakk> \<beta> \<gamma> \<delta>\<close>
+  \<comment>\<open>You could use the following, but that would aggressively split \<^verbatim>\<open>option\<close> everywhere.\<close>
+  apply (crush_base split!: option.splits)
+  \<comment>\<open>\<^verbatim>\<open> 1. \<And>x2 x2a. x = Some x2 \<Longrightarrow> y = Some x2a \<Longrightarrow> \<alpha> \<longlongrightarrow> \<W>\<P> \<Gamma> (call f) \<beta> \<gamma> \<delta>
+        2. \<And>x2. x = Some x2 \<Longrightarrow> y = None \<Longrightarrow> \<alpha> \<longlongrightarrow> \<W>\<P> \<Gamma> (call f) \<beta> \<gamma> \<delta>
+        3. \<And>x2. x = None \<Longrightarrow> y = Some x2 \<Longrightarrow> \<alpha> \<longlongrightarrow> \<W>\<P> \<Gamma> (call g) \<beta> \<gamma> \<delta>
+        4. x = None \<Longrightarrow> y = None \<Longrightarrow> \<alpha> \<longlongrightarrow> \<W>\<P> \<Gamma> (call g) \<beta> \<gamma> \<delta>\<close>\<close>
+  oops
+
+lemma \<open>(case y of Some t \<Rightarrow> True | None \<Rightarrow> True) \<Longrightarrow> \<alpha> \<longlongrightarrow> \<W>\<P> \<Gamma> \<lbrakk> match x { None \<Rightarrow> f(), Some(y) \<Rightarrow> g() } \<rbrakk> \<beta> \<gamma> \<delta>\<close>
+  \<comment>\<open>If you instead want to split only micro rust expressions, use \<^verbatim>\<open>wp split: ...\<close>\<close> 
+  apply (crush_base wp split: option.splits)
+  \<comment>\<open>\<^verbatim>\<open> 1. \<And>x2. case y of None \<Rightarrow> True | _ \<Rightarrow> True \<Longrightarrow> x = Some x2 \<Longrightarrow> \<alpha> \<longlongrightarrow> \<W>\<P> \<Gamma> (call g) \<beta> \<gamma> \<delta>
+        2. case y of None \<Rightarrow> True | _ \<Rightarrow> True \<Longrightarrow> x = None \<Longrightarrow> \<alpha> \<longlongrightarrow> \<W>\<P> \<Gamma> (call f) \<beta> \<gamma> \<delta>\<close>\<close>
+  oops
 end
 
 paragraph\<open>Logging \<^verbatim>\<open>crush\<close>\<close>

--- a/Shallow_Micro_Rust/Micro_Rust.thy
+++ b/Shallow_Micro_Rust/Micro_Rust.thy
@@ -15,63 +15,6 @@ section\<open>Entry point for Micro Rust\<close>
 text\<open>This theory's main purpose is to import all of the material related to Core Micro Rust.  It
 also serves as a point where common material (for example, automation routines) can be placed.\<close>
 
-subsection\<open>Symbolic execution of Core Micro Rust programs\<close>
-
-text\<open>The following tactic transforms a Micro Rust expression appearing on the left-hand side of an
-equality into an SSA normal form:\<close>
-
-text\<open>The following tactic is able to close equations between semantically-equal Micro Rust programs
-by symbolically executing them with our semantic equivalences:\<close>
-method micro_rust_symbolic_execute =
-  (rule expression_eqI; elim micro_rust_elims; clarsimp simp add: micro_rust_simps;
-    intro micro_rust_intros; clarsimp simp add: micro_rust_simps)
-
-term \<open>(match (return r) \<lbrace>
-         \<guillemotleft>None\<guillemotright> \<Rightarrow> skip,
-         \<guillemotleft>Some\<guillemotright>(s) \<Rightarrow> skip
-       \<rbrace> ) = skip\<close>
-
-text\<open>Some tests of the two tactics:\<close>
-notepad
-begin
-  fix e :: \<open>String.literal\<close>
-  have \<open>(match (panic e) \<lbrace>
-          \<guillemotleft>None\<guillemotright> \<Rightarrow> skip,
-          \<guillemotleft>Some\<guillemotright>(s) \<Rightarrow> s
-        \<rbrace>) = panic e\<close>
-    by micro_rust_symbolic_execute
-next
-  fix r :: \<open>('s, 'r, 'r, 'abort, 'i, 'o) expression\<close> and e :: \<open>String.literal\<close>
-  have \<open>\<lbrace> match (return r) \<lbrace>
-          \<guillemotleft>None\<guillemotright> \<Rightarrow> \<lbrace>
-            if (panic e) \<lbrace>
-              skip
-            \<rbrace>
-          \<rbrace>,
-          \<guillemotleft>Some\<guillemotright>(s) \<Rightarrow> s
-        \<rbrace> \<rbrace> =
-        \<lbrace> let r = r;
-          let x = return (\<up>r);
-          match (\<up>x) \<lbrace>
-            \<guillemotleft>None\<guillemotright> \<Rightarrow> \<lbrace>
-              let y = panic e;
-              if \<up>y \<lbrace> 
-                skip
-              \<rbrace>
-            \<rbrace>,
-            \<guillemotleft>Some\<guillemotright>(s) \<Rightarrow> s \<rbrace> \<rbrace>\<close>
-    by micro_rust_ssa_normalize (simp add: bind_literal_unit)
-next
-  fix s e :: \<open>('s, 'a::{ord}, 'r, 'abort, 'i, 'o) expression\<close> and oof :: \<open>String.literal\<close>
-  have \<open>(\<langle>s\<dots>e\<rangle>)\<cdot>contains\<langle>panic oof\<rangle> =
-         (let s = s;
-          let e = e;
-          let r = \<langle>\<up>s\<dots>\<up>e\<rangle>;
-          let x = panic oof;
-            (\<up>r)\<cdot>contains\<langle>\<up>x\<rangle>)\<close>
-    by micro_rust_ssa_normalize
-end
-
 (*<*)
 end
 (*>*)

--- a/Shallow_Micro_Rust/SSA.thy
+++ b/Shallow_Micro_Rust/SSA.thy
@@ -8,7 +8,6 @@ theory SSA
 begin
 (*>*)
 
-
 subsection\<open>Converting expressions to SSA form\<close>
 
 text\<open>This section shows that each expression of Core Micro Rust can be transformed into a form of
@@ -21,20 +20,10 @@ expression in a conditional, for example.
 
 Note below that we use a ``trick'' to ensure that simplification using these rules remains tightly
 controlled.  Namely, we use the \<^verbatim>\<open>MICRO_RUST_SSA_CONTROL\<close> function, which is merely the identity
-function, to ``mark'' exactly where we want SSAification to apply: compound expressions are
-simplified from the ``outside in'' wherein we push the \<^verbatim>\<open>MICRO_RUST_SSA_CONTROL\<close> inwards towards
-new terms that must be simplified.  In this way, we stop simplification looping forever, constantly
-trying to hoist the discriminant term out of a conditional or match expression, for example.  In
-effect, we use simplification but bake a \<^emph>\<open>rewrite strategy\<close> of our own design into the
-simplification engine using this trick.\<close>
+function, to ``mark'' exactly where we want SSAification to apply.\<close>
 
-definition MICRO_RUST_SSA_CONTROL :: \<open>'a \<Rightarrow> 'a\<close> where
+definition MICRO_RUST_SSA_CONTROL :: \<open>('a, 'b, 'c, 'd, 'e, 'f) expression \<Rightarrow> _\<close> where
   \<open>MICRO_RUST_SSA_CONTROL x \<equiv> x\<close>
-
-method micro_rust_ssa_normalize =
-  (rewrite at "\<hole> = _" MICRO_RUST_SSA_CONTROL_def[symmetric], \<comment> \<open>Add the constant on the LHS\<close>
-    clarsimp simp only: micro_rust_ssa,                      \<comment> \<open>Simplify the expression\<close>
-    (simp only: MICRO_RUST_SSA_CONTROL_def bind_assoc)?)     \<comment> \<open>Remove the constant\<close>
 
 text\<open>We want the SSA transformations to operate as closely to the syntactic level as possible.
 In fact, we could express them entirely at the syntax level, but they would not be provably correct
@@ -49,6 +38,10 @@ case-by-case basis.
 
 To not stray afar, though, we use a middle ground below: We refer to the abstract Micro Rust syntax
 for the constructions to be simplified, but use HOL antiquotations for the arguments.\<close>
+
+text\<open>At present, SSA rewrites happen bottom-up. In this case, the SSA control is strictly speaking
+not needed on the RHS of an SSA rewrite rule. We keep it to allow falling back to the original top-down
+application of SSA rules if necessary.\<close>
 
 lemma ssa_transform_funcall1 [micro_rust_ssa]:
   shows \<open>MICRO_RUST_SSA_CONTROL \<lbrakk> \<epsilon>\<open>f\<close>(\<epsilon>\<open>e\<close>) \<rbrakk> =
@@ -164,52 +157,12 @@ lemma ssa_transform_funcall10 [micro_rust_ssa]:
   unfolding MICRO_RUST_SSA_CONTROL_def
   by (clarsimp simp add: micro_rust_simps)
 
-lemma ssa_transform_function_body [micro_rust_ssa]:
-  shows \<open>MICRO_RUST_SSA_CONTROL (FunctionBody e) = FunctionBody (MICRO_RUST_SSA_CONTROL e)\<close>
-  by (clarsimp simp add: MICRO_RUST_SSA_CONTROL_def)
-
-lemma ssa_transform_call [micro_rust_ssa]:
-  shows \<open>MICRO_RUST_SSA_CONTROL (call f) = call (MICRO_RUST_SSA_CONTROL f)\<close>
-  by (clarsimp simp add: MICRO_RUST_SSA_CONTROL_def)
-
-lemma ssa_transform_lambda [micro_rust_ssa]:
-  shows \<open>MICRO_RUST_SSA_CONTROL \<lbrakk> |t| { \<epsilon>\<open>b\<close> } \<rbrakk> = \<lbrakk> |t| { \<epsilon>\<open>MICRO_RUST_SSA_CONTROL b\<close> } \<rbrakk>\<close>
-  by (clarsimp simp add: MICRO_RUST_SSA_CONTROL_def)
-
-lemma ssa_transform_lambda_hol [micro_rust_ssa]:
-  shows \<open>MICRO_RUST_SSA_CONTROL (\<lambda>v. b v) = (\<lambda>v. (MICRO_RUST_SSA_CONTROL (b v)))\<close>
-  by (clarsimp simp add: MICRO_RUST_SSA_CONTROL_def)
-
 text\<open>We hoist the expression to be returned out of the \<^verbatim>\<open>return\<close> expression, simplify it recursively
 and bind it to a variable.  We then return that variable:\<close>
 lemma ssa_transform_return [micro_rust_ssa]:
   shows \<open>MICRO_RUST_SSA_CONTROL \<lbrakk> return \<epsilon>\<open>r\<close>; \<rbrakk> =
           \<lbrakk> let x = \<epsilon>\<open>MICRO_RUST_SSA_CONTROL r\<close>; return x; \<rbrakk>\<close>
   by (simp add: MICRO_RUST_SSA_CONTROL_def return_func_def micro_rust_simps)
-
-text\<open>The \<^term>\<open>MICRO_RUST_SSA_CONTROL\<close> marker commutes with the  \<^verbatim>\<open>let\<close> construct, entering both the
-body and the bound expression, simplifying both recursively:\<close>
-lemma ssa_transform_let_in [micro_rust_ssa]:
-  shows \<open>MICRO_RUST_SSA_CONTROL (bind e f) =
-          bind (MICRO_RUST_SSA_CONTROL e) (\<lambda>x. MICRO_RUST_SSA_CONTROL (f x))\<close>
-  by (auto simp add: MICRO_RUST_SSA_CONTROL_def)
-
-text\<open>The \<^term>\<open>MICRO_RUST_SSA_CONTROL\<close> marker commutes with the sequencing operator, entering the
-two sequenced expressions and recursively transforming them.  Note that this is essentially a
-corollary of the rule for ``let in'' as sequencing is a degenerate form of \<^verbatim>\<open>let\<close>:\<close>
-corollary ssa_transform_sequence [micro_rust_ssa]:
-  shows \<open>MICRO_RUST_SSA_CONTROL (sequence s t) = 
-          sequence (MICRO_RUST_SSA_CONTROL s) (MICRO_RUST_SSA_CONTROL t)\<close>
-  by (auto simp add: sequence_def bind_def MICRO_RUST_SSA_CONTROL_def)
-
-text\<open>Since these lemmas are not expressible in terms of abstract Micro Rust, we probably don't want
-them as part of \<^text>\<open>micro_rust_ssa\<close>?\<close>
-
-lemma ssa_transform_lift1 [micro_rust_ssa]:
-  shows \<open>MICRO_RUST_SSA_CONTROL (bindlift1 fn e) = 
-            (let x = MICRO_RUST_SSA_CONTROL e; 
-               bindlift1 fn (\<up>x))\<close>
-  by (simp add: MICRO_RUST_SSA_CONTROL_def micro_rust_simps)
 
 lemma ssa_transform_bind2 [micro_rust_ssa]:
   shows \<open>MICRO_RUST_SSA_CONTROL (bind2 exp e f) =
@@ -288,57 +241,6 @@ lemma ssa_transform_bind8 [micro_rust_ssa]:
   unfolding MICRO_RUST_SSA_CONTROL_def
   by (clarsimp simp add: micro_rust_simps)
 
-
-subsection\<open>Single static assignment form for \<^emph>\<open>Range\<close>\<close>
-
-lemma ssa_transform_range_is_empty [micro_rust_ssa]:
-  shows \<open>\<lbrace> MICRO_RUST_SSA_CONTROL (r\<cdot>is_empty\<langle>\<rangle>) \<rbrace> = \<lbrace>
-           let x = MICRO_RUST_SSA_CONTROL r; (\<up>x)\<cdot>is_empty\<langle>\<rangle> \<rbrace>\<close>
-  unfolding MICRO_RUST_SSA_CONTROL_def
-    by (clarsimp simp add: micro_rust_simps)
-
-lemma ssa_transform_range_contains [micro_rust_ssa]:
-  shows \<open>\<lbrace> MICRO_RUST_SSA_CONTROL (r\<cdot>contains\<langle>x\<rangle>) \<rbrace> =
-          \<lbrace> let r = MICRO_RUST_SSA_CONTROL r;
-            let x = MICRO_RUST_SSA_CONTROL x;
-             (\<up>r)\<cdot>contains\<langle>\<up>x\<rangle> \<rbrace>\<close>
-  unfolding MICRO_RUST_SSA_CONTROL_def
-    by (clarsimp simp add: micro_rust_simps)
-
-lemma ssa_transform_range_new [micro_rust_ssa]:
-  shows \<open>\<lbrace> MICRO_RUST_SSA_CONTROL (\<langle>b\<dots>e\<rangle>) \<rbrace> = \<lbrace>
-            let x = MICRO_RUST_SSA_CONTROL b;
-            let y = MICRO_RUST_SSA_CONTROL e;
-             \<langle>(\<up>x) \<dots> (\<up>y)\<rangle> \<rbrace>\<close>
-  unfolding MICRO_RUST_SSA_CONTROL_def
-    by (clarsimp simp add: micro_rust_simps)
-
-lemma ssa_transform_range_eq_new [micro_rust_ssa]:
-  shows \<open>\<lbrace> MICRO_RUST_SSA_CONTROL (\<langle>b\<dots>=e\<rangle>) \<rbrace> = \<lbrace>
-            let x = MICRO_RUST_SSA_CONTROL b;
-            let y = MICRO_RUST_SSA_CONTROL e;
-             \<langle>(\<up>x) \<dots>= (\<up>y)\<rangle> \<rbrace>\<close>
-  unfolding MICRO_RUST_SSA_CONTROL_def
-    by (clarsimp simp add: micro_rust_simps)
-
-
-subsection\<open>Single static assignment form for \<^emph>\<open>Option\<close>\<close>
-
-text\<open>TODO: should apply more generally to any match expression? The transformation below is not only
-specific to the Option type, but also to the order of constructors given.\<close>
-lemma ssa_transform_option_cases [micro_rust_ssa]:
-  shows \<open>MICRO_RUST_SSA_CONTROL \<lbrakk> match \<epsilon>\<open>e\<close> {
-                                    None \<Rightarrow> \<epsilon>\<open>n\<close>,
-                                    Some(s) \<Rightarrow> \<epsilon>\<open>sm s\<close>
-                                  }\<rbrakk> =
-          \<lbrakk> let x = \<epsilon>\<open>MICRO_RUST_SSA_CONTROL e\<close>;
-            match x {
-               None \<Rightarrow> \<epsilon>\<open>MICRO_RUST_SSA_CONTROL n\<close>,
-               Some(s) \<Rightarrow> \<epsilon>\<open>MICRO_RUST_SSA_CONTROL (sm s)\<close>
-            }\<rbrakk>\<close>
-  unfolding MICRO_RUST_SSA_CONTROL_def
-    by (clarsimp simp add: micro_rust_simps)
-
 lemma ssa_transform_option_propagate [micro_rust_ssa]:
   shows \<open>MICRO_RUST_SSA_CONTROL (propagate_option exp) =
          \<lbrakk> let x = \<epsilon>\<open>MICRO_RUST_SSA_CONTROL exp\<close>;
@@ -348,28 +250,6 @@ lemma ssa_transform_option_propagate [micro_rust_ssa]:
            } \<rbrakk>\<close>
   unfolding MICRO_RUST_SSA_CONTROL_def propagate_option_def
     by (clarsimp simp add: micro_rust_simps)
-
-subsection\<open>Single static assignment form for \<^emph>\<open>Result\<close>\<close>
-
-text\<open>We extend the transformation of expressions into an SSA form to the operations on the \<^verbatim>\<open>Result\<close>
-type, here.
-
-TODO: should apply more generally to any match expression? The transformation below is not only
-specific to the Result type, but also to the order of constructors given.  A similar problem exists
-above for \<^verbatim>\<open>Option\<close>, too.\<close>
-lemma ssa_transform_result_cases [micro_rust_ssa]:
-  shows \<open>MICRO_RUST_SSA_CONTROL \<lbrakk> match \<epsilon>\<open>e\<close> {
-                                    Ok(x) \<Rightarrow> \<epsilon>\<open>ok x\<close>,
-                                    Err(y) \<Rightarrow> \<epsilon>\<open>err y\<close>
-                                  }\<rbrakk> =
-          \<lbrakk> let x = \<epsilon>\<open>MICRO_RUST_SSA_CONTROL e\<close>;
-            match x {
-               Ok(x) \<Rightarrow> \<epsilon>\<open>MICRO_RUST_SSA_CONTROL (ok x)\<close>,
-               Err(y) \<Rightarrow> \<epsilon>\<open>MICRO_RUST_SSA_CONTROL (err y)\<close>
-            }\<rbrakk>\<close>
-  unfolding MICRO_RUST_SSA_CONTROL_def
-    by (clarsimp simp add: micro_rust_simps)
-
 lemma ssa_transform_result_propagate [micro_rust_ssa]:
   shows \<open>MICRO_RUST_SSA_CONTROL (propagate_result exp) =
          \<lbrakk> let x = \<epsilon>\<open>MICRO_RUST_SSA_CONTROL exp\<close>;
@@ -379,8 +259,6 @@ lemma ssa_transform_result_propagate [micro_rust_ssa]:
            } \<rbrakk>\<close>
   unfolding MICRO_RUST_SSA_CONTROL_def propagate_result_def
     by (clarsimp simp add: micro_rust_simps)
-
-
 subsection\<open>Single static assignment form for \<^emph>\<open>Bool\<close>\<close>
 
 lemma ssa_transform_assert [micro_rust_ssa]:
@@ -396,77 +274,16 @@ lemma ssa_transform_assert_eq [micro_rust_ssa]:
 unfolding MICRO_RUST_SSA_CONTROL_def by (rule expression_eqI; clarsimp simp add: bind2_def
   assert_eq_def bind_literal_unit)
 
+lemma ssa_transform_assert_ne [micro_rust_ssa]:
+  shows \<open>MICRO_RUST_SSA_CONTROL \<lbrakk> assert_ne!(\<epsilon>\<open>e\<close>, \<epsilon>\<open>f\<close>) \<rbrakk> =
+           \<lbrakk> let x = \<epsilon>\<open>MICRO_RUST_SSA_CONTROL e\<close>;
+             let y = \<epsilon>\<open>MICRO_RUST_SSA_CONTROL f\<close>;
+              assert_ne!(x,  y) 
+           \<rbrakk>\<close>
+unfolding MICRO_RUST_SSA_CONTROL_def by (rule expression_eqI; clarsimp simp add: bind2_def
+  assert_ne_def bind_literal_unit)
+
 subsection\<open>Single static assignment form for numeric and bitwise operators\<close>
-
-lemma ssa_transform_HOL_if [micro_rust_ssa]:
-  shows \<open>MICRO_RUST_SSA_CONTROL (if b then e else f) =
-    (if b then MICRO_RUST_SSA_CONTROL e else MICRO_RUST_SSA_CONTROL f)\<close>
-  by (clarsimp simp add: MICRO_RUST_SSA_CONTROL_def)
-
-text\<open>It is rather unfortunate that we have to do this, but there is no generic way to write those
-simplifications: case expressions are only syntactic sugar, and are elaborated into type-specific
-expressions during parsing.\<close>
-
-lemma ssa_transform_option [micro_rust_ssa]:
-  shows \<open>MICRO_RUST_SSA_CONTROL (case_option f g x) =
-          case_option (MICRO_RUST_SSA_CONTROL f) (MICRO_RUST_SSA_CONTROL g) x\<close>
-  unfolding MICRO_RUST_SSA_CONTROL_def by auto
-
-lemma ssa_transform_result [micro_rust_ssa]:
-  shows \<open>MICRO_RUST_SSA_CONTROL (case_result f g x) =
-          case_result (MICRO_RUST_SSA_CONTROL f) (MICRO_RUST_SSA_CONTROL g) x\<close>
-  unfolding MICRO_RUST_SSA_CONTROL_def by auto 
-
-text\<open>The following rules seem more suitable because they restrict to \<^verbatim>\<open>\<mu>Rust\<close> match constructs
-rather than general case expressions. However, since the \<^verbatim>\<open>\<mu>Rust\<close> match construct is defined as a
-bind with an anonymous HOL case, SSA simplification might step into the bind first, in which case we
-end up with a nested HOL lambda and case:\<close>
-
-lemma ssa_transform_option_urust [micro_rust_ssa]:
-  shows \<open>MICRO_RUST_SSA_CONTROL \<lbrakk> match \<epsilon>\<open>e\<close> {
-            Some (v) \<Rightarrow> \<epsilon>\<open>case_some v\<close>,
-            None \<Rightarrow> \<epsilon>\<open>case_none\<close>
-         } \<rbrakk> = 
-         \<lbrakk> let ve = \<epsilon>\<open>e\<close>;
-           match ve {
-             Some (v) \<Rightarrow> \<epsilon>\<open>MICRO_RUST_SSA_CONTROL (case_some v)\<close>,
-             None \<Rightarrow> \<epsilon>\<open>MICRO_RUST_SSA_CONTROL case_none\<close>
-           } \<rbrakk>\<close>
-  unfolding MICRO_RUST_SSA_CONTROL_def 
-  by (simp add: bind_literal_unit)
-
-lemma ssa_transform_result_urust [micro_rust_ssa]:
-  shows \<open>MICRO_RUST_SSA_CONTROL \<lbrakk> match \<epsilon>\<open>e\<close> {
-            Ok (v) \<Rightarrow> \<epsilon>\<open>case_ok v\<close>,
-            Err (v) \<Rightarrow> \<epsilon>\<open>case_err v\<close>
-         } \<rbrakk> = 
-         \<lbrakk> let ve = \<epsilon>\<open>e\<close>;
-           match ve {
-             Ok (v) \<Rightarrow> \<epsilon>\<open>MICRO_RUST_SSA_CONTROL (case_ok v)\<close>,
-             Err (v) \<Rightarrow> \<epsilon>\<open>MICRO_RUST_SSA_CONTROL (case_err v)\<close>
-           } \<rbrakk>\<close>
-  unfolding MICRO_RUST_SSA_CONTROL_def 
-  by (simp add: bind_literal_unit)
-
-lemma ssa_transform_HOL_case_prod [micro_rust_ssa]:
-  shows \<open>MICRO_RUST_SSA_CONTROL (case t of (a,b) \<Rightarrow> e a b) =
-    (case t of (a,b) \<Rightarrow> MICRO_RUST_SSA_CONTROL (e a b))\<close>
-  by (clarsimp simp add: MICRO_RUST_SSA_CONTROL_def)
-
-lemma ssa_transform_let [micro_rust_ssa]:
-  shows \<open>MICRO_RUST_SSA_CONTROL \<lbrakk> let x = \<epsilon>\<open>e\<close>; \<epsilon>\<open>f\<close> \<rbrakk> =
-          \<lbrakk> let x = \<epsilon>\<open>MICRO_RUST_SSA_CONTROL e\<close>;
-            \<epsilon>\<open>MICRO_RUST_SSA_CONTROL f\<close> \<rbrakk>\<close>
-  unfolding MICRO_RUST_SSA_CONTROL_def by (rule expression_eqI; elim micro_rust_elims;
-      clarsimp; intro micro_rust_intros;
-      clarsimp simp add: micro_rust_simps; force)
-
-lemma ssa_transform_to_unit [micro_rust_ssa]:
-  shows \<open>MICRO_RUST_SSA_CONTROL \<lbrakk> \<epsilon>\<open>e\<close>; \<rbrakk> =
-          \<lbrakk> \<epsilon>\<open>MICRO_RUST_SSA_CONTROL e\<close>; \<rbrakk>\<close>
-  unfolding MICRO_RUST_SSA_CONTROL_def by (rule expression_eqI; elim micro_rust_elims;
-      clarsimp; intro micro_rust_intros;
-      clarsimp simp add: micro_rust_simps; force)
 
 lemma ssa_transform_two_armed_conditional [micro_rust_ssa]:
   shows \<open>MICRO_RUST_SSA_CONTROL 


### PR DESCRIPTION
Various improvements to `crush`'s proof automation:
1. Definitions added to `simp [prems,concls] add:` now work for definitions of the form `some_def \equiv \lambda x. `: these are now automatically eta-expanded
2. Add a `wp split:` parameter to `crush`. This accepts the same arguments as `split:`, but only applies them when the top-level expression in a WP statement get stuck on the split.
3. Guard the crush branches `crush_branch_base_simps_early_unfold` and `crush_branch_base_detect_aentails_contradiction` with a configuration option. This is helpful when debugging/speeding up long-running crush calls.
4. Change SSA normalization from top-down to bottom-up. This avoids having to define new SSA rules for additional datatypes.
5. No longer drop premises marked `ASSUMPTION` in the MePo filter
6. Add a configuration option `crush_stop_at_full_blown_clarsimp` to make crush stop whenever it would otherwise apply a full-blown clarsimp. This makes it easier to figure out why such last-resort full-blown clarsimps happen.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
