### PR TITLE
Add disjunctive/or-pattern support for Micro Rust

### DIFF
--- a/Micro_Rust_Parsing_Frontend/Micro_Rust_Syntax.thy
+++ b/Micro_Rust_Parsing_Frontend/Micro_Rust_Syntax.thy
@@ -304,17 +304,21 @@ syntax
   "_urust_match_pattern_constr_no_args" :: \<open>urust_identifier \<Rightarrow> urust_pattern\<close>
     ("_" [0]1000)
   "_urust_match_pattern_num_const" :: \<open>num_const \<Rightarrow> urust_pattern\<close>
-    ("_" [1000]100)
+    ("_" [1000]1000)
   "_urust_match_pattern_zero" :: \<open>urust_pattern\<close>
-    ("0")
+    ("0" 1000)
   "_urust_match_pattern_one" :: \<open>urust_pattern\<close>
-    ("1")
+    ("1" 1000)
   "_urust_match_pattern_constr_with_args" :: \<open>urust_identifier \<Rightarrow> urust_pattern_args \<Rightarrow> urust_pattern\<close>
-    ("_ '(_')"[1000,100]100)
+    ("_ '(_')"[1000,100]1000)
   "_urust_match_pattern_args_single" :: \<open>urust_pattern \<Rightarrow> urust_pattern_args\<close>
     ("_")
   "_urust_match_pattern_args_app" :: \<open>urust_pattern \<Rightarrow> urust_pattern_args \<Rightarrow> urust_pattern_args\<close>
     ("_,/ _"[1000,100]100)
+
+  \<comment>\<open>Disjunctive patterns: p1 | p2 (right-associative)\<close>
+  "_urust_match_pattern_disjunction" :: \<open>urust_pattern \<Rightarrow> urust_pattern \<Rightarrow> urust_pattern\<close>
+    ("_ '|/ _" [1000, 100] 100)
 
   \<comment> \<open>See the rust documentation for a list of expression precedences and fixities:
        https://doc.rust-lang.org/reference/expressions.html\<close>

--- a/Shallow_Micro_Rust/Micro_Rust_Shallow_Embedding.thy
+++ b/Shallow_Micro_Rust/Micro_Rust_Shallow_Embedding.thy
@@ -660,6 +660,8 @@ translations
     \<rightharpoonup> "_urust_shallow_match_pattern_constr_no_args (_shallow_identifier_as_literal id)"
   "_shallow_match_pattern (_urust_match_pattern_constr_with_args id args)"
     \<rightharpoonup> "_urust_shallow_match_pattern_constr_with_args (_shallow_identifier_as_literal id) (_shallow_match_args args)"
+  "_shallow_match_pattern (_urust_match_pattern_disjunction p1 p2)"
+    \<rightharpoonup> "_urust_shallow_match_pattern_disjunction (_shallow_match_pattern p1) (_shallow_match_pattern p2)"
   "_shallow_match_pattern (_urust_let_pattern_tuple (_urust_let_pattern_tuple_base_pair a b))"
     \<rightharpoonup> "_urust_shallow_match_pattern_constr_with_args (CONST Pair)
       (_urust_shallow_match_pattern_args_app (_shallow_match_arg a)
@@ -764,6 +766,9 @@ ML\<open>
                 mk_pat_with_args id (shallow_match_args_of args)
             | Const (\<^syntax_const>\<open>_urust_let_pattern_tuple\<close>, _) $ args =>
                 tuple_pattern_of (tuple_args_destruct args)
+            | Const (\<^syntax_const>\<open>_urust_match_pattern_disjunction\<close>, _) $ p1 $ p2 =>
+                mk \<^syntax_const>\<open>_urust_shallow_match_pattern_disjunction\<close>
+                  $ shallow_match_pattern_of p1 $ shallow_match_pattern_of p2
             | _ =>
                 error ("_shallow_match_arg: invalid pattern: " ^ Syntax.string_of_term ctxt pat))
 


### PR DESCRIPTION
Implement Rust-style disjunctive patterns (p1 | p2) that work in all pattern contexts: match, match_switch, if let, let else, and for loops.

Changes:
- Micro_Rust_Syntax.thy: Add _urust_match_pattern_disjunction syntax with right-associative precedence [1000, 100] 100
- Core_Syntax.thy: Add shallow pattern syntax and expand disjunctions in parse_translation (expand_disjunction_pattern, expand_branch).  Add switch branch translations for numeric disjunctive patterns.
- Micro_Rust_Shallow_Embedding.thy: Add translation rule and handle nested disjunctions in shallow_match_pattern_of
- Micro_Rust_Shallow_Embedding_Tests.thy: Add comprehensive tests including guards, nested patterns, and match_switch. Use three_case datatype for non-exhaustive if-let/let-else tests.

Examples now supported:
```
match x { Some(a) | None => ..., _ => ... }

match_switch n { 1 | 2 | 3 => ..., _ => ... }

if let CaseA(x) | CaseB(x) = val { ... }

let Ok(x) | Err(x) = result else { return; };

match nested { Some(Ok(x) | Err(x)) => x, _ => default }
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
