### PR TITLE
Bumped Isabelle CI version to Isabelle2025-1

### DIFF
--- a/.github/actions/setup-isabelle-action/action.yml
+++ b/.github/actions/setup-isabelle-action/action.yml
@@ -1,5 +1,5 @@
 # Composite action to setup Isabelle
-# NOTE: Needs to be run under the makarius/isabelle:Isabelle2025 container
+# NOTE: Needs to be run under the makarius/isabelle:Isabelle2025-2 container
 name: Setup Isabelle
 description: 'Setup Isabelle: checkout the AFP, set environment variables, cache heap images'
 runs:
@@ -8,7 +8,7 @@ runs:
     - name: Checkout AFP
       uses: actions/checkout@v3
       with:
-        repository: isabelle-prover/mirror-afp-2025
+        repository: isabelle-prover/mirror-afp-2025-1
         path: afp
 
     - name: Set AFP component base

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     container:
-      image: makarius/isabelle:Isabelle2025
+      image: makarius/isabelle:Isabelle2025-2
       options: --user root
 
     steps:
@@ -41,7 +41,7 @@ jobs:
   iq:
     runs-on: ubuntu-latest
     container:
-      image: makarius/isabelle:Isabelle2025
+      image: makarius/isabelle:Isabelle2025-2
       options: --user root
 
     steps:
@@ -55,8 +55,8 @@ jobs:
         run: |
           apt install -y make
           echo "ISABELLE_HOME=/home/isabelle/Isabelle" >> $GITHUB_ENV
-          echo "JAVA_HOME=/home/isabelle/Isabelle/contrib/jdk-21.0.6/x86_64-linux/" >> $GITHUB_ENV
-          echo "PATH=/home/isabelle/Isabelle/contrib/jdk-21.0.6/x86_64-linux/bin:$PATH" >> $GITHUB_ENV
+          echo "JAVA_HOME=/home/isabelle/Isabelle/contrib/jdk-21.0.9/x86_64-linux/" >> $GITHUB_ENV
+          echo "PATH=/home/isabelle/Isabelle/contrib/jdk-21.0.9/x86_64-linux/bin:$PATH" >> $GITHUB_ENV
 
       - name: Build I/Q plugin
         run: |

--- a/Makefile
+++ b/Makefile
@@ -10,8 +10,8 @@
 .DEFAULT_GOAL: jedit
 .PHONY: register-afp-components build jedit
 
-# Set this to the directory containing the Isabelle2025 binary
-ISABELLE_HOME?=/Applications/Isabelle2025.app/bin
+# Set this to the directory containing the Isabelle2025-2 binary
+ISABELLE_HOME?=/Applications/Isabelle2025-2.app/bin
 # Set this to your home directory
 USER_HOME?=$(HOME)
 # Set this to where you maintain, or want to maintain, AFP dependencies

--- a/Misc/Array.thy
+++ b/Misc/Array.thy
@@ -102,7 +102,7 @@ by (transfer, clarsimp simp add: is_array_def list_fast_correct size_list)
 
 lemma array_to_list_update [simp]:
   shows \<open>array_to_list (array_update l i v) = list_update (array_to_list l) i v\<close>
-  by (transfer, simp add: is_array_def list_fast_correct braun_update1 list_update1 size_list)
+by transfer (auto simp add: is_array_def list_fast_correct braun_update1 list_update1 size_list list_update_beyond)
 
 lemma array_map_nth [simp]:
   assumes \<open>i < array_len xs\<close>

--- a/Misc/Remove_Enum_Discriminate_Elims.thy
+++ b/Misc/Remove_Enum_Discriminate_Elims.thy
@@ -19,10 +19,14 @@ rules from a newly generated \<^verbatim>\<open>datatype\<close> directly after 
 
 ML\<open>
   \<comment> \<open>Given a generic context, get the list of safe elimination rules\<close>
