### PR TITLE
Add borrow syntax (&, &mut) to Micro Rust embedding and tests

### DIFF
--- a/Micro_Rust_Parsing_Frontend/Micro_Rust_Syntax.thy
+++ b/Micro_Rust_Parsing_Frontend/Micro_Rust_Syntax.thy
@@ -330,6 +330,10 @@ syntax
     ("'! _" [300]300)
   "_urust_double_negation" :: \<open>urust \<Rightarrow> urust\<close>
     ("'!'! _" [300]300)
+  "_urust_borrow" :: \<open>urust \<Rightarrow> urust\<close>
+    ("&_" [200]100)
+  "_urust_borrow_mut" :: \<open>urust \<Rightarrow> urust\<close>
+    ("& mut _" [200]100)
   "_urust_deref" :: \<open>urust \<Rightarrow> urust\<close>
     ("*_" [200]100)
   "_urust_double_deref" :: \<open>urust \<Rightarrow> urust\<close>

--- a/Shallow_Micro_Rust/Global_Store.thy
+++ b/Shallow_Micro_Rust/Global_Store.thy
@@ -56,6 +56,9 @@ translations
 definition ro_ref_from_ref :: \<open>('a, 'b, 'v) ref \<Rightarrow> ('a, 'b, 'v) ro_ref\<close> where
   \<open>ro_ref_from_ref \<equiv> update_unwrap_focused ROGRef\<close>
 
+definition mut_ref_from_ref :: \<open>('a, 'b, 'v) ref \<Rightarrow> ('a, 'b, 'v) ref\<close> where
+  \<open>mut_ref_from_ref \<equiv> id\<close>
+
 definition unsafe_ref_from_ro_ref :: \<open>('a, 'b, 'v) ro_ref \<Rightarrow> ('a, 'b, 'v) ref\<close> where
   \<open>unsafe_ref_from_ro_ref \<equiv> update_unwrap_focused unsafe_gref_from_ro_gref\<close>
 

--- a/Shallow_Micro_Rust/Micro_Rust_Shallow_Embedding.thy
+++ b/Shallow_Micro_Rust/Micro_Rust_Shallow_Embedding.thy
@@ -483,6 +483,10 @@ translations
 
   "_shallow (_urust_propagate exp)"
     \<rightharpoonup> "_urust_shallow_propagate (_shallow exp)"
+  "_shallow (_urust_borrow exp)"
+    \<rightharpoonup> "CONST bindlift1 (CONST ro_ref_from_ref) (_shallow exp)"
+  "_shallow (_urust_borrow_mut exp)"
+    \<rightharpoonup> "CONST bindlift1 (CONST mut_ref_from_ref) (_shallow exp)"
   "_shallow (_urust_deref exp)"
     \<rightharpoonup> "_urust_shallow_store_dereference (_shallow exp)"
 

--- a/Shallow_Micro_Rust/Micro_Rust_Shallow_Embedding_Tests.thy
+++ b/Shallow_Micro_Rust/Micro_Rust_Shallow_Embedding_Tests.thy
@@ -1114,6 +1114,24 @@ term\<open>\<lbrakk>
   x
 \<rbrakk>\<close>
 
+subsubsection\<open>Borrow Syntax\<close>
+
+context
+  fixes r :: \<open>('s, 'b, integer) ref\<close>
+  fixes x y :: \<open>32 word\<close>
+begin
+term \<open>\<lbrakk> &r \<rbrakk>\<close>
+term \<open>\<lbrakk> &mut r \<rbrakk>\<close>
+term \<open>\<lbrakk> x & y \<rbrakk>\<close>
+end
+
+term\<open>\<lbrakk>
+  let mut x = \<llangle>0 :: 32 word\<rrangle>;
+  let xr = &x;
+  let xw = &mut x;
+  xw
+\<rbrakk>\<close>
+
 subsubsection\<open>Dereference\<close>
 
 context


### PR DESCRIPTION
Add borrow syntax (&, &mut) to Micro Rust embedding and tests

- add unary borrow forms to parser grammar: `&e` and `& mut e`
- translate `&e` in shallow embedding to immutable-reference coercion via `ro_ref_from_ref`
- translate `&mut e` to mutable-reference identity in shallow embedding
- add syntactic tests in `Micro_Rust_Shallow_Embedding_Tests` for:
  - immutable borrow
  - mutable borrow
  - disambiguation from bitwise `&`
  - borrowing from `let mut` bindings


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
