### PR TITLE
Unify match and match_switch into single match syntax

### DIFF
--- a/Shallow_Micro_Rust/Core_Syntax.thy
+++ b/Shallow_Micro_Rust/Core_Syntax.thy
@@ -167,7 +167,8 @@ nonterminal urust_shallow_match_pattern_args
 
 syntax
   "_urust_shallow_match" :: "[('s, 'v, 'r, 'abort, 'i, 'o) expression, urust_shallow_match_branches] \<Rightarrow> ('sp, 'vp, 'rp, 'abort, 'i, 'o) expression"  ("match (_) \<lbrace>/ _/ \<rbrace>" [20, 20]20)
-  "_urust_shallow_switch" :: "[('s, 'v, 'r, 'abort, 'i, 'o) expression, urust_shallow_match_branches] \<Rightarrow> ('sp, 'vp, 'rp, 'abort, 'i, 'o) expression"  ("match'_switch (_) \<lbrace>/ _/ \<rbrace>" [20, 20]20)
+  \<comment>\<open>Internal syntax for numeric switch - used by translation, not user-facing\<close>
+  "_urust_shallow_switch" :: "[('s, 'v, 'r, 'abort, 'i, 'o) expression, urust_shallow_match_branches] \<Rightarrow> ('sp, 'vp, 'rp, 'abort, 'i, 'o) expression"
   \<comment>\<open>Basic case branches\<close>
   "_urust_shallow_match1" :: "[urust_shallow_match_pattern, 'b] \<Rightarrow> urust_shallow_match_branches"  ("(2_ \<Rightarrow>/ _)" [100, 20] 21)
   "_urust_shallow_match1_guard"
@@ -738,15 +739,10 @@ let
       Const (name, _) =>
         if name = "_urust_shallow_match_pattern_other" then
           Syntax.const \<^syntax_const>\<open>_case_basic_pattern_other\<close>
-        else if name = "_urust_shallow_match_pattern_zero" orelse
-                name = "_urust_shallow_match_pattern_one" then
-          case_error ("numeric pattern in match_case: " ^ Syntax.string_of_term ctxt pat)
         else case_error ("invalid match pattern: " ^ Syntax.string_of_term ctxt pat)
     | Const (name, _) $ id =>
         if name = "_urust_shallow_match_pattern_constr_no_args" then
           Syntax.const \<^syntax_const>\<open>_case_basic_pattern_constr_no_args\<close> $ id
-        else if name = "_urust_shallow_match_pattern_num_const" then
-          case_error ("numeric pattern in match_case: " ^ Syntax.string_of_term ctxt pat)
         else case_error ("invalid match pattern: " ^ Syntax.string_of_term ctxt pat)
     | Const (name, _) $ id $ args =>
         if name = "_urust_shallow_match_pattern_constr_with_args" then
@@ -1182,21 +1178,8 @@ term \<open>
   \<up>x +=\<^sub>\<mu> \<up>12
 \<close>
 
-term\<open>let y = x; match_switch y \<lbrace>
-  3 \<Rightarrow> \<up>True,
-  5 \<Rightarrow> \<up>False
-\<rbrace>\<close>
-
-term\<open>
-  match_switch x \<lbrace>
-    3 \<Rightarrow> \<up>True,
-    5 \<Rightarrow> \<up>True,
-    \<guillemotleft>twentyfive\<guillemotright> \<Rightarrow> \<up>True,
-    0 \<Rightarrow> \<up>True,
-    1 \<Rightarrow> \<up>True,
-    _ \<Rightarrow> \<up>False
-  \<rbrace>
-\<close>
+\<comment>\<open>Numeric match tests are in Micro_Rust_Shallow_Embedding_Tests.thy using the full uRust syntax,
+   which properly dispatches to the switch path. The shallow syntax here bypasses that dispatch.\<close>
 
 (*>*)
 end

--- a/Shallow_Micro_Rust/Micro_Rust_Shallow_Embedding.thy
+++ b/Shallow_Micro_Rust/Micro_Rust_Shallow_Embedding.thy
@@ -678,7 +678,6 @@ translations
   "_shallow_match_args (_urust_match_pattern_args_app a bs)"
     \<rightharpoonup> "_urust_shallow_match_pattern_args_app (_shallow_match_arg a) (_shallow_match_args bs)"
 
-
   "_shallow (_urust_match_switch exp branches)"
     \<rightharpoonup> "_urust_shallow_switch (_shallow exp) (_shallow_match_branches branches)"
 

--- a/Shallow_Micro_Rust/Micro_Rust_Shallow_Embedding_Tests.thy
+++ b/Shallow_Micro_Rust/Micro_Rust_Shallow_Embedding_Tests.thy
@@ -737,9 +737,9 @@ term\<open>\<lbrakk>
   };
 \<rbrakk>\<close>
 
-subsubsection\<open>Numeric Match (match_switch)\<close>
+subsubsection\<open>Numeric Match\<close>
 
