### PR TITLE
Fix match on numerals not supporting zero and one

### DIFF
--- a/Micro_Rust_Parsing_Frontend/Micro_Rust_Syntax.thy
+++ b/Micro_Rust_Parsing_Frontend/Micro_Rust_Syntax.thy
@@ -319,6 +319,10 @@ syntax
     ("_" [1000]100)
   "_urust_match_pattern_num_const" :: \<open>num_const \<Rightarrow> urust_match_pattern\<close>
     ("_" [1000]100)
+  "_urust_match_pattern_zero" :: \<open>urust_match_pattern\<close>
+    ("0")
+  "_urust_match_pattern_one" :: \<open>urust_match_pattern\<close>
+    ("1")
   "_urust_match_pattern_constr_with_args" :: \<open>urust_identifier \<Rightarrow> urust_match_pattern_args \<Rightarrow> urust_match_pattern\<close>
     ("_ '(_')"[1000,100]100)
   "_urust_match_pattern_arg_id" :: \<open>id \<Rightarrow> urust_match_pattern_arg\<close>
@@ -691,13 +695,18 @@ parse_ast_translation\<open>
           [pattern_ast_to_head_const clause]
 
     \<comment> \<open>Is this pattern valid in a \<^verbatim>\<open>match_case\<close>?\<close>
-    fun pat_is_match_case pat = pat <> \<^syntax_const>\<open>_urust_match_pattern_num_const\<close>
+    fun pat_is_match_case pat =
+      pat <> \<^syntax_const>\<open>_urust_match_pattern_num_const\<close> andalso
+      pat <> \<^syntax_const>\<open>_urust_match_pattern_zero\<close> andalso
+      pat <> \<^syntax_const>\<open>_urust_match_pattern_one\<close>
 
     \<comment> \<open>Is this pattern valid in a \<^verbatim>\<open>match_switch\<close>?\<close>
     fun pat_is_match_switch pat =
       (pat = \<^syntax_const>\<open>_urust_match_pattern_num_const\<close>)
       orelse (pat = \<^syntax_const>\<open>_urust_match_pattern_constr_no_args\<close>)
       orelse (pat = \<^syntax_const>\<open>_urust_match_pattern_other\<close>)
+      orelse (pat = \<^syntax_const>\<open>_urust_match_pattern_zero\<close>)
+      orelse (pat = \<^syntax_const>\<open>_urust_match_pattern_one\<close>)
 
     \<comment> \<open>Replace a \<^verbatim>\<open>_urust_temporary_match\<close> AST node with arguments \<^verbatim>\<open>[arg, branches]\<close> with the
         appropriate match AST node\<close>
@@ -749,7 +758,9 @@ term\<open>\<guillemotleft>foo::bar::zoo.boo.far\<guillemotright>\<close>
 term\<open>\<guillemotleft>foo::bar.boo(3)\<guillemotright>\<close>
 term\<open>\<guillemotleft>match 3 {
 a \<Rightarrow> 2,
-b(a) \<Rightarrow> 6,
+2 \<Rightarrow> 6,
+0 \<Rightarrow> 7,
+1 \<Rightarrow> 8,
 _ \<Rightarrow> 7
 }\<guillemotright>\<close>
 end

--- a/Shallow_Micro_Rust/Core_Syntax.thy
+++ b/Shallow_Micro_Rust/Core_Syntax.thy
@@ -176,6 +176,10 @@ syntax
     ("'_")
   "_urust_shallow_match_pattern_num_const" :: \<open>num_const \<Rightarrow> urust_shallow_match_pattern\<close>
     ("_")
+  "_urust_shallow_match_pattern_zero" :: \<open>urust_shallow_match_pattern\<close>
+    ("0")
+  "_urust_shallow_match_pattern_one" :: \<open>urust_shallow_match_pattern\<close>
+    ("1")
   "_urust_shallow_match_pattern_constr_no_args" :: \<open>logic \<Rightarrow> urust_shallow_match_pattern\<close>
     ("\<guillemotleft>_\<guillemotright>")
   "_urust_shallow_match_pattern_constr_with_args" :: \<open>logic \<Rightarrow> urust_shallow_match_pattern_args \<Rightarrow> urust_shallow_match_pattern\<close>
