### PR TITLE
Add struct-pattern support in shallow embedding

### DIFF
--- a/Micro_Rust_Parsing_Frontend/Micro_Rust_Syntax.thy
+++ b/Micro_Rust_Parsing_Frontend/Micro_Rust_Syntax.thy
@@ -56,6 +56,8 @@ nonterminal urust_match_branches \<comment> \<open>Comma-separate lists of match
 nonterminal urust_pattern
 nonterminal urust_pattern_args
 nonterminal urust_pattern_slice_args
+nonterminal urust_pattern_struct_fields
+nonterminal urust_pattern_struct_field
 nonterminal urust_let_pattern_args
 
 nonterminal urust_integral_type
@@ -342,6 +344,7 @@ syntax
     ("_")
   "_urust_match_pattern_args_app" :: \<open>urust_pattern \<Rightarrow> urust_pattern_args \<Rightarrow> urust_pattern_args\<close>
     ("_,/ _"[1000,100]100)
+
   \<comment>\<open>Slice/list patterns: [p0, p1, ...]\<close>
   "_urust_match_pattern_slice_empty" :: \<open>urust_pattern\<close>
     ("'[]")
@@ -353,6 +356,16 @@ syntax
     ("_")
   "_urust_match_pattern_slice_args_app" :: \<open>urust_pattern \<Rightarrow> urust_pattern_slice_args \<Rightarrow> urust_pattern_slice_args\<close>
     ("_,/ _"[1000,100]100)
+
+  \<comment>\<open>Struct patterns: Foo { foo: p, goo: q }\<close>
+  "_urust_match_pattern_struct" :: \<open>urust_identifier \<Rightarrow> urust_pattern_struct_fields \<Rightarrow> urust_pattern\<close>
+    ("_/ {/ _/ }" [1000, 0] 1000)
+  "_urust_match_pattern_struct_field" :: \<open>urust_identifier \<Rightarrow> urust_pattern \<Rightarrow> urust_pattern_struct_field\<close>
+    ("_ :/ _" [1000, 100] 1000)
+  "_urust_match_pattern_struct_fields_single" :: \<open>urust_pattern_struct_field \<Rightarrow> urust_pattern_struct_fields\<close>
+    ("_")
+  "_urust_match_pattern_struct_fields_app" :: \<open>urust_pattern_struct_field \<Rightarrow> urust_pattern_struct_fields \<Rightarrow> urust_pattern_struct_fields\<close>
+    ("_,/ _" [1000, 100] 100)
 
   \<comment>\<open>Disjunctive patterns: p1 | p2 (right-associative)\<close>
   "_urust_match_pattern_disjunction" :: \<open>urust_pattern \<Rightarrow> urust_pattern \<Rightarrow> urust_pattern\<close>

--- a/Shallow_Micro_Rust/Micro_Rust_Shallow_Embedding_Tests.thy
+++ b/Shallow_Micro_Rust/Micro_Rust_Shallow_Embedding_Tests.thy
@@ -794,6 +794,16 @@ value[simp]\<open>\<lbrakk>
 
 subsubsection\<open>Tuple Patterns in Match\<close>
 
+datatype struct_pattern_fixture = Foo (foo: "32 word") (goo: "32 word") | Other
+
+datatype_record struct_pattern_dr =
+  dr_foo :: "32 word"
+  dr_goo :: "32 word"
+
+record struct_pattern_rec =
+  rec_foo :: "32 word"
+  rec_goo :: "32 word"
+
 term\<open>\<lbrakk>
   match (\<llangle>1 :: 32 word\<rrangle>, \<llangle>2 :: 32 word\<rrangle>) {
     (a, b) \<Rightarrow> a
@@ -835,6 +845,48 @@ value[simp]\<open>\<lbrakk>
   assert!(res.1 == b);
   assert!(res.2 == c);
   assert!(res.3 == d)
+\<rbrakk>\<close>
+
+subsubsection\<open>Struct Patterns\<close>
+
+term\<open>\<lbrakk>
+  match \<llangle>Foo (1 :: 32 word) 2\<rrangle> {
+    Foo { foo: p, goo: q } \<Rightarrow> p + q,
+    _ \<Rightarrow> \<llangle>0 :: 32 word\<rrangle>
+  }
+\<rbrakk>\<close>
+
+term\<open>\<lbrakk>
+  let res = match \<llangle>Foo (3 :: 32 word) 4\<rrangle> {
+    Foo { foo: p, goo: q } \<Rightarrow> p + q,
+    _ \<Rightarrow> \<llangle>0 :: 32 word\<rrangle>
+  };
+  assert!(res == \<llangle>7 :: 32 word\<rrangle>)
+\<rbrakk>\<close>
+
+term\<open>\<lbrakk>
+  if let Foo { foo: p, goo: q } = \<llangle>Foo (5 :: 32 word) 6\<rrangle> {
+    assert!(p == \<llangle>5 :: 32 word\<rrangle>);
+    assert!(q == \<llangle>6 :: 32 word\<rrangle>);
+    ()
+  } else {
+    assert!(False);
+    ()
+  }
+\<rbrakk>\<close>
+
+term\<open>\<lbrakk>
+  let Foo { foo: p, goo: q } = \<llangle>Foo (8 :: 32 word) 9\<rrangle> else {
+    return;
+  };
+  p + q
+\<rbrakk>\<close>
+
+term\<open>\<lbrakk>
+  let res = match \<llangle>make_struct_pattern_dr (10 :: 32 word) 11\<rrangle> {
+    struct_pattern_dr { dr_goo: q, dr_foo: p } \<Rightarrow> p + q
+  };
+  assert!(res == \<llangle>21 :: 32 word\<rrangle>)
 \<rbrakk>\<close>
 
 subsubsection\<open>Pattern Guards\<close>


### PR DESCRIPTION
- extend Micro Rust syntax with Rust-style struct patterns: `Foo { foo: p, goo: q }`
- normalize struct patterns to constructor patterns with selector-order field reordering
- resolve constructor/selector metadata for `datatype`, `datatype_record`, and `record`
- enforce struct-pattern diagnostics for duplicate, unknown, and missing fields
- handle record `more` tail as an optional implicit wildcard in translation
- add/update syntactic struct-pattern tests in `Micro_Rust_Shallow_Embedding_Tests.thy`
- keep record checks syntactic where case-expression backend does not support record constructors directly

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