-text\<open>See Section 21 (Rust Path Expressions) for match_switch examples\<close>
+text\<open>See Section 21 (Rust Path Expressions) for numeric match examples\<close>
 
 subsection\<open>Control Flow - Loops\<close>
 
@@ -1380,15 +1380,6 @@ term\<open>\<lbrakk>
   }
 \<rbrakk>\<close>
 
-term\<open>\<lbrakk>
-  let x = 5;
-\<comment> \<open>\<^verbatim>\<open>match_switch\<close> forces interpretation of this \<^verbatim>\<open>match\<close> clause as a \<^verbatim>\<open>switch\<close>\<close>
-  match_switch x {
-    number::three \<Rightarrow> False,
-    _ \<Rightarrow> True
-  }
-\<rbrakk>\<close>
-
 end
 
 subsection\<open>Disjunctive Patterns\<close>
@@ -1414,7 +1405,7 @@ context
   fixes x :: \<open>32 word\<close>
 begin
 term\<open>\<lbrakk>
-  match_switch x {
+  match x {
     1 | 2 | 3 \<Rightarrow> True,
     _ \<Rightarrow> False
   }
@@ -1481,13 +1472,13 @@ term\<open>\<lbrakk>
   }
 \<rbrakk>\<close>
 
-subsubsection\<open>Match-Switch with Disjunctive Numeric Patterns\<close>
+subsubsection\<open>Match with Disjunctive Numeric Patterns\<close>
 
 context
   fixes x :: \<open>64 word\<close>
 begin
 term\<open>\<lbrakk>
-  match_switch x {
+  match x {
     0 | 1 \<Rightarrow> False,
     _ \<Rightarrow> True
   }
@@ -1510,6 +1501,175 @@ term\<open>\<lbrakk>
     (Some(x), Some(y)) | (None, Some(y)) \<Rightarrow> y,
     _ \<Rightarrow> \<llangle>0 :: nat\<rrangle>
   }
