### PR TITLE
Fix implementation of `.count()` on iterators, remove unresolved constant

### DIFF
--- a/Micro_Rust_Std_Lib/StdLib_Iterators.thy
+++ b/Micro_Rust_Std_Lib/StdLib_Iterators.thy
@@ -36,20 +36,14 @@ definition any :: \<open>('s, 'v, 'abort, 'i prompt, 'o prompt_output) iterator 
      }
    \<rbrakk>\<close>
 
-context reference
-begin
-
-definition count :: \<open>('s, 'a, 'abort, 'i prompt, 'o prompt_output) iterator \<Rightarrow>
+definition count :: \<open>('s, 'v, 'abort, 'i prompt, 'o prompt_output) iterator \<Rightarrow>
       ('s, 64 word, 'abort, 'i prompt, 'o prompt_output) function_body\<close> where
   \<open>count self \<equiv> FunctionBody \<lbrakk>
-     let mut count = 0_usize;
-
-     for x in self {
-       count = (*count) + 1;
-     };
-
-     *count
+    \<llangle>of_nat \<circ> length \<circ> iterator_thunks\<rrangle>\<^sub>1(self)
    \<rbrakk>\<close>
+
+context reference
+begin
 
 definition iter_mut ::
   \<open>('a, 'b, 'v list) ref \<Rightarrow> ('s, ('s, ('a, 'b, 'v) ref, 'abort, 'i prompt, 'o prompt_output) iterator, 'abort, 'i prompt, 'o prompt_output) function_body\<close>


### PR DESCRIPTION
The µRust implementation of `.count()` uses `let mut count` to tally the iterations in an iterator. However, it is defined in the `reference` locale, while one needs the `reference_allocatable` locale here to ensure that `u64`s can actually be allocated like this. The `store_reference_const` constant is therefore never resolved to a usable allocator, meaning that e.g. code generation will not work.

Change the implementation of `count` to just call `length` on the underlying `iterator_thunks`.

An alternative would be to require a `reference_allocatable` locale in which we can allocate `u64`s. That seems too invasive for simple library functions, although we may wish to consider this in the future.

Fixes: #47

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
