### PR TITLE
Add support for `switch`-like matching on numerals in µRust

### DIFF
--- a/Shallow_Micro_Rust/Core_Syntax.thy
+++ b/Shallow_Micro_Rust/Core_Syntax.thy
@@ -4,7 +4,7 @@
 (*<*)
 theory Core_Syntax
   imports Core_Expression Rust_Iterator Result_Type Numeric_Types Option_Type
-    Range_Type Bool_Type Global_Store
+    Range_Type Bool_Type Global_Store Num_Case_Expression
 begin
 (*>*)
 
@@ -167,12 +167,15 @@ nonterminal urust_shallow_match_pattern_args
 
 syntax
   "_urust_shallow_match" :: "[('s, 'v, 'r, 'abort, 'i, 'o) expression, urust_shallow_match_branches] \<Rightarrow> ('sp, 'vp, 'rp, 'abort, 'i, 'o) expression"  ("match (_) \<lbrace>/ _/ \<rbrace>" [20, 20]20)
+  "_urust_shallow_switch" :: "[('s, 'v, 'r, 'abort, 'i, 'o) expression, urust_shallow_match_branches] \<Rightarrow> ('sp, 'vp, 'rp, 'abort, 'i, 'o) expression"  ("match'_switch (_) \<lbrace>/ _/ \<rbrace>" [20, 20]20)
   \<comment>\<open>Basic case branches\<close>
   "_urust_shallow_match1" :: "[urust_shallow_match_pattern, 'b] \<Rightarrow> urust_shallow_match_branches"  ("(2_ \<Rightarrow>/ _)" [100, 20] 21)
   "_urust_shallow_match2" :: "[urust_shallow_match_branches, urust_shallow_match_branches] \<Rightarrow> urust_shallow_match_branches"  ("_/, _" [21, 20]20)
   \<comment>\<open>Basic case patterns, restricted to constructor identifiers followed by a potentially empty list of argument identifiers\<close>
   "_urust_shallow_match_pattern_other" :: \<open>urust_shallow_match_pattern\<close>
     ("'_")
+  "_urust_shallow_match_pattern_num_const" :: \<open>num_const \<Rightarrow> urust_shallow_match_pattern\<close>
+    ("_")
   "_urust_shallow_match_pattern_constr_no_args" :: \<open>logic \<Rightarrow> urust_shallow_match_pattern\<close>
     ("\<guillemotleft>_\<guillemotright>")
   "_urust_shallow_match_pattern_constr_with_args" :: \<open>logic \<Rightarrow> urust_shallow_match_pattern_args \<Rightarrow> urust_shallow_match_pattern\<close>
@@ -302,6 +305,8 @@ syntax
   "_urust_shallow_match_convert_arg" :: \<open>urust_shallow_match_pattern_arg \<Rightarrow> case_basic_pattern_arg\<close>
   "_anonymous_var" :: \<open>logic\<close>
   "_anonymous_case" :: \<open>logic \<Rightarrow> logic\<close>
+  "_urust_shallow_switch_convert_branches" :: \<open>urust_shallow_match_branches \<Rightarrow> case_num_branches\<close>
+  "_urust_shallow_switch_convert_pattern" :: \<open>urust_shallow_match_branch \<Rightarrow> case_num_pattern\<close>
 
 translations
   \<comment>\<open>Conditionals\<close>
@@ -531,6 +536,23 @@ translations
     \<rightharpoonup> "_case_basic_pattern_arg_id id"
   "_urust_shallow_match_convert_arg (_urust_shallow_match_pattern_arg_dummy)"
     \<rightharpoonup> "_case_basic_pattern_arg_dummy"