-  val safe_elims_of =
-    Classical.get_cs #>
-    Classical.rep_cs #> #safeEs #>
-    Item_Net.content #> List.map #1;
+  fun safe_elims_of ctxt =
+    let
+      fun is_safe_elim (_, {kind, ...}) =
+        Bires.kind_safe kind andalso Bires.kind_is_elim kind;
+    in
+      Classical.dest_decls (Context.proof_of ctxt) is_safe_elim
+      |> List.map #1
+    end;
 
   \<comment> \<open>Some wrappers for use with \<^verbatim>\<open>@{theory}\<close> and \<^verbatim>\<open>@{context}\<close>}\<close>
   val safe_elims_of_thy = Context.Theory #> safe_elims_of;

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ An HTML rendering of the AutoCorrode source code is available [here](https://aws
 
 ## Setup
 
-AutoCorrode requires Isabelle2025, which can be downloaded [here](https://isabelle.in.tum.de/website-Isabelle2025/). Set `ISABELLE_HOME` to the directory containing the `isabelle` binary.
+AutoCorrode requires Isabelle2025-2, which can be downloaded [here](https://isabelle.in.tum.de/website-Isabelle2025-2/). Set `ISABELLE_HOME` to the directory containing the `isabelle` binary.
 
 AutoCorrode also requires the [WordLib](https://www.isa-afp.org/entries/Word_Lib.html) AFP entry. Set `AFP_COMPONENT_BASE` to the directory contaning the `Word_Lib` directory. By default, AutoCorrode expects it to be located in [dependencies/afp-2025](dependencies/afp-2025).
 

--- a/iq/Isar_Explore.thy
+++ b/iq/Isar_Explore.thy
@@ -85,10 +85,9 @@ fun isar_explore exec_id instance text state =
             directly into error_messages to Isabelle's output channel. *)
          val old_parallel_proofs = ! Multithreading.parallel_proofs
          val _ = Multithreading.parallel_proofs := Int.min(2, old_parallel_proofs)
-         val (st', err_opt) = Toplevel.transition false tr st
+         val st' = Toplevel.command_exception false tr st
          val _ = Multithreading.parallel_proofs := old_parallel_proofs
-      in case err_opt of NONE => st' | SOME (exn, _) =>
-            (raise exn) end
+      in st' end
   in
     List.foldl (fn (tr, st) => run_transition (tr, st)) state transitions
   end;
@@ -100,7 +99,7 @@ fun isar_explore exec_id instance text state =
 val _ = register {name = "isar_explore", pri = Task_Queue.urgent_pri}
     (fn {state, args, writeln_result, instance, exec_id, ...} =>
       (case args of [isar_text] => isar_explore exec_id instance isar_text state
-                                   |> Toplevel.string_of_state
+                                   |> (fn st => Pretty.string_of (Pretty.chunks (Toplevel.pretty_state st)))
                                    |> writeln_result
          | _ => raise (ERROR "Invalid number of arguments for isar_explore")))
 \<close>

--- a/iq/Makefile
+++ b/iq/Makefile
@@ -7,8 +7,9 @@ endif
 
 # Paths (configurable via environment variables)
 PLUGIN_DIR := $(shell pwd)
-ISABELLE_HOME ?= /Applications/Isabelle2025.app
-JEDIT_JAR ?= $(ISABELLE_HOME)/contrib/jedit-20250215/jedit5.7.0-patched/jedit.jar
+ISABELLE_HOME ?= /Applications/Isabelle2025-2.app
+JEDIT_DIR := $(shell ls -d $(ISABELLE_HOME)/contrib/jedit-* 2>/dev/null | head -1)
+JEDIT_JAR ?= $(JEDIT_DIR)/jedit5.7.0-patched/jedit.jar
 SCALA_HOME ?= $(ISABELLE_HOME)/contrib/scala-3.3.4
 SCALAC ?= $(SCALA_HOME)/bin/scalac
 ISABELLE_JAR ?= $(ISABELLE_HOME)/lib/classes/isabelle.jar

--- a/iq/src/Extended_Query_Operation.scala
+++ b/iq/src/Extended_Query_Operation.scala
@@ -38,9 +38,9 @@ object Extended_Query_Operation {
     exec_id: Document_ID.Exec = Document_ID.none)
 }
 
-class Extended_Query_Operation[Editor_Context](
-  editor: Editor[Editor_Context],
-  editor_context: Editor_Context,
+class Extended_Query_Operation(
+  editor: Editor,
+  editor_context: editor.Context,
   operation_name: String,
   consume_status: Extended_Query_Operation.Status => Unit,
   consume_output: (Document.Snapshot, Command.Results, List[XML.Elem]) => Unit,
@@ -245,7 +245,7 @@ class Extended_Query_Operation[Editor_Context](
     for {
       command <- state.location
       snapshot = editor.node_snapshot(command.node_name)
-      link <- editor.hyperlink_command(true, snapshot, command.id)
+      link <- editor.hyperlink_command(snapshot, command.id, focus = true)
     } link.follow(editor_context)
   }
 

--- a/iq/src/IQExploreDockable.scala
+++ b/iq/src/IQExploreDockable.scala
@@ -564,7 +564,7 @@ extends JPanel(new BorderLayout) with DefaultFocusComponent {
   initializeHistoryEntries()
 
   // Query operation - use our custom Extended_Query_Operation class
-  private var exploreOperation: Option[Extended_Query_Operation[View]] = None
+  private var exploreOperation: Option[Extended_Query_Operation] = None
 
   // Find command at file+offset
   private def findCommandAtFileOffset(file_path: String, offset: Int): Option[Command] = {
@@ -622,7 +622,7 @@ extends JPanel(new BorderLayout) with DefaultFocusComponent {
       exploreOperation.foreach(_.deactivate())
 
       // Create new operation with the selected print function
-      exploreOperation = Some(new Extended_Query_Operation[View](
+      exploreOperation = Some(new Extended_Query_Operation(
         PIDE.editor, view, printFunction,
         status => {
           status match {


### PR DESCRIPTION
Swinged the CI action.yml pointer to point to isabelle-prover/mirror-afp-2025-1. Note a pre-baked Isabelle2025-2 mirror has not yet been prepared, though -1 and -2 are compatible barring some changes in the command line parameter parsing.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