@@ -553,6 +557,10 @@ translations
     \<rightharpoonup> "_case_num_pattern_const id"
   "_urust_shallow_switch_convert_pattern (_urust_shallow_match_pattern_num_const num)"
     \<rightharpoonup> "_case_num_pattern_numeral num"
+  "_urust_shallow_switch_convert_pattern (_urust_shallow_match_pattern_zero)"
+    \<rightharpoonup> "_case_num_pattern_zero"
+  "_urust_shallow_switch_convert_pattern (_urust_shallow_match_pattern_one)"
+    \<rightharpoonup> "_case_num_pattern_one"
 
 \<comment>\<open>todo: add print translation for this so the case expressions remain readable\<close>
 parse_translation\<open>
@@ -912,6 +920,8 @@ term\<open>
     3 \<Rightarrow> \<up>True,
     5 \<Rightarrow> \<up>True,
     \<guillemotleft>twentyfive\<guillemotright> \<Rightarrow> \<up>True,
+    0 \<Rightarrow> \<up>True,
+    1 \<Rightarrow> \<up>True,
     _ \<Rightarrow> \<up>False
   \<rbrace>
 \<close>

--- a/Shallow_Micro_Rust/Micro_Rust_Shallow_Embedding.thy
+++ b/Shallow_Micro_Rust/Micro_Rust_Shallow_Embedding.thy
@@ -627,6 +627,10 @@ translations
     \<rightharpoonup> "_urust_shallow_match_pattern_other"
   "_shallow_match_pattern (_urust_match_pattern_num_const num)"
     \<rightharpoonup> "_urust_shallow_match_pattern_num_const num"
+  "_shallow_match_pattern (_urust_match_pattern_zero)"
+    \<rightharpoonup> "_urust_shallow_match_pattern_zero"
+  "_shallow_match_pattern (_urust_match_pattern_one)"
+    \<rightharpoonup> "_urust_shallow_match_pattern_one"
   "_shallow_match_pattern (_urust_match_pattern_constr_no_args id)"
     \<rightharpoonup> "_urust_shallow_match_pattern_constr_no_args (_shallow_identifier_as_literal id)"
   "_shallow_match_pattern (_urust_match_pattern_constr_with_args id args)"
@@ -1358,6 +1362,8 @@ term\<open>\<lbrakk>
   match x {
     2 \<Rightarrow> False,
     number::three \<Rightarrow> False,
+    0 \<Rightarrow> False,
+    1 \<Rightarrow> False,
     _ \<Rightarrow> True
   }
 \<rbrakk>\<close>
@@ -1366,7 +1372,6 @@ term\<open>\<lbrakk>
   let x = 5;
 \<comment> \<open>\<^verbatim>\<open>match_switch\<close> forces interpretation of this \<^verbatim>\<open>match\<close> clause as a \<^verbatim>\<open>switch\<close>\<close>
   match_switch x {
-    2 \<Rightarrow> False,
     number::three \<Rightarrow> False,
     _ \<Rightarrow> True
   }

--- a/Shallow_Micro_Rust/Num_Case_Expression.thy
+++ b/Shallow_Micro_Rust/Num_Case_Expression.thy
@@ -46,6 +46,11 @@ syntax
     ("'_")
   "_case_num_pattern_numeral" :: \<open>num_const \<Rightarrow> case_num_pattern\<close>
     ("_" 100)
+  \<comment> \<open>Turns out we need special branches to support matching on 0 and 1, since these are notations of their own\<close>
+  "_case_num_pattern_zero" :: \<open>case_num_pattern\<close>
+    ("0")
+  "_case_num_pattern_one" :: \<open>case_num_pattern\<close>
+    ("1")
   \<comment> \<open>Note: cannot take \<^verbatim>\<open>logic\<close> arguments, because that will conflict with the \<^verbatim>\<open>_\<close> defined above\<close>
   "_case_num_pattern_const" :: \<open>id \<Rightarrow> case_num_pattern\<close>
     ("_" 100)
