### PR TITLE
Added "count" function on iterator, returning the number of elements it has

### DIFF
--- a/Micro_Rust_Std_Lib/StdLib_Iterators.thy
+++ b/Micro_Rust_Std_Lib/StdLib_Iterators.thy
@@ -39,6 +39,18 @@ definition any :: \<open>('s, 'v, 'abort, 'i prompt, 'o prompt_output) iterator 
 context reference
 begin
 
+definition count :: \<open>('s, 'a, 'abort, 'i prompt, 'o prompt_output) iterator \<Rightarrow>
+      ('s, 64 word, 'abort, 'i prompt, 'o prompt_output) function_body\<close> where
+  \<open>count self \<equiv> FunctionBody \<lbrakk>
+     let mut count = 0_usize;
+
+     for x in self {
+       count = (*count) + 1;
+     };
+
+     *count
+   \<rbrakk>\<close>
+
 definition iter_mut ::
   \<open>('a, 'b, 'v list) ref \<Rightarrow> ('s, ('s, ('a, 'b, 'v) ref, 'abort, 'i prompt, 'o prompt_output) iterator, 'abort, 'i prompt, 'o prompt_output) function_body\<close>
   where


### PR DESCRIPTION
Like the Rust counterpart, for very large iterators it will overflow.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