+
+translations
+  \<comment> \<open>Since we can convert these numeric cases to a function, we don't have to worry about creating
+      an anonymous function and variable, as we have to do for the \<^verbatim>\<open>match_case\<close>-types of matches.\<close>
+  "_urust_shallow_switch exp branches"
+    \<rightharpoonup> "(CONST bind) exp (_case_num_fun_syntax (_urust_shallow_switch_convert_branches branches))"
+  "_urust_shallow_switch_convert_branches (_urust_shallow_match2 (_urust_shallow_match1 pat1 exp) branch2)"
+    \<rightharpoonup> "_case_num2 (_case_num1 (_urust_shallow_switch_convert_pattern pat1) exp) (_urust_shallow_switch_convert_branches branch2)"
+  "_urust_shallow_switch_convert_branches (_urust_shallow_match1 pat exp)"
+    \<rightharpoonup> "_case_num_branch_as_branches (_case_num1 (_urust_shallow_switch_convert_pattern pat) exp)"
+
+  "_urust_shallow_switch_convert_pattern _urust_shallow_match_pattern_other"
+    \<rightharpoonup> "_case_num_pattern_other"
+  "_urust_shallow_switch_convert_pattern (_urust_shallow_match_pattern_constr_no_args id)"
+    \<rightharpoonup> "_case_num_pattern_const id"
+  "_urust_shallow_switch_convert_pattern (_urust_shallow_match_pattern_num_const num)"
+    \<rightharpoonup> "_case_num_pattern_numeral num"
 
 \<comment>\<open>todo: add print translation for this so the case expressions remain readable\<close>
 parse_translation\<open>
@@ -878,6 +900,20 @@ value\<open>
 term \<open>
   let x = Ref::new\<langle>\<up>42\<rangle>;
   \<up>x +=\<^sub>\<mu> \<up>12
+\<close>
+
+term\<open>let y = x; match_switch y \<lbrace>
+  3 \<Rightarrow> \<up>True,
+  5 \<Rightarrow> \<up>False
+\<rbrace>\<close>
+
+term\<open>
+  match_switch x \<lbrace>
+    3 \<Rightarrow> \<up>True,
+    5 \<Rightarrow> \<up>True,
+    \<guillemotleft>twentyfive\<guillemotright> \<Rightarrow> \<up>True,
+    _ \<Rightarrow> \<up>False
+  \<rbrace>
 \<close>
 
 (*>*)

--- a/Shallow_Micro_Rust/Micro_Rust_Shallow_Embedding.thy
+++ b/Shallow_Micro_Rust/Micro_Rust_Shallow_Embedding.thy
@@ -615,7 +615,7 @@ translations
   "_shallow (_urust_if_let_else ptrn exp this that )"
     \<rightharpoonup> "_urust_shallow_if_let_else (_shallow_match_pattern ptrn) (_shallow exp) (_shallow this) (_shallow that)"
 
-  "_shallow (_urust_match exp branches)"
+  "_shallow (_urust_match_case exp branches)"
     \<rightharpoonup> "_urust_shallow_match (_shallow exp) (_shallow_match_branches branches)"
 
   "_shallow_match_branches (_urust_match1 pattern exp)"
@@ -625,6 +625,8 @@ translations
 
   "_shallow_match_pattern _urust_match_pattern_other"
     \<rightharpoonup> "_urust_shallow_match_pattern_other"
+  "_shallow_match_pattern (_urust_match_pattern_num_const num)"
+    \<rightharpoonup> "_urust_shallow_match_pattern_num_const num"
   "_shallow_match_pattern (_urust_match_pattern_constr_no_args id)"
     \<rightharpoonup> "_urust_shallow_match_pattern_constr_no_args (_shallow_identifier_as_literal id)"
   "_shallow_match_pattern (_urust_match_pattern_constr_with_args id args)"
@@ -639,6 +641,9 @@ translations
     \<rightharpoonup> "_urust_shallow_match_pattern_arg_id id"
   "_shallow_match_arg _urust_match_pattern_arg_dummy"
     \<rightharpoonup> "_urust_shallow_match_pattern_arg_dummy"
+
+  "_shallow (_urust_match_switch exp branches)"
+    \<rightharpoonup> "_urust_shallow_switch (_shallow exp) (_shallow_match_branches branches)"
 
   "_shallow (_urust_for_loop x iter body)"
     \<rightharpoonup> "_urust_shallow_for_loop (_shallow_let_pattern x) (_shallow iter) (_shallow body)"
@@ -1332,6 +1337,7 @@ definition \<open>plus_two_lift \<equiv> lift_fun1 plus_two\<close>
 notation_nano_rust plus_two_lift ("plus2::lifted")
 
 definition three :: \<open>64 word\<close> where \<open>three = 3\<close>
+notation_nano_rust three ("number::three")
 
 term\<open>\<lbrakk> test::Test_1 \<rbrakk>\<close>
 