@@ -80,6 +85,10 @@ translations
     "CONST Cons left right"
   "_case_num1 _case_num_pattern_other result" \<rightharpoonup>
     "CONST Pair (CONST None) result"
+  "_case_num1 (_case_num_pattern_zero) result" \<rightharpoonup>
+    "CONST Pair (CONST Some 0) result"
+  "_case_num1 (_case_num_pattern_one) result" \<rightharpoonup>
+    "CONST Pair (CONST Some 1) result"
   "_case_num1 (_case_num_pattern_numeral num) result" \<rightharpoonup>
     "CONST Pair (CONST Some (_Numeral num)) result"
   "_case_num1 (_case_num_pattern_const c) result" \<rightharpoonup>
@@ -95,6 +104,8 @@ term\<open>ncase (4 :: nat) of
   3 \<Rightarrow> True
 | 4 \<Rightarrow> False
 | twentyfive \<Rightarrow> False
+| 0 \<Rightarrow> False
+| 1 \<Rightarrow> False
 | _ \<Rightarrow> True\<close>
 \<comment> \<open>Prints as: 
 \<^term>\<open>ncase_selector [(Some 3, True), (Some 4, False), (Some twentyfive, False), (None, True)] 4\<close>\<close>
@@ -103,6 +114,8 @@ term\<open>ncase_fun of
   3 \<Rightarrow> True
 | 4 \<Rightarrow> False
 | twentyfive \<Rightarrow> False
+| 0 \<Rightarrow> False
+| 1 \<Rightarrow> False
 | _ \<Rightarrow> True\<close>
 \<comment> \<open>Prints as: 
 \<^term>\<open>ncase_selector [(Some 3, True), (Some 4, False), (Some twentyfive, False), (None, True)]\<close>\<close>
@@ -144,6 +157,8 @@ term\<open>ncase (4 :: nat) of
   3 \<Rightarrow> True
 | 4 \<Rightarrow> False
 | twentyfive \<Rightarrow> True
+| 0 \<Rightarrow> False
+| 1 \<Rightarrow> False
 | _ \<Rightarrow> True\<close>
 \<comment> \<open>Prints as:
 \<^term>\<open>ncase 4 of 3 \<Rightarrow> True | 4 \<Rightarrow> False | twentyfive \<Rightarrow> True | _ \<Rightarrow> True\<close>\<close>
@@ -152,6 +167,8 @@ term\<open>ncase_fun of
   3 \<Rightarrow> True
 | 4 \<Rightarrow> False
 | twentyfive \<Rightarrow> False
+| 0 \<Rightarrow> False
+| 1 \<Rightarrow> False
 | _ \<Rightarrow> True\<close>
 \<comment> \<open>Prints as: 
 \<^term>\<open>ncase_fun of 3 \<Rightarrow> True | 4 \<Rightarrow> False | twentyfive \<Rightarrow> False | _ \<Rightarrow> True\<close>\<close>
@@ -161,6 +178,8 @@ lemma test1:
   shows \<open>(ncase (4 :: nat) of
           3 \<Rightarrow> True
         | 4 \<Rightarrow> False
+        | 1 \<Rightarrow> True
+        | 0 \<Rightarrow> False
         | _ \<Rightarrow> True) = False\<close>
   \<comment> \<open>Using @{thm ncase_def} will just get rid of the pretty syntax\<close>
   apply (simp add: ncase_def)
@@ -171,6 +190,8 @@ lemma test2:
   shows \<open>(ncase (4 :: nat) of
           4 \<Rightarrow> False
         | 3 \<Rightarrow> True
+        | 0 \<Rightarrow> False
+        | 1 \<Rightarrow> False
         | _ \<Rightarrow> True) = False\<close>
   \<comment> \<open>Using @{thm ncase_simps} will get rid of the syntax and simplify as expected\<close>
   by (simp add: ncase_simps)


### PR DESCRIPTION
It turns out that the literals '0' and '1' are not parsed like other numerals. Instead, zero and one have their own notation, and this means the approach from #51 does not yet work for matching on zero and one.

Therefore, add explicit clauses to the syntax for matching on zero and one. Make sure to add tests for such matches.

Fixes: #51

*Issue #, if available:*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