+\<rbrakk>\<close>
+
+subsection\<open>Unified Match (Numeric Patterns in match)\<close>
+
+text\<open>These tests verify that numeric patterns can be used directly in \<^verbatim>\<open>match\<close>
+expressions. The \<^verbatim>\<open>match\<close> keyword handles all pattern types uniformly:
+algebraic patterns (constructors), numeric patterns (0, 1, numerals), and wildcards.\<close>
+
+subsubsection\<open>Basic Match with Numeric Literals\<close>
+
+text\<open>Numeric literals work directly in \<^verbatim>\<open>match\<close> expressions.\<close>
+
+context
+  fixes x :: \<open>32 word\<close>
+begin
+term\<open>\<lbrakk>
+  match x {
+    0 \<Rightarrow> True,
+    1 \<Rightarrow> False,
+    _ \<Rightarrow> True
+  }
+\<rbrakk>\<close>
+end
+
+subsubsection\<open>Unified Match with Disjunctive Numeric Patterns\<close>
+
+context
+  fixes x :: \<open>64 word\<close>
+begin
+term\<open>\<lbrakk>
+  match x {
+    1 | 2 | 3 \<Rightarrow> True,
+    _ \<Rightarrow> False
+  }
+\<rbrakk>\<close>
+end
+
+subsubsection\<open>Unified Match with Zero and One Literals\<close>
+
+context
+  fixes x :: \<open>16 word\<close>
+begin
+term\<open>\<lbrakk>
+  match x {
+    0 \<Rightarrow> \<llangle>0 :: nat\<rrangle>,
+    1 \<Rightarrow> \<llangle>1 :: nat\<rrangle>,
+    _ \<Rightarrow> \<llangle>2 :: nat\<rrangle>
+  }
+\<rbrakk>\<close>
+end
+
+subsubsection\<open>Numeric Match Evaluation Tests\<close>
+
+text\<open>These tests verify that numeric matches actually evaluate correctly, not just parse.\<close>
+
+value[simp]\<open>\<lbrakk>
+  let x = \<llangle>0 :: 32 word\<rrangle>;
+  let res = match x {
+    0 \<Rightarrow> \<llangle>100 :: 32 word\<rrangle>,
+    1 \<Rightarrow> \<llangle>200 :: 32 word\<rrangle>,
+    _ \<Rightarrow> \<llangle>300 :: 32 word\<rrangle>
+  };
+  assert!(res == \<llangle>100 :: 32 word\<rrangle>)
+\<rbrakk>\<close>
+
+value[simp]\<open>\<lbrakk>
+  let x = \<llangle>1 :: 32 word\<rrangle>;
+  let res = match x {
+    0 \<Rightarrow> \<llangle>100 :: 32 word\<rrangle>,
+    1 \<Rightarrow> \<llangle>200 :: 32 word\<rrangle>,
+    _ \<Rightarrow> \<llangle>300 :: 32 word\<rrangle>
+  };
+  assert!(res == \<llangle>200 :: 32 word\<rrangle>)
+\<rbrakk>\<close>
+
+value[simp]\<open>\<lbrakk>
+  let x = \<llangle>99 :: 32 word\<rrangle>;
+  let res = match x {
+    0 \<Rightarrow> \<llangle>100 :: 32 word\<rrangle>,
+    1 \<Rightarrow> \<llangle>200 :: 32 word\<rrangle>,
+    _ \<Rightarrow> \<llangle>300 :: 32 word\<rrangle>
+  };
+  assert!(res == \<llangle>300 :: 32 word\<rrangle>)
+\<rbrakk>\<close>
+
+subsubsection\<open>Larger Numerals in Match\<close>
+
+value[simp]\<open>\<lbrakk>
+  let x = \<llangle>42 :: 32 word\<rrangle>;
+  let res = match x {
+    42 \<Rightarrow> True,
+    100 \<Rightarrow> False,
+    255 \<Rightarrow> False,
+    _ \<Rightarrow> False
+  };
+  assert!(res == True)
+\<rbrakk>\<close>
+
+value[simp]\<open>\<lbrakk>
+  let x = \<llangle>255 :: 32 word\<rrangle>;
+  let res = match x {
+    42 \<Rightarrow> \<llangle>1 :: nat\<rrangle>,
+    100 \<Rightarrow> \<llangle>2 :: nat\<rrangle>,
+    255 \<Rightarrow> \<llangle>3 :: nat\<rrangle>,
+    _ \<Rightarrow> \<llangle>0 :: nat\<rrangle>
+  };
+  assert!(res == \<llangle>3 :: nat\<rrangle>)
+\<rbrakk>\<close>
+
+subsubsection\<open>Numeric Match with Different Word Sizes\<close>
+
+value[simp]\<open>\<lbrakk>
+  let x = \<llangle>5 :: 8 word\<rrangle>;
+  let res = match x {
+    0 \<Rightarrow> \<llangle>0 :: 8 word\<rrangle>,
+    5 \<Rightarrow> \<llangle>50 :: 8 word\<rrangle>,
+    _ \<Rightarrow> \<llangle>255 :: 8 word\<rrangle>
+  };
+  assert!(res == \<llangle>50 :: 8 word\<rrangle>)
+\<rbrakk>\<close>
+
+value[simp]\<open>\<lbrakk>
+  let x = \<llangle>1000 :: 64 word\<rrangle>;
+  let res = match x {
+    0 \<Rightarrow> False,
+    1000 \<Rightarrow> True,
+    _ \<Rightarrow> False
+  };
+  assert!(res == True)
+\<rbrakk>\<close>
+
+subsubsection\<open>Single Branch Numeric Match\<close>
+
+value[simp]\<open>\<lbrakk>
+  let x = \<llangle>7 :: 32 word\<rrangle>;
+  let res = match x {
+    _ \<Rightarrow> \<llangle>42 :: 32 word\<rrangle>
+  };
+  assert!(res == \<llangle>42 :: 32 word\<rrangle>)
+\<rbrakk>\<close>
+
+subsubsection\<open>Disjunctive Numeric Match Evaluation\<close>
+
+value[simp]\<open>\<lbrakk>
+  let x = \<llangle>2 :: 32 word\<rrangle>;
+  let res = match x {
+    1 | 2 | 3 \<Rightarrow> True,
+    _ \<Rightarrow> False
+  };
+  assert!(res == True)
+\<rbrakk>\<close>
+
+value[simp]\<open>\<lbrakk>
+  let x = \<llangle>5 :: 32 word\<rrangle>;
+  let res = match x {
+    1 | 2 | 3 \<Rightarrow> True,
+    _ \<Rightarrow> False
+  };
+  assert!(res == False)
+\<rbrakk>\<close>
+
+value[simp]\<open>\<lbrakk>
+  let x = \<llangle>0 :: 64 word\<rrangle>;
+  let res = match x {
+    0 | 1 \<Rightarrow> \<llangle>10 :: nat\<rrangle>,
+    2 | 3 | 4 \<Rightarrow> \<llangle>20 :: nat\<rrangle>,
+    _ \<Rightarrow> \<llangle>30 :: nat\<rrangle>
+  };
+  assert!(res == \<llangle>10 :: nat\<rrangle>)
 \<rbrakk>\<close>
 
 end


### PR DESCRIPTION
Users now write `match` for all pattern matching - both algebraic patterns (constructors, tuples) and numeric patterns (0, 1, numerals).  The system automatically dispatches to the appropriate backend:

- Algebraic patterns → HOL case expression (bcase)
- Numeric patterns → numeric case selector (ncase)

The dispatch logic analyzes patterns at the AST level:
- If any pattern has constructor arguments or is a tuple → algebraic
- If any pattern is a numeric literal AND all patterns are switch-compatible (no constructor args) → switch
- Otherwise → algebraic (default)

Changes:
- Remove user-facing `match_switch` syntax (internal `_urust_match_switch` retained for implementation)
- Add pattern classification that handles disjunctions recursively
- Add `value[simp]` tests verifying numeric match evaluation
- Test coverage for different word sizes, larger numerals, disjunctive numeric patterns

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