@@ -1344,6 +1350,25 @@ term\<open>\<lbrakk>
   match arg {
     test::Test_1 \<Rightarrow> fun(three),
     test::Test_2 \<Rightarrow> plus2::lifted(three)
+  }
+\<rbrakk>\<close>
+
+term\<open>\<lbrakk>
+  let x = 5;
+  match x {
+    2 \<Rightarrow> False,
+    number::three \<Rightarrow> False,
+    _ \<Rightarrow> True
+  }
+\<rbrakk>\<close>
+
+term\<open>\<lbrakk>
+  let x = 5;
+\<comment> \<open>\<^verbatim>\<open>match_switch\<close> forces interpretation of this \<^verbatim>\<open>match\<close> clause as a \<^verbatim>\<open>switch\<close>\<close>
+  match_switch x {
+    2 \<Rightarrow> False,
+    number::three \<Rightarrow> False,
+    _ \<Rightarrow> True
   }
 \<rbrakk>\<close>
 

--- a/Shallow_Micro_Rust/Num_Case_Expression.thy
+++ b/Shallow_Micro_Rust/Num_Case_Expression.thy
@@ -1,0 +1,181 @@
+(*<*)
+theory Num_Case_Expression
+  imports
+    Main
+    Misc.WordAdditional
+begin
+(*>*)
+
+section\<open>Case expressions over numerals\<close>
+
+text\<open>Unlike in languages such as Rust, we cannot do case splits on numeral types in native Isabelle.
+We'd like to be able to do e.g.:
+\<^verbatim>\<open>
+term\<open>case (4 :: nat) of
+  (2 :: nat) \<Rightarrow> True
+| 4 \<Rightarrow> False\<close>\<close>
+and
+\<^verbatim>\<open>
+term\<open>case (4 :: 64 word) of
+  2 \<Rightarrow> True
+| 4 \<Rightarrow> False\<close>
+\<close>.
+
+Besides being more readable than nesting if/else statements, this will also be helpful when
+shallowly embedding \<mu>Rust in Isabelle, since Rust \<^emph>\<open>does\<close> support these kinds of matches.
+
+This file constructs an \<^verbatim>\<open>ncase\<close> match statement, that does allow you to write the above\<close>
+
+nonterminal case_num_pattern
+nonterminal case_num_branch
+nonterminal case_num_branches
+
+syntax
+  \<comment>\<open>Numeral case expressions\<close>
+  "_case_num_syntax" :: "['a, case_num_branches] \<Rightarrow> 'b"  ("(ncase _ of/ _)" [20, 20]20)
+  \<comment> \<open>We also add a 'functional' version of this, which turns out to be useful when parsing
+      \<mu>Rust. This is because we have to first evaluate the argument before pattern matching,
+      which will be parsed as a \<^verbatim>\<open>bind arg (pattern_match_function)\<close>. By having notation for
+      the function, we don't need to introduce an anonymous lambda (which comes with its own problems)\<close>
+  "_case_num_fun_syntax" :: "[case_num_branches] \<Rightarrow> 'b"  ("(ncase'_fun of/ _)" [20]20)
+  \<comment>\<open>Numeral case branches\<close>
+  "_case_num1" :: "[case_num_pattern, 'b] \<Rightarrow> case_num_branch"  ("(2_ \<Rightarrow>/ _)" [100, 20] 21)
+  "_case_num2" :: "[case_num_branch, case_num_branches] \<Rightarrow> case_num_branches"  ("_/ | _" [21, 20]20)
+  \<comment>\<open>Numeral case patterns\<close>
+  "_case_num_pattern_other" :: \<open>case_num_pattern\<close>
+    ("'_")
+  "_case_num_pattern_numeral" :: \<open>num_const \<Rightarrow> case_num_pattern\<close>
+    ("_" 100)
+  \<comment> \<open>Note: cannot take \<^verbatim>\<open>logic\<close> arguments, because that will conflict with the \<^verbatim>\<open>_\<close> defined above\<close>
+  "_case_num_pattern_const" :: \<open>id \<Rightarrow> case_num_pattern\<close>
+    ("_" 100)
+  "_case_num_branch_as_branches" :: \<open>case_num_branch \<Rightarrow> case_num_branches\<close>
+    ("_")
+
+text\<open>Now we define the 'raw' function that such \<^verbatim>\<open>ncase\<close> statements will be parsed down to.\<close>
+definition ncase_selector_raw :: \<open>('a option \<times> 'b) list \<Rightarrow> 'a \<Rightarrow> 'b\<close> where
+  \<open>ncase_selector_raw cases arg \<equiv>
+    case List.find (\<lambda> (ma, b). case ma of None \<Rightarrow> True | Some a \<Rightarrow> a = arg) cases of
+      None \<Rightarrow> undefined
+    | Some (ma, b) \<Rightarrow> b\<close>
+
+definition \<open>ncase_selector \<equiv> ncase_selector_raw\<close>
+
+lemmas ncase_def = ncase_selector_def
+lemmas ncase_simps = ncase_selector_def ncase_selector_raw_def
+text\<open>We have separate definitions so that users can more easily see what's going on underneath
+the syntax. That is, \<^verbatim>\<open>ncase_selector\<close> should always be pretty printed as \<^verbatim>\<open>ncase _ of _\<close>,
+but by unfolding @{thm ncase_def} you can see the raw clauses being operated on, without
+reducing the entire \<^verbatim>\<open>ncase\<close> construct.\<close>
+
+translations
+  \<comment> \<open>Parse \<^verbatim>\<open>ncase arg of cases\<close> as \<^verbatim>\<open>(ncase_fun of cases) arg\<close>, print the other way around\<close>
+  "_case_num_syntax arg cases" \<rightleftharpoons>
+    "_case_num_fun_syntax cases arg"
+  \<comment> \<open>The rest of the rules are \<^emph>\<open>just\<close> parsing rules, since we don't want e.g.
+       \<^term>\<open>[(None, a)]\<close> to print as \<^verbatim>\<open>_ \<Rightarrow> a\<close>!\<close>
+  "_case_num_fun_syntax cases" \<rightharpoonup>
+    "CONST ncase_selector cases"
+  "_case_num2 left right" \<rightharpoonup>
+    "CONST Cons left right"
+  "_case_num1 _case_num_pattern_other result" \<rightharpoonup>
+    "CONST Pair (CONST None) result"
+  "_case_num1 (_case_num_pattern_numeral num) result" \<rightharpoonup>
+    "CONST Pair (CONST Some (_Numeral num)) result"
+  "_case_num1 (_case_num_pattern_const c) result" \<rightharpoonup>
+    "CONST Pair (CONST Some c) result"
+  "_case_num_branch_as_branches branch" \<rightharpoonup>
+    "CONST Cons branch (CONST Nil)"
+
+experiment
+begin
+definition twentyfive :: nat where \<open>twentyfive \<equiv> 25\<close>
+
+term\<open>ncase (4 :: nat) of
+  3 \<Rightarrow> True
+| 4 \<Rightarrow> False
+| twentyfive \<Rightarrow> False
+| _ \<Rightarrow> True\<close>
+\<comment> \<open>Prints as: 
+\<^term>\<open>ncase_selector [(Some 3, True), (Some 4, False), (Some twentyfive, False), (None, True)] 4\<close>\<close>
+
+term\<open>ncase_fun of
+  3 \<Rightarrow> True
+| 4 \<Rightarrow> False
+| twentyfive \<Rightarrow> False
+| _ \<Rightarrow> True\<close>
+\<comment> \<open>Prints as: 
+\<^term>\<open>ncase_selector [(Some 3, True), (Some 4, False), (Some twentyfive, False), (None, True)]\<close>\<close>
+end
+
+
+text\<open>We have the desired \<^verbatim>\<open>ncase\<close> - now we add pretty printing\<close>
+
+nonterminal printing_only
+
+syntax
+  \<comment> \<open>Tag to print as a branch of a case expression\<close>
+  "_case_print_tag" :: "logic \<Rightarrow> logic"
+  \<comment> \<open>Tag that ensures arguments are printed as a branch\<close>
+  "_case_print_tag_num" :: "logic \<Rightarrow> logic \<Rightarrow> printing_only" ("(2_ \<Rightarrow>/ _)")
+
+translations
+  \<comment> \<open>When printing, the \<^verbatim>\<open>_case_print_tag\<close> is pushed down and ensures things are printed as branches\<close>
+  "_case_num_syntax arg (_case_print_tag cases)" <=
+    "CONST ncase_selector cases arg"
+  "_case_num_fun_syntax (_case_print_tag cases)" <=
+    "CONST ncase_selector cases"
+  "_case_num2 (_case_print_tag left) (_case_print_tag (CONST Cons right1 right2))" <=
+    "_case_print_tag (CONST Cons left (CONST Cons right1 right2))"
+  "_case_num_branch_as_branches (_case_print_tag left)" <=
+    "_case_print_tag (CONST Cons left (CONST Nil))"
+  "_case_num1 _case_num_pattern_other result" <=
+    "_case_print_tag (CONST Pair (CONST None) result)"
+  "_case_print_tag_num num result" <=
+    "_case_print_tag (CONST Pair (CONST Some num) result)"
+  "_case_num_branch_as_branches (_case_print_tag branch)" <=
+    "_case_print_tag (_case_num_branch_as_branches branch)"
+
+experiment
+begin
+definition twentyfive :: nat where \<open>twentyfive \<equiv> 25\<close>
+
+term\<open>ncase (4 :: nat) of
+  3 \<Rightarrow> True
+| 4 \<Rightarrow> False
+| twentyfive \<Rightarrow> True
+| _ \<Rightarrow> True\<close>
+\<comment> \<open>Prints as:
+\<^term>\<open>ncase 4 of 3 \<Rightarrow> True | 4 \<Rightarrow> False | twentyfive \<Rightarrow> True | _ \<Rightarrow> True\<close>\<close>
+
+term\<open>ncase_fun of
+  3 \<Rightarrow> True
+| 4 \<Rightarrow> False
+| twentyfive \<Rightarrow> False
+| _ \<Rightarrow> True\<close>
+\<comment> \<open>Prints as: 
+\<^term>\<open>ncase_fun of 3 \<Rightarrow> True | 4 \<Rightarrow> False | twentyfive \<Rightarrow> False | _ \<Rightarrow> True\<close>\<close>
+
+\<comment> \<open>Showcasing simplification rules\<close>
+lemma test1:
+  shows \<open>(ncase (4 :: nat) of
+          3 \<Rightarrow> True
+        | 4 \<Rightarrow> False
+        | _ \<Rightarrow> True) = False\<close>
+  \<comment> \<open>Using @{thm ncase_def} will just get rid of the pretty syntax\<close>
+  apply (simp add: ncase_def)
+  apply (simp add: ncase_selector_raw_def)
+  done
+
+lemma test2:
+  shows \<open>(ncase (4 :: nat) of
+          4 \<Rightarrow> False
+        | 3 \<Rightarrow> True
+        | _ \<Rightarrow> True) = False\<close>
+  \<comment> \<open>Using @{thm ncase_simps} will get rid of the syntax and simplify as expected\<close>
+  by (simp add: ncase_simps)
+end
+
+(*<*)
+end
+(*>*)

