### PR TITLE
Compatibility fixes for Isabelle2025 2

### DIFF
--- a/Misc/Array.thy
+++ b/Misc/Array.thy
@@ -102,7 +102,7 @@ by (transfer, clarsimp simp add: is_array_def list_fast_correct size_list)
 
 lemma array_to_list_update [simp]:
   shows \<open>array_to_list (array_update l i v) = list_update (array_to_list l) i v\<close>
-  by (transfer, simp add: is_array_def list_fast_correct braun_update1 list_update1 size_list)
+  by (transfer, auto simp add: is_array_def list_fast_correct braun_update1 list_update1 size_list list_update_beyond)
 
 lemma array_map_nth [simp]:
   assumes \<open>i < array_len xs\<close>

--- a/Misc/Remove_Enum_Discriminate_Elims.thy
+++ b/Misc/Remove_Enum_Discriminate_Elims.thy
@@ -19,10 +19,14 @@ rules from a newly generated \<^verbatim>\<open>datatype\<close> directly after 
 
 ML\<open>
   \<comment> \<open>Given a generic context, get the list of safe elimination rules\<close>
-  val safe_elims_of =
-    Classical.get_cs #>
-    Classical.rep_cs #> #safeEs #>
-    Item_Net.content #> List.map #1;
+  fun safe_elims_of ctxt =
+    let
+      fun is_safe_elim (_, {kind, ...}) =
+        Bires.kind_safe kind andalso Bires.kind_is_elim kind;
+    in
+      Classical.dest_decls (Context.proof_of ctxt) is_safe_elim
+      |> List.map #1
+    end;
 
   \<comment> \<open>Some wrappers for use with \<^verbatim>\<open>@{theory}\<close> and \<^verbatim>\<open>@{context}\<close>}\<close>
   val safe_elims_of_thy = Context.Theory #> safe_elims_of;

--- a/iq/Isar_Explore.thy
+++ b/iq/Isar_Explore.thy
@@ -85,10 +85,9 @@ fun isar_explore exec_id instance text state =
             directly into error_messages to Isabelle's output channel. *)
          val old_parallel_proofs = ! Multithreading.parallel_proofs
          val _ = Multithreading.parallel_proofs := Int.min(2, old_parallel_proofs)
-         val (st', err_opt) = Toplevel.transition false tr st
+         val st' = Toplevel.command_exception false tr st
          val _ = Multithreading.parallel_proofs := old_parallel_proofs
-      in case err_opt of NONE => st' | SOME (exn, _) =>
-            (raise exn) end
+      in st' end
   in
     List.foldl (fn (tr, st) => run_transition (tr, st)) state transitions
   end;
@@ -100,7 +99,7 @@ fun isar_explore exec_id instance text state =
 val _ = register {name = "isar_explore", pri = Task_Queue.urgent_pri}
     (fn {state, args, writeln_result, instance, exec_id, ...} =>
       (case args of [isar_text] => isar_explore exec_id instance isar_text state
-                                   |> Toplevel.string_of_state
+                                   |> (fn st => Pretty.string_of (Pretty.chunks (Toplevel.pretty_state st)))
                                    |> writeln_result
          | _ => raise (ERROR "Invalid number of arguments for isar_explore")))
 \<close>


### PR DESCRIPTION
Compatibility fixes for Isabelle2025-2

Minor fixes in `Misc/Array.thy` and `Misc/Remove_Enum_Discriminate_Elims.thy`.  Got I/Q compiling again.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
