### PR TITLE
Remove unnecessary import from `Num_Case_Expression.thy`

### DIFF
--- a/Shallow_Micro_Rust/Num_Case_Expression.thy
+++ b/Shallow_Micro_Rust/Num_Case_Expression.thy
@@ -2,7 +2,6 @@
 theory Num_Case_Expression
   imports
     Main
-    Misc.WordAdditional
 begin
 (*>*)
 


### PR DESCRIPTION
The `Num_Case_Expression.thy` file imports `Misc.WordAdditional`, but this import is not actually needed. Moreover, this import can cause downstream issues: it transitively imports `Word_Lib.Word_Lib_Sumo`, which adds simplification rules on numerals which are known to have poor performance in Isabelle2025 [(link)].

Therefore, remove this import.

[(link)]: https://isabelle.systems/zulip-archive/stream/247541-Mirror.3A-Isabelle-Users-Mailing-List/topic/.5Bisabelle.5D.20Word_Lib.3A.20Performance.20problem.20for.20proving.20ineq.2E.2E.2E.html

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