--- a/Shallow_Micro_Rust/ROOT
+++ b/Shallow_Micro_Rust/ROOT
@@ -16,6 +16,7 @@ session Shallow_Micro_Rust = HOL +
     Pullback
     Rust_Iterator Rust_Iterator_Lemmas
     Range_Type
+    Num_Case_Expression
     Numeric_Types Numeric_Types_Lemmas
     Global_Store
     Micro_Rust_Shallow_Embedding


### PR DESCRIPTION
Rust supports `switch`-like matching on numerals, e.g.:
```
match number {
   42 => Ok(()),
   _ => Err(())
}
```
This commit adds support for such `match`es in µRust.

We first add Isabelle syntax for a new `ncase _ of` construct, to which the shallow embedding of these `switch`-like matches will parse down to.

Determining whether a µRust `match` should become an Isabelle `case` or an `ncase` is somewhat tricky. We do this via a parse AST translation which detects the presence of numeral patterns.

Note that one can also match on constant, but non-concrete numbers, e.g.
```
match number {
   the_answer => Ok(()),
   _ => Err(())
}
```
In this case, we cannot know at parse time whether this should become a `case` or an `ncase`. Instead, one can use the `match_switch` keyword to force parsing this as an `ncase`.

This change should be backwards compatible with existing µRust.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
