### PR TITLE
I/P: Isabelle/Proxy for remote ML prover execution

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,3 +41,8 @@ jobs:
       run: |
         cd isabelle-assistant
         make test ISABELLE_HOME=$ISABELLE_HOME
+
+    - name: Build I/P plugin
+      run: |
+        cd ip/ip_plugin
+        make build ISABELLE_HOME=$ISABELLE_HOME

--- a/README.md
+++ b/README.md
@@ -17,6 +17,10 @@ The [Showcase.thy](https://awslabs.github.io/AutoCorrode/Unsorted/AutoCorrode/Mi
 [I/Q](iq) -- short for Isabelle/Q -- is an experimental Isabelle/jEdit plugin exposing proof editing/exploration capabilities as an MCP server. Its purpose is to enable MCP-capable AI agents such as [Amazon Q](https://aws.amazon.com/q/) to autonomously
 or collaboratively conduct interactive theorem proving using Isabelle. See [iq](iq) for more information.
 
+## I/P
+
+[I/P](ip) -- short for Isabelle/Proxy -- runs the Isabelle ML prover on a remote machine while keeping Isabelle/jEdit local. It requires no Isabelle source changes and includes a jEdit plugin for remote status monitoring. See [ip](ip) for more information.
+
 ## Isabelle Assistant
 
 [Isabelle Assistant](isabelle-assistant) is an LLM-powered proof assistant for Isabelle/jEdit, built on [AWS Bedrock](https://aws.amazon.com/bedrock/). It provides autonomous proof search, interactive chat with LaTeX rendering, proof suggestions, code explanation, refactoring, and more — all integrated into the Isabelle/jEdit IDE. When combined with [I/Q](iq), generated proofs are automatically verified against Isabelle before display. See [isabelle-assistant](isabelle-assistant) for more information.

--- a/ip/.gitignore
+++ b/ip/.gitignore
@@ -1,0 +1,3 @@
+__pycache__/
+*.pyc
+ip_plugin/build/

--- a/ip/README.md
+++ b/ip/README.md
@@ -1,0 +1,59 @@
+# I/P — Isabelle/Proxy
+
+I/P runs the Isabelle ML prover on a remote machine while keeping
+Isabelle/jEdit local. No Isabelle source changes are required.
+
+## Overview
+
+I/P consists of three components:
+
+- **`ml_proxy.py`** — PIDE protocol proxy that interposes between the local
+  Scala/jEdit and a remote Poly/ML process. Handles path rewriting,
+  Bash.Server forwarding, ML statistics monitoring, and PIDE message
+  interception.
+- **`configure-remote.py`** — Setup and configuration tool. Installs Isabelle
+  on the remote, syncs poly binaries and heaps, and generates the jEdit
+  flags needed to enable the proxy.
+- **`ip_plugin/`** — Isabelle/jEdit plugin providing a status bar widget
+  (remote host + throughput) and ML heap monitoring for proxied sessions.
+
+## Quick Start
+
+```bash
+# 1. Install Isabelle on the remote and sync heaps
+./configure-remote.py setup ubuntu@host --ml-platform aarch64-ubuntu \
+  --local-isabelle-home YOUR_ISABELLE_INSTALLATION
+
+# 2. Add the shell helper to .zshrc / .bashrc, replacing AUTOCORRODE_HOME accordingly:
+
+isabelle-remote() {
+  local flags
+  flags=$($AUTOCORRODE_HOME/ip/configure-remote.py run "$@") || return 1
+  ISABELLE_REMOTE="$flags"
+  echo ""
+  echo "ISABELLE_REMOTE set to the following flags:"
+  echo "-------------------------------------------"
+  echo "$ISABELLE_REMOTE"
+}
+
+# 3. Configure and launch jEdit with the remote prover
+isabelle-remote ubuntu@host
+isabelle jedit -l HOL $ISABELLE_REMOTE
+```
+
+## Setup Scripts
+
+- `setup_aarch64_ubuntu.sh` — Installs Isabelle on a remote aarch64 Ubuntu host.
+- `setup_al2.sh` — Installs Isabelle on a remote Amazon Linux 2
+   host, building Poly/ML from source (to avoid glibc versioning issue).
+
+## Poly/ML Tuning
+
+The proxy supports overriding Poly/ML runtime options:
+
+```bash
+isabelle-remote ubuntu@host --minheap 48000 --maxheap 80000 --threads 16
+```
+
+See `configure-remote.py --help` and the module docstring of `ml_proxy.py`
+for full documentation.

--- a/ip/configure-remote.py
+++ b/ip/configure-remote.py
@@ -1,0 +1,793 @@
+#!/usr/bin/env python3
+"""Configure Isabelle remote ML prover.
+
+Subcommands:
+
+  setup HOST   Install Isabelle on remote and mirror poly binary and heaps
+               with local copies stored under a configurable ML platform name
+               specified with --ml-platform.
+
+               By default, expects target ML platform to be unused.
+               - Use --copy-from-local when you want to setup a
+                 new remote from an existing ML platform.
+                 This is useful to 'fork' new remote instances from ML platforms
+                 and heaps that have built previously.
+               - Use --force-write-local to overwrite the local ML platform
+                 with a fresh rebuild installation and build of poly and the
+                 Pure + HOL heap.
+
+  run HOST     Print jEdit flags to use for enabling ML proxy.
+
+               Verifies local poly/heaps match the remote before emitting flags.
+
+  list         List all local ML platforms with poly hashes and available heaps.
+
+  remove PLAT  Remove a local ML platform and its associated heaps.
+
+Common options (setup, run):
+
+  HOST                     SSH host in user@host format (positional, required).
+  --isabelle-home PATH     ISABELLE_HOME on the remote machine.
+                           Default: /home/<user>/{ISABELLE_VERSION} (user from HOST).
+  --local-isabelle-home P  Local Isabelle installation root. Default: if
+                           ISABELLE_HOME is set and points to the binary
+                           directory of an existing Isabelle installation,
+                           uses ISABELLE_HOME/../ as the root.
+                           Otherwise, this option is required.
+  --ml-platform NAME       Force the local ML platform directory name
+                           (e.g. arm64-ubuntu). If omitted, a name is
+                           derived from the remote base platform and poly hash.
+  --64 / --32              Use 64-bit (default) or 32-in-64-bit ML platform.
+
+Setup-only options:
+
+  --force-write-local      Overwrite an existing local ML platform with the
+                           remote poly binary and heaps. Mutually exclusive
+                           with --copy-from-local.
+  --copy-from-local        Push the local poly binary and heaps to the remote
+                           instead of pulling from it. Mutually exclusive with
+                           --force-write-local.
+  --sync-all-heaps         With --copy-from-local: sync the entire local heaps
+                           directory, not just Pure and HOL.
+
+Run-only options:
+
+  --sync-all-heaps         Sync all local heaps to the remote before printing
+                           jEdit flags.
+  --minheap MB             Override Poly/ML --minheap (minimum heap size).
+  --maxheap MB             Override Poly/ML --maxheap (maximum heap size).
+  --gcthreads N            Override Poly/ML --gcthreads (GC thread count).
+  -H MB                    Override Poly/ML -H (initial heap size).
+  --gcpercent N            Override Poly/ML --gcpercent (target GC time, 1-99).
+
+List options:
+
+  --local-isabelle-home P  As above.
+
+Remove options:
+
+  PLAT                     ML platform name to remove (positional, required).
+  --local-isabelle-home P  As above.
+  -y, --yes                Skip the confirmation prompt.
+
+Examples:
+
+  # First-time setup (install Isabelle on remote, sync to local):
+  configure-remote.py setup ubuntu@host --ml-platform aarch64-ubuntu
+
+  # Spawn a new remote with an existing ML platform + all heaps:
+  configure-remote.py setup ubuntu@host --ml-platform aarch64-ubuntu \
+     --copy-from-local --sync-all-heaps
+
+  # Print jEdit flags
+  configure-remote.py run ubuntu@host --ml-platform aarch64-ubuntu
+
+  # List local platforms:
+  configure-remote.py list
+
+  # Remove a platform:
+  configure-remote.py remove aarch64-ubuntu
+
+Shell alias:
+
+  The following alias makes ./configure-remote.py more convenient to use.
+  Put it in your .zshrc or equivalent and then invoke pass $ISABELLE_REMOTE
+  to invocations of `isabelle jedit`.
+
+``
+  # Isabelle remote ML prover
+  isabelle-remote() {
+    local flags
+    flags=$(~/remote_isabelle/configure-remote.py run "$@") || return 1
+    ISABELLE_REMOTE="$flags"
+    echo "ISABELLE_REMOTE set ✓" >&2
+  }
+```
+"""
+
+import argparse
+import hashlib
+import os
+import shutil
+import subprocess
+import sys
+
+
+SCRIPT_DIR = os.path.dirname(os.path.abspath(__file__))
+ISABELLE_VERSION = "Isabelle2025-2"
+POLYML_CONTRIB = "contrib/polyml-5.9.2-2"
+HEAP_PREFIX = "polyml-5.9.2"
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def die(msg):
+    print(msg, file=sys.stderr)
+    sys.exit(1)
+
+
+def info(msg):
+    print(msg, file=sys.stderr)
+
+
+import time as _time
+
+# ANSI colors and symbols
+_RED = "\033[31m"
+_GREEN = "\033[32m"
+_YELLOW = "\033[33m"
+_BOLD = "\033[1m"
+_DIM = "\033[2m"
+_RESET = "\033[0m"
+_CLEAR_LINE = "\r\033[2K"
+_SYM_OK = f"{_GREEN}✓{_RESET}"
+_SYM_BUSY = f"{_YELLOW}↻{_RESET}"
+_SYM_FAIL = f"{_RED}✗{_RESET}"
+
+_step_t0 = None
+_step_msg = ""
+_step_indent = "  "
+
+def _finish_step():
+    """Overwrite busy symbol with checkmark and print elapsed time."""
+    global _step_t0
+    if _step_t0 is not None:
+        elapsed = _time.time() - _step_t0
+        print(f"{_CLEAR_LINE}{_step_indent}{_SYM_OK} {_step_msg}"
+              f" {_DIM}({elapsed:.1f}s){_RESET}", file=sys.stderr)
+        _step_t0 = None
+
+def step(msg, indent=0):
+    """Start a new progress step. Shows ↻ until the next step replaces it with ✓."""
+    global _step_t0, _step_msg, _step_indent
+    _finish_step()
+    _step_indent = "  " + "  " * indent
+    _step_msg = msg
+    print(f"{_step_indent}{_SYM_BUSY} {msg}", end="", file=sys.stderr, flush=True)
+    _step_t0 = _time.time()
+
+def step_detail(detail):
+    """Append detail to the current step (before timing is printed)."""
+    global _step_msg
+    _step_msg += f": {detail}"
+    print(f": {detail}", end="", file=sys.stderr, flush=True)
+
+def step_done():
+    _finish_step()
+
+def step_fail(msg):
+    """Mark the current step as failed with ✗ and die."""
+    global _step_t0
+    if _step_t0 is not None:
+        elapsed = _time.time() - _step_t0
+        print(f"{_CLEAR_LINE}{_step_indent}{_SYM_FAIL} {_step_msg}"
+              f" {_DIM}({elapsed:.1f}s){_RESET}", file=sys.stderr)
+        _step_t0 = None
+    die(msg)
+
+
+_ssh_control_path = None
+
+def _ssh_mux_flags():
+    """SSH multiplexing flags — reuses a single connection for all calls."""
+    global _ssh_control_path
+    if _ssh_control_path is None:
+        _ssh_control_path = f"/tmp/configure-remote-ssh_{os.getpid()}_%h"
+    return ["-o", "ControlMaster=auto",
+            "-o", f"ControlPath={_ssh_control_path}",
+            "-o", "ControlPersist=30s"]
+
+def _ssh_mux_cleanup():
+    """Stop the SSH master connection."""
+    if _ssh_control_path:
+        import glob
+        for sock in glob.glob(_ssh_control_path.replace("%h", "*")):
+            subprocess.run(["ssh", "-o", f"ControlPath={sock}", "-O", "exit", "dummy"],
+                           capture_output=True)
+
+def ssh_check(host, *cmd, timeout=15):
+    """Run a command on the remote, return stdout stripped. Returns None on failure."""
+    try:
+        r = subprocess.run(
+            ["ssh"] + _ssh_mux_flags() + ["-o", "ConnectTimeout=5", host] + [" ".join(cmd)],
+            capture_output=True, text=True, timeout=timeout)
+        return r.stdout.strip() if r.returncode == 0 else None
+    except subprocess.TimeoutExpired:
+        return None
+
+
+def rsync(src, dst, **kwargs):
+    """Run rsync -az with progress on stderr."""
+    kwargs.setdefault("stdout", sys.stderr)
+    subprocess.run(["rsync", "-az", "--progress", src, dst], **kwargs)
+
+
+def sha1_file(path):
+    """SHA1 of a local file, or None if it doesn't exist."""
+    if not os.path.isfile(path):
+        return None
+    h = hashlib.sha1()
+    with open(path, "rb") as f:
+        for chunk in iter(lambda: f.read(1 << 20), b""):
+            h.update(chunk)
+    return h.hexdigest()
+
+
+def remote_sha1(host, path):
+    """SHA1 of a remote file via ssh."""
+    out = ssh_check(host, "sha1sum", path)
+    return out.split()[0] if out else None
+
+
+def detect_remote(host):
+    """Detect remote arch and OS. Returns (arch, os_id)."""
+    arch = ssh_check(host, "uname", "-m")
+    if not arch:
+        die("Failed to detect remote architecture")
+    os_id = ssh_check(host, "bash", "-c",
+                       "'source /etc/os-release 2>/dev/null && echo $ID'") or "unknown"
+    return arch, os_id
+
+
+def pick_setup_script(arch, os_id):
+    """Pick the right setup script for the detected system."""
+    if os_id in ("ubuntu", "debian"):
+        if arch != "aarch64":
+            die(f"Ubuntu setup script only supports aarch64 (got {arch})")
+        return os.path.join(SCRIPT_DIR, "setup_aarch64_ubuntu.sh")
+    elif os_id in ("amzn",):
+        return os.path.join(SCRIPT_DIR, "setup_al2.sh")
+    else:
+        die(f"Unsupported OS: {os_id} (supported: Ubuntu, Amazon Linux 2)")
+
+
+def resolve_local_home(explicit):
+    """Resolve local Isabelle installation root."""
+    if explicit:
+        return explicit
+    env = os.environ.get("ISABELLE_HOME")
+    if env:
+        isa = os.path.join(env, "isabelle")
+        if os.path.isfile(isa):
+            return os.path.dirname(env)
+        die(f"ISABELLE_HOME={env} but {isa} not found")
+    die("Set ISABELLE_HOME or use --local-isabelle-home")
+
+
+def query_base_platform(host, remote_home, use_64):
+    """Query the base ML platform name from the remote."""
+    base = ssh_check(host, remote_home + "/bin/isabelle", "getenv", "-b", "ISABELLE_PLATFORM64")
+    if not base:
+        die("Failed to query ISABELLE_PLATFORM64")
+    if not use_64:
+        base = base.replace("arm64-", "arm64_32-", 1)
+    return base
+
+
+def local_platform_dir(local_home, platform):
+    return os.path.join(local_home, POLYML_CONTRIB, platform)
+
+
+def local_heap_dir(platform):
+    return os.path.join(os.path.expanduser("~"), ".isabelle", ISABELLE_VERSION,
+                        "heaps", f"{HEAP_PREFIX}_{platform}")
+
+
+def remote_user_heap_dir(host, base_platform):
+    """Remote user heap directory: ~/.isabelle/{ISABELLE_VERSION}/heaps/<prefix>_<platform>."""
+    remote_home = ssh_check(host, "printenv", "HOME") or ""
+    return f"{remote_home}/.isabelle/{ISABELLE_VERSION}/heaps/{HEAP_PREFIX}_{base_platform}"
+
+
+
+
+
+# ---------------------------------------------------------------------------
+# setup subcommand
+# ---------------------------------------------------------------------------
+
+def cmd_setup(args):
+    host = args.host
+    user = host.split("@")[0] if "@" in host else os.environ.get("USER") or die("USER not set")
+    remote_home = args.isabelle_home or f"/home/{user}/{ISABELLE_VERSION}"
+    local_home = resolve_local_home(args.local_isabelle_home)
+
+    info(f"setup {host}")
+
+    step(f"Checking local Isabelle installation: {local_home}")
+
+    # Verify SSH
+    step(f"Connecting to {host}")
+    if ssh_check(host, "true", timeout=10) is None:
+        step_fail(f"Cannot connect to {host}")
+
+    arch, os_id = detect_remote(host)
+
+    # Early check: if we know the platform name and it exists locally,
+    # fail fast before running expensive remote setup.
+    if args.ml_platform and not args.force_write_local and not args.copy_from_local:
+        early_poly = os.path.join(local_platform_dir(local_home, args.ml_platform), "poly")
+        if os.path.isfile(early_poly):
+            step_fail(f"ML platform {args.ml_platform} already exists locally at "
+                      f"{local_platform_dir(local_home, args.ml_platform)}\n"
+                      f"Use --force-write-local to overwrite, or --copy-from-local to push to remote.")
+
+    # Install Isabelle on remote if needed
+    if ssh_check(host, "test", "-d", remote_home) is None:
+        setup_script = pick_setup_script(arch, os_id)
+        step(f"Installing Isabelle on remote ({os.path.basename(setup_script)})")
+        print("", file=sys.stderr)
+        install_dir = os.path.basename(remote_home)
+        setup_args = [setup_script, host, install_dir,
+                      "64" if args.use_64 else "32"]
+        if args.copy_from_local:
+            setup_args.append("skip_build")
+        rc = subprocess.call(setup_args)
+        if rc != 0:
+            step_fail("Remote Isabelle installation failed")
+    else:
+        step(f"Checking remote Isabelle installation: {remote_home} ({arch} {os_id})")
+
+    step("Identifying ML platform")
+    base_platform = query_base_platform(host, remote_home, args.use_64)
+    platform = args.ml_platform
+    if not platform:
+        remote_poly = f"{remote_home}/{POLYML_CONTRIB}/{base_platform}/poly"
+        rh = remote_sha1(host, remote_poly)
+        if not rh:
+            step_fail(f"Failed to hash remote poly: {remote_poly}")
+        platform = f"{base_platform}-{rh[:7]}"
+    step_detail(platform)
+
+    local_plat_dir = local_platform_dir(local_home, platform)
+    local_poly = os.path.join(local_plat_dir, "poly")
+    local_hdir = local_heap_dir(platform)
+    platform_exists_locally = os.path.isfile(local_poly)
+
+    # Determine sync direction
+    if args.force_write_local and args.copy_from_local:
+        step_fail("Cannot use both --force-write-local and --copy-from-local")
+
+    if args.copy_from_local:
+        _setup_copy_from_local(host, remote_home, local_home,
+                               platform, base_platform, local_plat_dir, local_hdir,
+                               sync_all=args.sync_all_heaps)
+    elif args.force_write_local:
+        _setup_write_local(host, remote_home, local_home,
+                           platform, base_platform, local_plat_dir, local_hdir,
+                           force=True)
+    else:
+        if platform_exists_locally:
+            step_fail(f"ML platform {platform} already exists locally at {local_plat_dir}\n"
+                      f"Use --force-write-local to overwrite, or --copy-from-local to push to remote.")
+        _setup_write_local(host, remote_home, local_home,
+                           platform, base_platform, local_plat_dir, local_hdir,
+                           force=False)
+
+    step_done()
+    info(f"\n{_SYM_OK} Setup complete.")
+
+
+def _setup_write_local(host, remote_home, local_home,
+                       platform, base_platform, local_plat_dir, local_hdir,
+                       force):
+    """Copy poly binary and heaps from remote to local."""
+    remote_poly = f"{remote_home}/{POLYML_CONTRIB}/{base_platform}/poly"
+    local_poly = os.path.join(local_plat_dir, "poly")
+
+    if force and os.path.exists(local_plat_dir):
+        step("Removing existing local platform")
+        shutil.rmtree(local_plat_dir)
+    if force and os.path.exists(local_hdir):
+        step("Removing existing local heaps")
+        shutil.rmtree(local_hdir)
+
+    # Poly binary
+    step("Fetching poly binary from remote")
+    os.makedirs(local_plat_dir, exist_ok=True)
+    rsync(f"{host}:{remote_poly}", local_poly, check=True)
+    os.chmod(local_poly, 0o755)
+
+    # Heaps
+    remote_hdir = remote_user_heap_dir(host, base_platform)
+    os.makedirs(local_hdir, exist_ok=True)
+    for heap in ("Pure", "HOL"):
+        remote_path = f"{remote_hdir}/{heap}"
+        if ssh_check(host, "test", "-f", remote_path) is None:
+            step_fail(f"Heap {heap} not found at {remote_path}")
+        local_path = os.path.join(local_hdir, heap)
+        step(f"Fetching {heap} heap from remote", indent=1)
+        rsync(f"{host}:{remote_path}", local_path, check=True)
+
+    # Log
+    remote_log = f"{remote_hdir}/log"
+    local_log = os.path.join(local_hdir, "log")
+    if ssh_check(host, "test", "-d", remote_log) is not None:
+        step("Fetching build log from remote", indent=1)
+        os.makedirs(local_log, exist_ok=True)
+        rsync(f"{host}:{remote_log}/", local_log + "/", check=True)
+
+
+def _setup_copy_from_local(host, remote_home, local_home,
+                           platform, base_platform, local_plat_dir, local_hdir,
+                           sync_all=False):
+    """Copy poly binary and heaps from local to remote.
+
+    All heaps (including Pure/HOL) are synced to the remote user heap directory.
+    """
+    local_poly = os.path.join(local_plat_dir, "poly")
+    if not os.path.isfile(local_poly):
+        step_fail(f"Local poly not found: {local_poly}")
+
+    remote_poly_dir = f"{remote_home}/{POLYML_CONTRIB}/{base_platform}"
+    remote_poly = f"{remote_poly_dir}/poly"
+
+    step("Pushing poly binary to remote")
+    rsync(local_poly, f"{host}:{remote_poly}", check=True)
+
+    # All heaps go to user heap dir
+    remote_hdir = remote_user_heap_dir(host, base_platform)
+
+    if sync_all:
+        heaps = [f for f in os.listdir(local_hdir)
+                 if os.path.isfile(os.path.join(local_hdir, f))]
+    else:
+        heaps = ["Pure", "HOL"]
+
+    for heap in heaps:
+        local_path = os.path.join(local_hdir, heap)
+        if not os.path.isfile(local_path):
+            step_fail(f"Local heap not found: {local_path}")
+        sz = os.path.getsize(local_path)
+        step(f"Pushing {heap} ({sz // (1024*1024)}MB) to remote", indent=1)
+        ssh_check(host, "mkdir", "-p", remote_hdir)
+        remote_path = f"{remote_hdir}/{heap}"
+        rsync(local_path, f"{host}:{remote_path}", check=True)
+
+    # Log
+    local_log = os.path.join(local_hdir, "log")
+    if os.path.isdir(local_log):
+        step("Pushing build log to remote", indent=1)
+        ssh_check(host, "mkdir", "-p", f"{remote_hdir}/log")
+        rsync(local_log + "/", f"{host}:{remote_hdir}/log/", check=True)
+
+
+# ---------------------------------------------------------------------------
+# run subcommand
+# ---------------------------------------------------------------------------
+
+def cmd_run(args):
+    host = args.host
+    user = host.split("@")[0] if "@" in host else os.environ.get("USER") or die("USER not set")
+    remote_home = args.isabelle_home or f"/home/{user}/{ISABELLE_VERSION}"
+    local_home = resolve_local_home(args.local_isabelle_home)
+    proxy = os.path.join(SCRIPT_DIR, "ml_proxy.py")
+
+    info(f"run {host}")
+
+    step(f"Checking local Isabelle installation: {local_home}")
+
+    # Verify SSH
+    step(f"Establishing SSH connection to {host}")
+    if ssh_check(host, "true", timeout=10) is None:
+        step_fail(f"Cannot connect to {host}")
+
+    arch, os_id = detect_remote(host)
+
+    step(f"Checking remote Isabelle installation: {remote_home} ({arch} {os_id})")
+    if ssh_check(host, "test", "-d", remote_home) is None:
+        step_fail(f"Isabelle not found at {remote_home} (run 'setup' first)")
+
+    base_platform = query_base_platform(host, remote_home, args.use_64)
+
+    # Determine local platform
+    if args.ml_platform:
+        platform = args.ml_platform
+        step(f"Using ML platform: {platform}")
+        step_done()
+    else:
+        step("Identifying ML platform")
+        remote_poly = f"{remote_home}/{POLYML_CONTRIB}/{base_platform}/poly"
+        remote_hash = remote_sha1(host, remote_poly)
+        if not remote_hash:
+            step_fail(f"Failed to hash remote poly: {remote_poly}")
+
+        polyml_dir = os.path.join(local_home, POLYML_CONTRIB)
+        platform = None
+        if os.path.isdir(polyml_dir):
+            for entry in os.listdir(polyml_dir):
+                lp = os.path.join(polyml_dir, entry, "poly")
+                if os.path.isfile(lp) and sha1_file(lp) == remote_hash:
+                    platform = entry
+                    step_detail(platform)
+                    break
+        if not platform:
+            step_fail("No local poly binary matches remote. Run 'setup' first.")
+
+    # Verify poly and heap hashes match between local and remote
+    remote_poly = f"{remote_home}/{POLYML_CONTRIB}/{base_platform}/poly"
+    local_poly = os.path.join(local_home, POLYML_CONTRIB, platform, "poly")
+
+    step("Checking poly hash", indent=1)
+    lh = sha1_file(local_poly)
+    if not lh:
+        step_fail(f"Local poly not found: {local_poly}")
+    rh = remote_sha1(host, remote_poly)
+    if rh and lh != rh:
+        step_fail(f"Poly binary SHA1 MISMATCH for {platform}\n"
+                  f"  local:  {lh} ({local_poly[:7]})\n"
+                  f"  remote: {rh} ({remote_poly[:7]})")
+
+    lhdir = local_heap_dir(platform)
+    remote_hdir = remote_user_heap_dir(host, base_platform)
+    for heap in ("Pure", "HOL"):
+        step(f"Checking {heap} heap", indent=1)
+        local_path = os.path.join(lhdir, heap)
+        lh = sha1_file(local_path)
+        if not lh:
+            step_fail(f"Local heap missing: {local_path}\nRun 'setup' first.")
+        lh = sha1_file(local_path)
+        rh = remote_sha1(host, f"{remote_hdir}/{heap}")
+        if rh and lh != rh:
+            step_fail(f"{heap} heap SHA1 mismatch for {platform}\n"
+                      f"  local:  {lh[:7]}\n"
+                      f"  remote: {rh[:7]}")
+
+    # Sync local heaps to remote
+    extra_heaps = sorted(f for f in os.listdir(lhdir)
+                         if os.path.isfile(os.path.join(lhdir, f))
+                         and f not in ("Pure", "HOL"))
+    sync = args.sync_heaps
+    if extra_heaps and sync is None:
+        step_done()
+        die(f"Additional local heaps: {_BOLD}{', '.join(extra_heaps)}{_RESET}\n"
+            f"Use {_GREEN}--sync-heaps{_RESET} to sync all heaps to remote, "
+            f"or {_YELLOW}--no-sync-heaps{_RESET} to skip.")
+
+    if sync:
+        step("Syncing heaps to remote")
+        step_done()
+        remote_hdir = remote_user_heap_dir(host, base_platform)
+        heaps = [f for f in os.listdir(lhdir)
+                 if os.path.isfile(os.path.join(lhdir, f))]
+        for heap in heaps:
+            sz = os.path.getsize(os.path.join(lhdir, heap))
+            step(f"{heap} ({sz // (1024*1024)}MB)", indent=1)
+            local_path = os.path.join(lhdir, heap)
+            ssh_check(host, "mkdir", "-p", remote_hdir)
+            remote_path = f"{remote_hdir}/{heap}"
+            rsync(local_path, f"{host}:{remote_path}", check=True)
+        local_log = os.path.join(lhdir, "log")
+        if os.path.isdir(local_log):
+            step("log", indent=1)
+            ssh_check(host, "mkdir", "-p", f"{remote_hdir}/log")
+            rsync(local_log + "/", f"{host}:{remote_hdir}/log/",
+                  check=True)
+
+    step("Setting thread count")
+    if args.threads:
+        threads = str(args.threads)
+        step_detail(f"{threads} (forced)")
+    else:
+        remote_nproc = int(ssh_check(host, "nproc") or "8")
+        threads = str(min(remote_nproc, args.maxthreads))
+        step_detail(f"{threads} (remote has {remote_nproc} cores, max {args.maxthreads})")
+
+    step(f"Generating jEdit flags (threads={threads}, platform={platform})")
+    step_done()
+
+    poly_overrides = ""
+    for opt, val in [("--minheap", args.minheap),
+                     ("--maxheap", args.maxheap),
+                     ("--gcthreads", args.gcthreads),
+                     ("-H", args.initial_heap),
+                     ("--gcpercent", args.gcpercent)]:
+        if val is not None:
+            poly_overrides += f" {opt} {val}"
+
+    flags = (
+        f"-o ML_platform={platform}"
+        f" -o threads={threads}"
+        f" -o jedit_auto_resolve=true"
+        f" -o 'process_policy={proxy}"
+        f" -v --log /tmp/ml_proxy.log"
+        f" --host {host}"
+        f" --target-isabelle-home {remote_home}"
+        f" --target-ml-platform {base_platform}"
+        f"{poly_overrides} --'"
+    )
+
+    if sys.stdout.isatty():
+        info(f"\nUse the following flags when starting Isabelle/jEdit:\n"
+             f"{'─' * 60}")
+
+    print(flags)
+
+
+# ---------------------------------------------------------------------------
+# list subcommand
+# ---------------------------------------------------------------------------
+
+def cmd_list(args):
+    local_home = resolve_local_home(args.local_isabelle_home)
+    polyml_dir = os.path.join(local_home, POLYML_CONTRIB)
+    heap_base = os.path.join(os.path.expanduser("~"), ".isabelle", ISABELLE_VERSION, "heaps")
+
+    if not os.path.isdir(polyml_dir):
+        die(f"No polyml contrib dir: {polyml_dir}")
+
+    entries = []
+    for entry in sorted(os.listdir(polyml_dir)):
+        poly = os.path.join(polyml_dir, entry, "poly")
+        if not os.path.isfile(poly):
+            continue
+        hdir = os.path.join(heap_base, f"{HEAP_PREFIX}_{entry}")
+        heaps = []
+        if os.path.isdir(hdir):
+            heaps = sorted(f for f in os.listdir(hdir) if os.path.isfile(os.path.join(hdir, f)))
+        h = sha1_file(poly)[:7]
+        entries.append((entry, h, heaps))
+
+    if not entries:
+        info("No ML platforms found.")
+        return
+
+    name_w = max(len(e[0]) for e in entries)
+    info(f"\n{'ML Platform':<{name_w}}  {'Poly Hash':<9}  Heaps")
+    info(f"{'─' * name_w}  {'─' * 9}  {'─' * 40}")
+    for name, h, heaps in entries:
+        heap_str = f"{_DIM}none{_RESET}" if not heaps else ", ".join(heaps)
+        print(f"{_BOLD}{name:<{name_w}}{_RESET}  {_DIM}{h}{_RESET}       {heap_str}",
+              file=sys.stderr)
+    info("")
+
+
+# ---------------------------------------------------------------------------
+# remove subcommand
+# ---------------------------------------------------------------------------
+
+def cmd_remove(args):
+    local_home = resolve_local_home(args.local_isabelle_home)
+    platform = args.platform
+    plat_dir = local_platform_dir(local_home, platform)
+    hdir = local_heap_dir(platform)
+
+    to_remove = []
+    if os.path.exists(plat_dir):
+        to_remove.append(("Poly binary dir", plat_dir))
+    if os.path.exists(hdir):
+        to_remove.append(("Heap dir", hdir))
+
+    if not to_remove:
+        die(f"Nothing to remove for platform {platform}")
+
+    print(f"Will remove platform '{platform}':", file=sys.stderr)
+    for label, path in to_remove:
+        print(f"  {label}: {path}", file=sys.stderr)
+        if label == "Heap dir":
+            for f in sorted(os.listdir(path)):
+                fp = os.path.join(path, f)
+                if os.path.isfile(fp):
+                    print(f"    {f} ({os.path.getsize(fp)} bytes)", file=sys.stderr)
+                elif os.path.isdir(fp):
+                    print(f"    {f}/", file=sys.stderr)
+
+    if not args.yes:
+        answer = input("Proceed? [y/N] ").strip().lower()
+        if answer != "y":
+            die("Aborted.")
+
+    for _, path in to_remove:
+        shutil.rmtree(path)
+        info(f"Removed {path}")
+    info("Done.")
+
+
+# ---------------------------------------------------------------------------
+# main
+# ---------------------------------------------------------------------------
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Configure Isabelle remote ML prover.")
+    sub = parser.add_subparsers(dest="command", required=True)
+
+    # Common arguments
+    def add_common(p):
+        p.add_argument("host", help="SSH host (user@host)")
+        p.add_argument("--isabelle-home",
+                        help="ISABELLE_HOME on remote (default: /home/<user>/{ISABELLE_VERSION})")
+        p.add_argument("--local-isabelle-home",
+                        help="Local ISABELLE_HOME (default: auto-detect)")
+        bits = p.add_mutually_exclusive_group()
+        bits.add_argument("--64", dest="use_64", action="store_true", default=True,
+                          help="Use 64-bit ML (default)")
+        bits.add_argument("--32", dest="use_64", action="store_false",
+                          help="Use 32-in-64-bit ML")
+        p.add_argument("--ml-platform",
+                        help="Force local ML platform name (e.g. aarch64-ubuntu)")
+
+    # setup
+    p_setup = sub.add_parser("setup",
+        help="Install Isabelle on remote, sync poly/heaps")
+    add_common(p_setup)
+    sync = p_setup.add_mutually_exclusive_group()
+    sync.add_argument("--force-write-local", action="store_true",
+                      help="Overwrite local ML platform with remote poly/heaps")
+    sync.add_argument("--copy-from-local", action="store_true",
+                      help="Copy local poly/heaps to remote")
+    p_setup.add_argument("--sync-all-heaps", action="store_true",
+                         help="With --copy-from-local: sync entire heaps dir, not just Pure/HOL")
+    p_setup.set_defaults(func=cmd_setup)
+
+    # run
+    p_run = sub.add_parser("run",
+        help="Print jEdit flags for remote ML prover")
+    add_common(p_run)
+    p_run.add_argument("--sync-heaps", dest="sync_heaps",
+                       action="store_true", default=None,
+                       help="Sync all local heaps to remote before printing flags")
+    p_run.add_argument("--no-sync-heaps", dest="sync_heaps",
+                       action="store_false",
+                       help="Do not sync heaps to remote")
+    p_run.add_argument("--threads", type=int, default=None,
+                       help="Force exact thread count (overrides --maxthreads)")
+    p_run.add_argument("--maxthreads", type=int, default=16,
+                       help="Maximum thread count (default: 16, capped to remote nproc)")
+    p_run.add_argument("--minheap", default=None, help="Override poly --minheap (MB)")
+    p_run.add_argument("--maxheap", default=None, help="Override poly --maxheap (MB)")
+    p_run.add_argument("--gcthreads", default=None, help="Override poly --gcthreads")
+    p_run.add_argument("-H", dest="initial_heap", default=None,
+                       help="Override poly -H initial heap size (MB)")
+    p_run.add_argument("--gcpercent", default=5,
+                       help="Override poly --gcpercent (1-99)")
+    p_run.set_defaults(func=cmd_run)
+
+    # list
+    p_list = sub.add_parser("list",
+        help="List local ML platforms")
+    p_list.add_argument("--local-isabelle-home",
+                        help="Local ISABELLE_HOME (default: auto-detect)")
+    p_list.set_defaults(func=cmd_list)
+
+    # remove
+    p_remove = sub.add_parser("remove",
+        help="Remove a local ML platform and its heaps")
+    p_remove.add_argument("platform", help="ML platform name to remove")
+    p_remove.add_argument("--local-isabelle-home",
+                          help="Local ISABELLE_HOME (default: auto-detect)")
+    p_remove.add_argument("-y", "--yes", action="store_true",
+                          help="Skip confirmation prompt")
+    p_remove.set_defaults(func=cmd_remove)
+
+    args = parser.parse_args()
+    try:
+        args.func(args)
+    finally:
+        _ssh_mux_cleanup()
+
+
+if __name__ == "__main__":
+    main()

--- a/ip/ip_plugin/Makefile
+++ b/ip/ip_plugin/Makefile
@@ -1,0 +1,77 @@
+# Makefile for Proxy Plugin
+
+ifndef V
+.SILENT:
+endif
+
+PLUGIN_DIR := $(shell pwd)
+ISABELLE_HOME ?= /Applications/Isabelle2025-2.app
+JEDIT_DIR := $(shell ls -d $(ISABELLE_HOME)/contrib/jedit-* 2>/dev/null | head -1)
+JEDIT_JAR ?= $(JEDIT_DIR)/jedit5.7.0-patched/jedit.jar
+SCALA_HOME ?= $(ISABELLE_HOME)/contrib/scala-3.3.4
+SCALAC ?= $(SCALA_HOME)/bin/scalac
+ISABELLE_JAR ?= $(ISABELLE_HOME)/lib/classes/isabelle.jar
+
+BUILD_DIR ?= $(PLUGIN_DIR)/build
+CLASSES_DIR ?= $(BUILD_DIR)/classes
+JAR_FILE ?= $(BUILD_DIR)/ip_plugin.jar
+INSTALL_DIR ?= $(HOME)/.isabelle/Isabelle2025-2/jedit/jars
+
+SCALA_SOURCES := $(wildcard src/*.scala)
+RESOURCE_FILES := $(wildcard resources/*)
+
+.PHONY: all build install clean uninstall help debug
+
+all:
+	echo "Building Proxy Plugin..."
+	$(MAKE) build
+
+build: $(JAR_FILE)
+	echo "Plugin built: $(JAR_FILE)"
+
+$(JAR_FILE): $(CLASSES_DIR)/.compiled $(CLASSES_DIR)/.resources
+	echo "Creating JAR..."
+	cd $(CLASSES_DIR) && jar cf $(JAR_FILE) .
+
+$(CLASSES_DIR)/.compiled: $(SCALA_SOURCES) | $(CLASSES_DIR)
+	echo "Compiling..."
+	$(SCALAC) \
+		-classpath "$(JEDIT_JAR):$(ISABELLE_JAR)" \
+		-d $(CLASSES_DIR) \
+		$(SCALA_SOURCES)
+	touch $@
+
+$(CLASSES_DIR)/.resources: $(RESOURCE_FILES) | $(CLASSES_DIR)
+	echo "Copying resources..."
+	cp -r resources/* $(CLASSES_DIR)/
+	touch $@
+
+$(CLASSES_DIR):
+	mkdir -p $(CLASSES_DIR)
+
+install: $(JAR_FILE)
+	echo "Installing to $(INSTALL_DIR)..."
+	mkdir -p $(INSTALL_DIR)
+	cp $(JAR_FILE) $(INSTALL_DIR)/
+	echo "Installed. Restart Isabelle/jEdit to activate."
+
+clean:
+	rm -rf $(BUILD_DIR)
+
+uninstall:
+	rm -f $(INSTALL_DIR)/ip_plugin.jar
+
+help:
+	echo "Targets: all build install clean uninstall help debug"
+	echo ""
+	echo "Variables:"
+	echo "  V=1              Verbose output"
+	echo "  ISABELLE_HOME    Isabelle installation (default: $(ISABELLE_HOME))"
+	echo "  INSTALL_DIR      Plugin install dir (default: $(INSTALL_DIR))"
+
+debug:
+	echo "ISABELLE_HOME = $(ISABELLE_HOME)"
+	echo "JEDIT_JAR     = $(JEDIT_JAR)"
+	echo "ISABELLE_JAR  = $(ISABELLE_JAR)"
+	echo "SCALAC        = $(SCALAC)"
+	echo "SCALA_SOURCES = $(SCALA_SOURCES)"

--- a/ip/ip_plugin/README.md
+++ b/ip/ip_plugin/README.md
@@ -1,0 +1,52 @@
+# Isabelle/jEdit Proxy Plugin
+
+Status bar widget and log panel for the Isabelle remote ML prover proxy.
+
+## Features
+
+- **Proxy status widget**: shows remote host and PIDE throughput (MB/s)
+  in the jEdit status bar. Appears automatically when the proxy connects.
+- **ML heap monitoring**: forwards remote Poly/ML runtime statistics to
+  the built-in ML heap widget and Monitor panel.
+- **Proxy log panel**: dockable panel showing log messages from the proxy.
+
+## Architecture
+
+The plugin registers a PIDE protocol handler that recognizes three
+message types injected by `ml_proxy.py` into the ML→Scala stream:
+
+- `proxy_status` — host and throughput, displayed in the status bar widget.
+- `proxy_ml_stats` — Poly/ML runtime statistics (heap, GC, threads),
+  forwarded to `session.runtime_statistics` so the built-in ML heap
+  widget and Monitor panel work with the remote prover.
+- `proxy_log` — text messages appended to the log panel.
+
+The handler is registered from a background thread at plugin startup,
+retrying until the PIDE session is available. The status bar widget is
+added dynamically on the first `proxy_status` message.
+
+## Build
+
+Requires an Isabelle installation with jEdit and Scala.
+
+```
+make build                          # Build the JAR
+make install                        # Build and install to ~/.isabelle/.../jedit/jars/
+make clean                          # Remove build artifacts
+make uninstall                      # Remove installed JAR
+```
+
+Override paths via environment variables:
+
+```
+ISABELLE_HOME=/path/to/Isabelle make install
+```
+
+## Files
+
+- `src/ProxyPlugin.scala` — plugin entry point, protocol handler, shared state
+- `src/ProxyStatusWidget.scala` — status bar widget with throughput progress bar
+- `src/ProxyLogDockable.scala` — log panel dockable
+- `resources/plugin.props` — jEdit plugin metadata
+- `resources/dockables.xml` — dockable registration
+- `resources/services.xml` — status bar widget factory registration

--- a/ip/ip_plugin/resources/dockables.xml
+++ b/ip/ip_plugin/resources/dockables.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0"?>
+<!DOCTYPE DOCKABLES SYSTEM "dockables.dtd">
+
+<DOCKABLES>
+	<DOCKABLE NAME="proxy-log-dockable" MOVABLE="TRUE">
+		new ProxyLogDockable(view, position);
+	</DOCKABLE>
+</DOCKABLES>

--- a/ip/ip_plugin/resources/plugin.props
+++ b/ip/ip_plugin/resources/plugin.props
@@ -1,0 +1,18 @@
+# Proxy Plugin Properties
+
+plugin.ProxyPlugin.name=ML Proxy
+plugin.ProxyPlugin.author=Generated
+plugin.ProxyPlugin.version=1.0
+plugin.ProxyPlugin.description=Status and log panel for Isabelle ML proxy
+
+plugin.ProxyPlugin.activate=startup
+plugin.ProxyPlugin.usePluginHome=false
+
+plugin.ProxyPlugin.depend.0=jdk 21
+plugin.ProxyPlugin.depend.1=jedit 05.06.00.00
+
+plugin.ProxyPlugin.menu.label=ML Proxy
+plugin.ProxyPlugin.menu=proxy-log-dockable
+
+proxy-log-dockable.label=Proxy Log
+proxy-log-dockable.title=Proxy Log

--- a/ip/ip_plugin/resources/services.xml
+++ b/ip/ip_plugin/resources/services.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0"?>
+<!DOCTYPE SERVICES SYSTEM "services.dtd">
+
+<SERVICES>
+	<SERVICE CLASS="org.gjt.sp.jedit.gui.statusbar.StatusWidgetFactory" NAME="proxy-status">
+		new ProxyStatusWidgetFactory();
+	</SERVICE>
+</SERVICES>

--- a/ip/ip_plugin/src/ProxyLogDockable.scala
+++ b/ip/ip_plugin/src/ProxyLogDockable.scala
@@ -1,0 +1,37 @@
+/* Proxy Log dockable: scrolling text area showing proxy_log messages. */
+
+import isabelle._
+
+import java.awt.{BorderLayout, Font}
+import java.awt.event.{ActionEvent, ActionListener}
+import javax.swing.{JButton, JPanel, JTextArea, JScrollPane}
+
+import org.gjt.sp.jedit.View
+import org.gjt.sp.jedit.gui.DefaultFocusComponent
+
+
+class ProxyLogDockable(view: View, position: String)
+extends JPanel(new BorderLayout) with DefaultFocusComponent {
+
+  private val textArea = new JTextArea
+  textArea.setEditable(false)
+  textArea.setFont(new Font(Font.MONOSPACED, Font.PLAIN, 12))
+
+  private val clearButton = new JButton("Clear")
+  clearButton.addActionListener((_: ActionEvent) => textArea.setText(""))
+
+  add(new JScrollPane(textArea), BorderLayout.CENTER)
+  add(clearButton, BorderLayout.SOUTH)
+
+  private val listener: String => Unit = { text =>
+    textArea.append(text + "\n")
+    textArea.setCaretPosition(textArea.getDocument.getLength)
+  }
+
+  ProxyState.addLogListener(listener)
+
+  /* Called by jEdit when the dockable is closed. */
+  def dispose(): Unit = ProxyState.removeLogListener(listener)
+
+  def focusOnDefaultComponent(): Unit = textArea.requestFocus()
+}

--- a/ip/ip_plugin/src/ProxyPlugin.scala
+++ b/ip/ip_plugin/src/ProxyPlugin.scala
@@ -1,0 +1,134 @@
+/* Proxy Plugin: entry point, protocol handler, shared state.
+
+   Registers a PIDE protocol handler that recognizes two message types
+   injected by ml_proxy.py into the ML→Scala message stream:
+
+     ("function", "proxy_log")    — body text appended to the log panel
+     ("function", "proxy_status") — properties: host, mbps
+*/
+
+import isabelle._
+import isabelle.jedit.PIDE
+
+import org.gjt.sp.jedit.{EBMessage, EBPlugin, jEdit}
+
+
+/* Shared mutable state between protocol handler and UI components. */
+object ProxyState {
+  case class Status(host: String = "", mbps: Double = 0.0)
+
+  @volatile var status: Status = Status()
+  @volatile private var activated: Boolean = false
+
+  private var statusListeners: List[Status => Unit] = Nil
+  private var logListeners: List[String => Unit] = Nil
+
+  def addStatusListener(f: Status => Unit): Unit = synchronized { statusListeners ::= f }
+  def removeStatusListener(f: Status => Unit): Unit = synchronized {
+    statusListeners = statusListeners.filterNot(_ eq f)
+  }
+
+  def addLogListener(f: String => Unit): Unit = synchronized { logListeners ::= f }
+  def removeLogListener(f: String => Unit): Unit = synchronized {
+    logListeners = logListeners.filterNot(_ eq f)
+  }
+
+  /* On first proxy_status, append proxy-status at the end (keep ml-status). */
+  private def activateStatusBar(): Unit = {
+    if (activated) return
+    synchronized {
+      if (activated) return
+      activated = true
+    }
+    GUI_Thread.later {
+      val key = "view.status"
+      var current = jEdit.getProperty(key, "")
+      if (!current.contains("proxy-status"))
+        current = current + " proxy-status"
+      jEdit.setProperty(key, current)
+      var view = jEdit.getFirstView()
+      while (view != null) {
+        view.getStatus.propertiesChanged()
+        view = view.getNext
+      }
+    }
+  }
+
+  def notifyStatus(s: Status): Unit = {
+    activateStatusBar()
+    status = s
+    val ls = synchronized { statusListeners }
+    GUI_Thread.later { ls.foreach(_(s)) }
+  }
+
+  def notifyLog(text: String): Unit = {
+    val ls = synchronized { logListeners }
+    GUI_Thread.later { ls.foreach(_(text)) }
+  }
+}
+
+
+/* PIDE protocol handler. */
+class ProxyProtocolHandler extends Session.Protocol_Handler {
+  private var session: Session = null
+
+  override def init(session: Session): Unit = { this.session = session }
+
+  private def handle_log(msg: Prover.Protocol_Output): Boolean = {
+    ProxyState.notifyLog(msg.text)
+    true
+  }
+
+  private def handle_status(msg: Prover.Protocol_Output): Boolean = {
+    val host = Properties.get(msg.properties, "host").getOrElse("")
+    val mbps = Properties.get(msg.properties, "mbps").flatMap(s =>
+      try { Some(s.toDouble) } catch { case _: NumberFormatException => None }
+    ).getOrElse(0.0)
+    ProxyState.notifyStatus(ProxyState.Status(host, mbps))
+    true
+  }
+
+  private def handle_ml_stats(msg: Prover.Protocol_Output): Boolean = {
+    if (session != null) {
+      val props = space_explode(',', msg.text).flatMap(Properties.Eq.unapply)
+      if (props.nonEmpty) {
+        val props1 = session.cache.props(props ::: Java_Statistics.jvm_statistics())
+        session.runtime_statistics.post(Session.Runtime_Statistics(props1))
+      }
+    }
+    true
+  }
+
+  override val functions: Session.Protocol_Functions =
+    List("proxy_log" -> handle_log,
+         "proxy_status" -> handle_status,
+         "proxy_ml_stats" -> handle_ml_stats)
+}
+
+
+/* jEdit plugin lifecycle. */
+class ProxyPlugin extends EBPlugin {
+  override def start(): Unit = {
+    /* Register protocol handler once PIDE session is available. */
+    Isabelle_Thread.fork(name = "ip_plugin_init") {
+      var registered = false
+      while (!registered) {
+        try {
+          PIDE.session.init_protocol_handler(new ProxyProtocolHandler)
+          registered = true
+        } catch {
+          case _: Throwable =>
+            Time.seconds(0.5).sleep()
+        }
+      }
+    }
+  }
+  override def stop(): Unit = {
+    val key = "view.status"
+    val current = jEdit.getProperty(key, "")
+    if (current.contains("proxy-status")) {
+      jEdit.setProperty(key, current.replace("proxy-status", "").replaceAll("  +", " ").trim)
+    }
+  }
+  override def handleMessage(message: EBMessage): Unit = {}
+}

--- a/ip/ip_plugin/src/ProxyStatusWidget.scala
+++ b/ip/ip_plugin/src/ProxyStatusWidget.scala
@@ -1,0 +1,104 @@
+/* Proxy status bar widget: shows "Proxy: host  X.X MB/s" with progress bar.
+
+   Modeled after Status_Widget.ML_GUI / Java_GUI.
+   Registered via services.xml as "proxy-status".
+*/
+
+import isabelle._
+
+import java.awt.{Color, Dimension, Graphics, Graphics2D, Insets, RenderingHints}
+import java.awt.font.FontRenderContext
+import javax.swing.JComponent
+
+import org.gjt.sp.jedit.{View, jEdit}
+import org.gjt.sp.jedit.gui.statusbar.{StatusWidgetFactory, Widget}
+
+
+class ProxyStatusWidget(view: View) extends JComponent {
+  /* The progress bar scales to this ceiling (MB/s). */
+  private val MAX_MBPS = 25.0
+
+  private val template = "Proxy: 999.999.999.999  99.9 MB/s"
+
+  setFont(GUI.copy_font(GUI.label_font()))
+
+  private val frc = new FontRenderContext(null, true, false)
+  private val lineMetrics = getFont.getLineMetrics(template, frc)
+
+  {
+    val bounds = getFont.getStringBounds(template, frc)
+    val dim = new Dimension(bounds.getWidth.toInt + 12, bounds.getHeight.toInt)
+    setPreferredSize(dim)
+    setMaximumSize(dim)
+  }
+
+  setForeground(jEdit.getColorProperty("view.status.foreground"))
+  setBackground(jEdit.getColorProperty("view.status.background"))
+
+  private def progressFg: Color = jEdit.getColorProperty("view.status.memory.foreground")
+  private def progressBg: Color = jEdit.getColorProperty("view.status.memory.background")
+
+  @volatile private var currentStatus = ProxyState.Status()
+
+  private val listener: ProxyState.Status => Unit = { s =>
+    if (s != currentStatus) { currentStatus = s; repaint() }
+  }
+
+  override def addNotify(): Unit = {
+    super.addNotify()
+    ProxyState.addStatusListener(listener)
+    listener(ProxyState.status)
+  }
+
+  override def removeNotify(): Unit = {
+    super.removeNotify()
+    ProxyState.removeStatusListener(listener)
+  }
+
+  override def paintComponent(gfx: Graphics): Unit = {
+    super.paintComponent(gfx)
+    val s = currentStatus
+    if (s.host.isEmpty) return
+
+    val host = if (s.host.contains("@")) s.host.split("@", 2)(1) else s.host
+    val text = f"Proxy: $host  ${s.mbps}%.1f MB/s"
+    val fraction = math.min(s.mbps / MAX_MBPS, 1.0)
+
+    val insets = new Insets(0, 0, 0, 0)
+    val width = getWidth - insets.left - insets.right
+    val height = getHeight - insets.top - insets.bottom - 1
+    val barWidth = (width * fraction).toInt
+
+    val textBounds = gfx.getFont.getStringBounds(text, frc)
+    val textX = insets.left + ((width - textBounds.getWidth.toInt) / 2)
+    val textY = lineMetrics.getAscent.toInt
+
+    val g2 = gfx.asInstanceOf[Graphics2D]
+    g2.setRenderingHint(RenderingHints.KEY_TEXT_ANTIALIASING,
+                        RenderingHints.VALUE_TEXT_ANTIALIAS_ON)
+
+    /* Progress bar background. */
+    gfx.setColor(progressBg)
+    gfx.fillRect(insets.left, insets.top, barWidth, height)
+
+    /* Text over the bar portion. */
+    gfx.setColor(progressFg)
+    gfx.setClip(insets.left, insets.top, barWidth, height)
+    gfx.drawString(text, textX, textY)
+
+    /* Text over the empty portion. */
+    gfx.setColor(getForeground)
+    gfx.setClip(insets.left + barWidth, insets.top, width - barWidth, height)
+    gfx.drawString(text, textX, textY)
+
+    gfx.setClip(null)
+  }
+
+  setToolTipText("Remote ML prover throughput")
+}
+
+
+class ProxyStatusWidgetFactory extends StatusWidgetFactory {
+  override def getWidget(view: View): Widget =
+    new Widget { override def getComponent: JComponent = new ProxyStatusWidget(view) }
+}

--- a/ip/ml_proxy.py
+++ b/ip/ml_proxy.py
@@ -1,0 +1,1124 @@
+#!/usr/bin/env python3
+"""
+Isabelle Remote ML Prover Proxy
+===============================
+
+Runs the Isabelle ML prover (Poly/ML) and Bash.Server on a remote machine
+while keeping jEdit + Scala/PIDE local. No Isabelle source changes required.
+
+Normal Isabelle Architecture
+----------------------------
+
+In a standard local session, Isabelle has three communicating processes:
+
+    jEdit/Scala (GUI + PIDE)          Poly/ML (prover)
+    ┌─────────────────────┐           ┌─────────────────────┐
+    │                     │           │                     │
+    │  Document model     │  PIDE     │  Theory processing  │
+    │  Rendering          │◄════════► │  Proof checking     │
+    │  Session management │  TCP      │  Code generation    │
+    │                     │           │                     │
+    │  Bash.Server ◄──────┼───────────┼── bash_process()    │
+    │  (localhost:P2)     │  TCP      │  (sledgehammer etc) │
+    │                     │           │                     │
+    └─────────────────────┘           └─────────────────────┘
+
+Startup sequence:
+  1. jEdit/Scala creates a System_Channel (TCP server on localhost:P1)
+     and writes its address + password to ISABELLE_PROCESS_OPTIONS file.
+  2. Scala starts a Bash.Server on localhost:P2 (random port + password).
+  3. Scala spawns the poly process wrapped in a configurable `process_policy`,
+     passing the full poly command line. The poly process inherits
+     ISABELLE_PROCESS_OPTIONS.
+  4. Poly/ML reads ISABELLE_PROCESS_OPTIONS, connects back to localhost:P1,
+     sends the password. The PIDE channel is established.
+  5. Scala sends `Prover.options` over PIDE, which includes
+     bash_process_address=127.0.0.1:P2 and bash_process_password=UUID.
+  6. When ML needs external tools (e.g. sledgehammer), it connects to
+     the Bash.Server at 127.0.0.1:P2 to run shell commands.
+  7. For heap builds, Scala sends `build_session` over PIDE, which includes
+     session_directories (filesystem paths) and options (including
+     bash_process_address/password). ML reads theory files from disk.
+  8. For interactive builds, Poly/ML receives file contents via PIDE;
+     it does not read the file system.
+
+Proxied Architecture
+--------------------
+
+This script interposes between Scala and a remote Poly/ML:
+
+    LOCAL MACHINE                                   REMOTE MACHINE
+    ┌──────────────────┐                            ┌──────────────────┐
+    │ jEdit/Scala      │                            │ Poly/ML          │
+    │                  │                            │                  │
+    │ System_Channel   │ ┌───────────────┐   SSH    │                  │
+    │ (localhost:P1) ◄─┼─┤ PIDE proxy    ├───-R────►│ connects to      │
+    │                  │ │ (localhost:P3)│  tunnel  │ localhost:P3     │
+    │ Bash.Server      │ │               │          │                  │
+    │ (localhost:P2)   │ │ Intercepts:   │          │ bash_process()───┼─┐
+    │ (unused)         │ │  • Prover.    │          │                  │ │
+    │                  │ │    options    │          └──────────────────┘ │
+    │                  │ │  • build_     │                               │
+    │                  │ │    session    │          ┌──────────────────┐ │
+    │                  │ │  • ML→Scala   │          │ Remote           │ │
+    │                  │ │    errors     │          │ Bash.Server      │◄┘
+    │                  │ └───────────────┘          │ (localhost:P4)   │
+    │                  │                            └──────────────────┘
+    └──────────────────┘
+
+Startup sequence:
+  1. The proxy + configuration is passed to Isabelle as a `process_policy`;
+     whenever Isabelle invokes Poly/ML, the invocation will thus be wrapped
+     by the proxy.
+  2. Proxy rewrites paths in the command line: ISABELLE_HOME, POLYML_HOME,
+     ML_PLATFORM, HOME (for heap paths in ~/.isabelle/).
+  3. Proxy matches local Isabelle components to remote components by basename,
+     building a path rewrite table for components outside ISABELLE_HOME/HOME.
+  4. Proxy extracts the PIDE channel port (P1) from ISABELLE_PROCESS_OPTIONS.
+  5. Proxy creates a PIDE proxy server on localhost:P3 (random port).
+  6. Proxy starts a Bash.Server on the remote (localhost:P4), capturing its
+     address and password.
+  7. Proxy rewrites ISABELLE_PROCESS_OPTIONS: P1 → P3 (so ML connects to
+     the proxy, not directly to Scala). Copies it to the remote.
+  8. Proxy rewrites ISABELLE_INIT_SESSION: replaces local paths with remote
+     paths (components, ISABELLE_HOME, HOME). Copies it to the remote.
+  9. Proxy queries remote Isabelle env vars and builds the remote command.
+ 10. For heap builds of local sessions (cwd outside ISABELLE_HOME), proxy
+     rsyncs the session source directory to a temp dir on the remote.
+ 11. Proxy starts the PIDE proxy thread (bidirectional message forwarding).
+ 12. Proxy launches poly on the remote via SSH with a reverse tunnel
+     (remote:P3 → local:P3) so ML can reach the PIDE proxy.
+
+PIDE proxy interceptions (Scala→ML):
+  • Prover.options: rewrites bash_process_address/password to point to the
+    remote Bash.Server (P4) instead of the local one (P2).
+  • build_session: rewrites session_directories paths (local → remote) and
+    bash_process_address/password (same as Prover.options).
+
+PIDE proxy interceptions (ML→Scala):
+  • "error" with "No such file": downgraded to "warning" (remote ML cannot
+    verify local file existence for \\<^file> annotations).
+  • "status" with "failed" on text commands: dropped (cosmetic failure from
+    \\<^file> checks; the subsequent "finished" status completes the command).
+
+Post-build:
+  • If ML_Heap.save_child is in the command (heap build), the built heap is
+    rsynced back from remote to the local heap directory, reversing the
+    platform/HOME/ISABELLE_HOME path rewrites. This way, an 'inventory' of
+    remote heaps can be retained on the localhost.
+  • Temp files on the remote are cleaned up.
+
+Usage
+-----
+
+To use the proxy directly, pass it as a Poly/ML wrapper via the existing
+`process_policy` option, e.g.:
+
+    isabelle jedit -l HOL -o 'process_policy=/path/to/ml_proxy.py \\
+      -v --log /tmp/ml_proxy.log \\
+      --host user@remote \\
+      --target-isabelle-home /path/to/isabelle/on/remote \\
+      --target-ml-platform arm64-linux --'
+
+To make this more convenient, however, the `configure-remote.py` script
+should be used to generate the required Isabelle flags. See the documentation
+of `configure-remote.py` for more information.
+"""
+
+import argparse
+import os
+import re
+import shlex
+import socket
+import subprocess
+import sys
+import tempfile
+import threading
+import time
+
+# ---------------------------------------------------------------------------
+# Logging
+# ---------------------------------------------------------------------------
+
+import logging
+
+logger = logging.getLogger("ml_proxy")
+
+def setup_logging(verbose, log_file=None):
+    """Configure the logger. DEBUG for verbose, WARNING otherwise.
+
+    Always logs to stderr. If log_file is set, also logs to that file.
+    """
+    level = logging.DEBUG if verbose else logging.WARNING
+    fmt = logging.Formatter("[ml_proxy] %(asctime)s.%(msecs)03d %(levelname)s %(message)s",
+                           datefmt="%H:%M:%S")
+    logger.setLevel(level)
+    stderr_handler = logging.StreamHandler(sys.stderr)
+    stderr_handler.setFormatter(fmt)
+    logger.addHandler(stderr_handler)
+    if log_file:
+        file_handler = logging.FileHandler(log_file)
+        file_handler.setFormatter(fmt)
+        logger.addHandler(file_handler)
+
+# ---------------------------------------------------------------------------
+# Remote command helpers
+# ---------------------------------------------------------------------------
+
+# SSH multiplexing: first call establishes a master, subsequent calls reuse it.
+_ssh_control_path = None
+
+def ssh_control_flags():
+    """Return SSH flags for connection multiplexing."""
+    global _ssh_control_path
+    if _ssh_control_path is None:
+        _ssh_control_path = f"/tmp/ml_proxy_ssh_{os.getpid()}_%h"
+    return ["-o", "ControlMaster=auto",
+            "-o", f"ControlPath={_ssh_control_path}",
+            "-o", "ControlPersist=60s"]
+
+def ssh_control_cleanup():
+    """Stop the SSH master connection."""
+    if _ssh_control_path:
+        import glob
+        for sock in glob.glob(_ssh_control_path.replace("%h", "*")):
+            subprocess.run(["ssh", "-o", f"ControlPath={sock}", "-O", "exit", "dummy"],
+                           capture_output=True)
+
+
+def ssh_run(host, *cmd_args, capture=True, ssh_flags=None, **kwargs):
+    """Run a command on the remote host via SSH. Returns CompletedProcess or Popen.
+
+    All remote command execution goes through this function.
+    """
+    ssh_cmd = ["ssh"] + ssh_control_flags() + (ssh_flags or []) + [host] + [" ".join(shlex.quote(str(a)) for a in cmd_args)]
+    if capture:
+        return subprocess.run(ssh_cmd, capture_output=True, text=True, **kwargs)
+    return subprocess.Popen(ssh_cmd, **kwargs)
+
+
+def ssh_run_stdout(host, *cmd_args):
+    """Run a command on the remote host, return stdout stripped."""
+    return ssh_run(host, *cmd_args).stdout.strip()
+
+
+def query_getenv(host, isabelle_home, var):
+    """Query an Isabelle environment variable on the remote via `isabelle getenv`."""
+    val = ssh_run_stdout(host, isabelle_home + "/bin/isabelle", "getenv", "-b", var)
+    logger.debug(f"getenv {var} = {val}")
+    return val
+
+
+# ---------------------------------------------------------------------------
+# YXML helpers
+# ---------------------------------------------------------------------------
+
+def yxml_text_leaves(data):
+    """Extract leaf text nodes from YXML-encoded data.
+
+    YXML uses \\x05 (X) and \\x06 (Y) as delimiters instead of < and >.
+    Text between markup tags appears as plain bytes between X/Y sequences.
+    Returns a list of decoded text strings (skipping empty ones).
+    """
+    # Split on markup: \x05\x06...\x05 is an open/close tag pair
+    texts = re.split(rb'\x05[\x05\x06][^\x05]*\x05', data)
+    return [t.decode(errors="replace") for t in texts if t.strip()]
+
+
+def parse_yxml_options(data):
+    """Parse ISABELLE_PROCESS_OPTIONS YXML into (name, type, value) triples."""
+    leaves = yxml_text_leaves(data)
+    # Options come in groups of 3: name, type, value
+    return list(zip(leaves[0::3], leaves[1::3], leaves[2::3]))
+
+
+# ---------------------------------------------------------------------------
+# PIDE protocol helpers
+# ---------------------------------------------------------------------------
+
+def read_pide_message(sock):
+    """Read one PIDE message: header line + chunks. Returns (header, chunks) or None.
+
+    Wire format:
+        "len1,len2,...\\n"   <- ASCII header
+        <chunk1><chunk2>...  <- raw bytes
+    """
+    header = b""
+    while True:
+        b = sock.recv(1)
+        if not b:
+            return None
+        header += b
+        if b == b"\n":
+            break
+    header_line = header.rstrip(b"\n")
+    try:
+        sizes = [int(s) for s in header_line.decode().split(",")]
+    except (ValueError, UnicodeDecodeError):
+        return None
+    chunks = []
+    for size in sizes:
+        data = b""
+        while len(data) < size:
+            part = sock.recv(size - len(data))
+            if not part:
+                return None
+            data += part
+        chunks.append(data)
+    return (header_line, chunks)
+
+
+def write_pide_message(sock, chunks):
+    """Write a PIDE message with recomputed header."""
+    header = ",".join(str(len(c)) for c in chunks) + "\n"
+    sock.sendall(header.encode())
+    for chunk in chunks:
+        sock.sendall(chunk)
+
+
+def inject_proxy_message(sock, function, props=None, body=b""):
+    """Inject a synthetic PIDE protocol message into the ML→Scala stream.
+
+    Args:
+        sock: The Scala-side socket.
+        function: Protocol function name (e.g. "proxy_log", "proxy_status").
+        props: Optional dict of additional properties (beyond "function").
+        body: Optional body bytes.
+    """
+    prop_chunks = [f"function={function}".encode()]
+    for k, v in (props or {}).items():
+        prop_chunks.append(f"{k}={v}".encode())
+    chunks = [b"protocol", str(len(prop_chunks)).encode()] + prop_chunks
+    if body:
+        chunks.append(body if isinstance(body, bytes) else body.encode())
+    write_pide_message(sock, chunks)
+
+
+def rewrite_bash_process_in_chunk(chunk, remote_bash_addr, remote_bash_pw):
+    """Rewrite bash_process_address and password in a YXML chunk.
+
+    Matches the YXML-encoded option fields by regex and replaces the values.
+    Returns (new_chunk, was_modified).
+    """
+    modified = False
+    if remote_bash_addr:
+        m = re.search(
+            rb"bash_process_address([\x05\x06:]+)string([\x05\x06:]+)(127\.0\.0\.1:\d+)",
+            chunk)
+        if m:
+            chunk = chunk.replace(m.group(3), remote_bash_addr.encode(), 1)
+            logger.debug(f"Rewrote bash_process_address: {m.group(3).decode()} -> {remote_bash_addr}")
+            modified = True
+    if remote_bash_pw:
+        m = re.search(
+            rb"(bash_process_password[\x05\x06:]+string[\x05\x06:]+)"
+            rb"([0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})",
+            chunk)
+        if m:
+            chunk = chunk.replace(m.group(2), remote_bash_pw.encode(), 1)
+            modified = True
+    return chunk, modified
+
+
+def rewrite_bash_process_options(chunks, remote_bash_addr, remote_bash_pw):
+    """Rewrite bash_process fields in a Prover.options message.
+    Returns (new_chunks, was_modified).
+    """
+    if not chunks or chunks[0] != b"Prover.options":
+        return chunks, False
+    modified = False
+    new_chunks = [chunks[0]]
+    for chunk in chunks[1:]:
+        chunk, m = rewrite_bash_process_in_chunk(chunk, remote_bash_addr, remote_bash_pw)
+        modified = modified or m
+        new_chunks.append(chunk)
+    return new_chunks, modified
+
+# ---------------------------------------------------------------------------
+# PIDE proxy: sits between Scala and ML, intercepts Prover.options
+# ---------------------------------------------------------------------------
+
+def rewrite_build_session_paths(chunks, path_rewrites,
+                                remote_bash_addr, remote_bash_pw):
+    """Rewrite local paths and bash_process options in a build_session command.
+
+    chunks: [b"build_session", resources_yxml, args_yxml].
+    - resources_yxml: session_directories with local paths → rewritten via path_rewrites.
+    - args_yxml: options including bash_process_address/password → rewritten to remote.
+
+    Returns (new_chunks, was_modified).
+    """
+    if not chunks or chunks[0] != b"build_session":
+        return chunks, False
+    modified = False
+    new_chunks = [chunks[0]]
+    for chunk in chunks[1:]:
+        # Rewrite paths
+        for old, new in path_rewrites:
+            if old in chunk:
+                chunk = chunk.replace(old, new)
+                modified = True
+        # Rewrite bash_process fields
+        chunk, m = rewrite_bash_process_in_chunk(chunk, remote_bash_addr, remote_bash_pw)
+        modified = modified or m
+        new_chunks.append(chunk)
+    if modified:
+        logger.debug("Rewrote build_session protocol command")
+    return new_chunks, modified
+
+
+def _start_remote_stats_monitor(host, pid, stats_dir, target_isabelle_home,
+                                target_ml_home, scala_sock, scala_write_lock):
+    """Start a remote poly process to monitor ML stats, inject as proxy_ml_stats."""
+    def monitor_thread():
+        try:
+            cmd = (
+                f"POLYSTATSDIR={shlex.quote(stats_dir)} "
+                f"{shlex.quote(target_ml_home + '/poly')} -q "
+                f"--use {shlex.quote(target_isabelle_home + '/src/Pure/ML/ml_statistics.ML')} "
+                f"--eval 'ML_Statistics.monitor {pid} 0.5'"
+            )
+            proc = subprocess.Popen(
+                ["ssh"] + ssh_control_flags() + [host, cmd],
+                stdout=subprocess.PIPE, stderr=subprocess.DEVNULL,
+                stdin=subprocess.DEVNULL)
+            while True:
+                line = proc.stdout.readline()
+                if not line:
+                    break
+                line = line.strip()
+                if line:
+                    try:
+                        with scala_write_lock:
+                            inject_proxy_message(scala_sock, "proxy_ml_stats",
+                                                 body=line)
+                    except (ConnectionError, OSError):
+                        break
+        except Exception as e:
+            logger.debug(f"Remote stats monitor error: {e}")
+
+    t = threading.Thread(target=monitor_thread, daemon=True)
+    t.start()
+
+
+def pide_proxy(server_sock, scala_port, scala_password,
+               remote_bash_addr, remote_bash_pw, local_isabelle_home,
+               path_rewrites=None, remote_host=None,
+               stats_rewrite=None, target_isabelle_home=None,
+               target_ml_home=None):
+    """PIDE protocol proxy.
+
+        ML (remote, via SSH tunnel)
+            │
+            ▼
+        proxy_port (this proxy listens here)
+            │  intercepts Prover.options
+            ▼
+        scala_port (Scala's System_Channel)
+    """
+    # Accept ML's connection
+    logger.debug(f"PIDE proxy listening on {server_sock.getsockname()}")
+
+    ml_sock, ml_addr = server_sock.accept()
+    server_sock.close()
+    logger.debug(f"ML connected from {ml_addr}")
+
+    # Read ML's password line
+    ml_pw = b""
+    while True:
+        b = ml_sock.recv(1)
+        if not b or b == b"\n":
+            break
+        ml_pw += b
+
+    # Connect to Scala's System_Channel, forward the password
+    scala_sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    scala_sock.connect(("127.0.0.1", scala_port))
+    scala_sock.sendall(ml_pw + b"\n")
+    logger.debug(f"Connected to Scala on 127.0.0.1:{scala_port}")
+
+    # --- Bidirectional forwarding ---
+
+    # Lock for writes to scala_sock (shared by ML forwarder and heartbeat)
+    scala_write_lock = threading.Lock()
+
+    def forward_scala_to_ml():
+        """Parse Scala→ML messages, intercept Prover.options and build_session."""
+        try:
+            while True:
+                msg = read_pide_message(scala_sock)
+                if msg is None:
+                    logger.debug("Scala disconnected")
+                    try: ml_sock.shutdown(socket.SHUT_WR)
+                    except OSError: pass
+                    break
+                header_line, chunks = msg
+                cmd = chunks[0] if chunks else b""
+
+                # Intercept Prover.options: rewrite bash_process_address/password
+                if cmd == b"Prover.options":
+                    new_chunks, modified = rewrite_bash_process_options(
+                        chunks, remote_bash_addr, remote_bash_pw)
+                    if modified:
+                        write_pide_message(ml_sock, new_chunks)
+                        continue
+
+                # Intercept build_session: rewrite session_directories paths
+                # and bash_process_address/password
+                if cmd == b"build_session" and path_rewrites:
+                    new_chunks, modified = rewrite_build_session_paths(
+                        chunks, path_rewrites,
+                        remote_bash_addr, remote_bash_pw)
+                    if modified:
+                        write_pide_message(ml_sock, new_chunks)
+                        continue
+
+                # Forward unmodified (preserve original header for efficiency)
+                ml_sock.sendall(header_line + b"\n")
+                for chunk in chunks:
+                    ml_sock.sendall(chunk)
+                count_bytes(len(header_line) + 1 + sum(len(c) for c in chunks))
+        except (ConnectionError, OSError) as e:
+            logger.debug(f"Scala->ML error: {e}")
+
+    def forward_ml_to_scala():
+        """Forward ML→Scala messages, downgrading file-not-found errors to warnings.
+
+        ML→Scala message format:
+            chunk[0] = kind ("error", "writeln", "status", ...)
+            chunk[1] = props_length (number of property chunks)
+            chunk[2..2+N-1] = property chunks
+            chunk[2+N..] = body chunks (YXML-encoded text)
+
+        When kind is "error" and the body contains "No such file" with a path
+        under the local ISABELLE_HOME, we change kind to "warning". This
+        suppresses red error markup for remote file-not-found errors (e.g.
+        \\<^file> annotations) while preserving the message as a warning.
+        """
+        local_home_bytes = local_isabelle_home.encode() if local_isabelle_home else b""
+        try:
+            while True:
+                msg = read_pide_message(ml_sock)
+                if msg is None:
+                    logger.debug("ML disconnected")
+                    try: scala_sock.shutdown(socket.SHUT_WR)
+                    except OSError: pass
+                    break
+                header_line, chunks = msg
+                kind = chunks[0] if chunks else b""
+
+                # Downgrade file-not-found errors to warnings with clearer message
+                if (kind == b"error" and
+                        any(b"No such file" in c for c in chunks[2:])):
+                    error_text = b" ".join(chunks[2:])
+                    file_match = re.search(rb'No such file: "([^"]*)"', error_text)
+                    missing = file_match.group(1).decode() if file_match else "?"
+                    logger.debug("File-not-found error chunks:\n" + "\n".join(
+                        f"  chunk[{i}]: {c[:300]!r}" for i, c in enumerate(chunks)))
+                    new_prefix = b"Prover cannot verify existence of file: "
+                    for j in range(2, len(chunks)):
+                        chunks[j] = chunks[j].replace(b"No such file: ", new_prefix)
+                    chunks[0] = b"warning"
+                    logger.info(f"Prover cannot verify existence of file: {missing}")
+                    with scala_write_lock:
+                        write_pide_message(scala_sock, chunks)
+                    continue
+
+                # Drop "failed" status on text commands
+                # (text blocks fail when \<^file> can't check remote paths,
+                #  but the failure is cosmetic — the proof state is unaffected.
+                #  The subsequent "finished" status will mark the command as done.)
+                if (kind == b"status" and
+                        any(b"label=command.text" == c for c in chunks) and
+                        any(b"failed" in c for c in chunks)):
+                    logger.debug("Dropped text command failed status")
+                    continue
+
+                # Suppress ML_statistics and start remote stats monitoring instead
+                if (kind == b"protocol" and stats_rewrite and
+                        any(b"function=ML_statistics" == c for c in chunks)):
+                    # Extract PID from the message
+                    stats_pid = None
+                    for c in chunks:
+                        if c.startswith(b"pid="):
+                            stats_pid = c[4:].decode()
+                    remote_stats_dir, local_stats_dir = stats_rewrite
+                    if stats_pid:
+                        logger.debug(f"Suppressed ML_statistics, starting remote monitor "
+                                     f"(pid={stats_pid}, dir={remote_stats_dir})")
+                        _start_remote_stats_monitor(
+                            remote_host, stats_pid, remote_stats_dir,
+                            target_isabelle_home, target_ml_home,
+                            scala_sock, scala_write_lock)
+                    continue
+
+                # Forward unmodified
+                n = len(header_line) + 1 + sum(len(c) for c in chunks)
+                with scala_write_lock:
+                    scala_sock.sendall(header_line + b"\n")
+                    for chunk in chunks:
+                        scala_sock.sendall(chunk)
+                count_bytes(n)
+        except (ConnectionError, OSError) as e:
+            logger.debug(f"ML->Scala error: {e}")
+
+    # Byte counter for throughput reporting (updated by both forwarding threads)
+    byte_counter = [0]  # mutable via list; protected by GIL for atomic reads
+    byte_counter_lock = threading.Lock()
+
+    def count_bytes(n):
+        with byte_counter_lock:
+            byte_counter[0] += n
+
+    def proxy_heartbeat():
+        """Send periodic proxy_status with throughput to Scala/jEdit."""
+        host_label = remote_host or "unknown"
+        interval = 0.5
+        try:
+            with scala_write_lock:
+                inject_proxy_message(scala_sock, "proxy_log",
+                                     body=f"Proxy connected to {host_label}")
+                inject_proxy_message(scala_sock, "proxy_status",
+                                     props={"host": host_label, "mbps": "0.0"})
+            while True:
+                time.sleep(interval)
+                with byte_counter_lock:
+                    b = byte_counter[0]
+                    byte_counter[0] = 0
+                mbps = b / interval / (1024 * 1024)
+                with scala_write_lock:
+                    inject_proxy_message(scala_sock, "proxy_status",
+                                         props={"host": host_label,
+                                                "mbps": f"{mbps:.1f}"})
+        except (ConnectionError, OSError):
+            pass
+
+    t1 = threading.Thread(target=forward_scala_to_ml, daemon=True)
+    t2 = threading.Thread(target=forward_ml_to_scala, daemon=True)
+    t3 = threading.Thread(target=proxy_heartbeat, daemon=True)
+    t1.start()
+    t2.start()
+    t3.start()
+    t1.join()
+    t2.join()
+    ml_sock.close()
+    scala_sock.close()
+    logger.debug("PIDE proxy stopped")
+
+# ---------------------------------------------------------------------------
+# Path rewriting
+# ---------------------------------------------------------------------------
+
+def rewrite_argv(poly_argv, local_isabelle_home, target_isabelle_home,
+                 local_polyml_home, target_polyml_home,
+                 local_platform, target_platform,
+                 local_home, remote_home):
+    """Rewrite paths in the poly command line.
+
+    Replaces ISABELLE_HOME, POLYML_HOME, ML_PLATFORM, and user HOME
+    (for heap paths in ~/.isabelle/).
+    """
+    new_argv = []
+    for i, arg in enumerate(poly_argv):
+        new_arg = arg
+        if local_isabelle_home:
+            new_arg = new_arg.replace(local_isabelle_home, target_isabelle_home)
+        if local_polyml_home and local_polyml_home != target_polyml_home:
+            new_arg = new_arg.replace(local_polyml_home, target_polyml_home)
+        if local_platform and target_platform and local_platform != target_platform:
+            new_arg = new_arg.replace(local_platform, target_platform)
+        if local_home and remote_home and local_home != remote_home:
+            new_arg = new_arg.replace(local_home, remote_home)
+        if new_arg != arg:
+            logger.debug(f"  REWRITE arg[{i}]")
+        new_argv.append(new_arg)
+    return new_argv
+
+# ---------------------------------------------------------------------------
+# Options file helpers
+# ---------------------------------------------------------------------------
+
+def extract_channel_port(opts_file):
+    """Extract the system_channel_address port from the ISABELLE_PROCESS_OPTIONS file.
+
+    The file is YXML-encoded and contains exactly one 127.0.0.1:PORT entry
+    at this point (the PIDE channel). bash_process_address is set later via
+    the PIDE protocol, not in this file.
+    """
+    data = open(opts_file, "rb").read()
+    match = re.search(rb"127\.0\.0\.1:(\d+)", data)
+    return int(match.group(1)) if match else None
+
+
+def make_proxy_server():
+    """Create a TCP server socket on a free port for the PIDE proxy."""
+    server = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    server.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+    server.bind(("127.0.0.1", 0))
+    server.listen(1)
+    return server
+
+# ---------------------------------------------------------------------------
+# Remote Bash.Server
+# ---------------------------------------------------------------------------
+
+def start_remote_bash_server(host, target_isabelle_home):
+    """Start a Bash.Server on the remote via `isabelle scala -e`.
+
+    A dummy `tput` is placed in PATH to work around Scala 3's `tput cols`
+    crash in non-interactive SSH. Slow on first invocation (~15-30s).
+
+    Returns (address, password, Popen).
+    """
+    ssh_run(host, "sh", "-c",
+            "mkdir -p /tmp/isabelle-proxy-bin && "
+            "printf '#!/bin/sh\\necho 80\\n' > /tmp/isabelle-proxy-bin/tput && "
+            "chmod +x /tmp/isabelle-proxy-bin/tput")
+    logger.debug("Starting remote Bash.Server...")
+    bash_server_cmd = (
+        f"PATH=/tmp/isabelle-proxy-bin:$PATH "
+        f"{shlex.quote(target_isabelle_home + '/bin/isabelle')} scala -e "
+        f"'{{ val server = isabelle.Bash.Server.start(debugging = true); "
+        f"println(\"BASH_SERVER_ADDRESS=\" + server.address); "
+        f"println(\"BASH_SERVER_PASSWORD=\" + server.password); "
+        f"Thread.sleep(Long.MaxValue) }}'"
+    )
+    proc = subprocess.Popen(
+        ["ssh"] + ssh_control_flags() + [host, bash_server_cmd],
+        stdin=subprocess.DEVNULL, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+
+    addr = None
+    pw = None
+    deadline = time.time() + 60
+    while time.time() < deadline:
+        line = proc.stdout.readline().decode().strip()
+        if line.startswith("BASH_SERVER_ADDRESS="):
+            addr = line.split("=", 1)[1]
+            logger.debug(f"Remote Bash.Server address: {addr}")
+        elif line.startswith("BASH_SERVER_PASSWORD="):
+            pw = line.split("=", 1)[1]
+        if addr and pw:
+            break
+        if proc.poll() is not None:
+            err = proc.stderr.read().decode()
+            logger.debug(f"Remote Bash.Server failed: {err}")
+            break
+
+    if not addr or not pw:
+        logger.error("Failed to start remote Bash.Server")
+        sys.exit(1)
+    return addr, pw, proc
+
+
+# ---------------------------------------------------------------------------
+# Main
+# ---------------------------------------------------------------------------
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Isabelle remote ML prover proxy",
+        formatter_class=argparse.RawDescriptionHelpFormatter)
+    parser.add_argument("--target-isabelle-home", required=True,
+                        help="ISABELLE_HOME on the target machine")
+    parser.add_argument("--target-ml-platform", default=None,
+                        help="ML platform on the target (e.g. arm64-linux). "
+                             "If unset, assumed same as local.")
+    parser.add_argument("--host", required=True,
+                        help="SSH host (user@host)")
+    parser.add_argument("-v", "--verbose", action="store_true")
+    parser.add_argument("--log", default=None,
+                        help="Log file (default: stderr)")
+    parser.add_argument("--minheap", default=None,
+                        help="Override poly --minheap (MB)")
+    parser.add_argument("--maxheap", default=None,
+                        help="Override poly --maxheap (MB)")
+    parser.add_argument("--gcthreads", default=None,
+                        help="Override poly --gcthreads")
+    parser.add_argument("-H", dest="initial_heap", default=None,
+                        help="Override poly -H initial heap size (MB)")
+    parser.add_argument("--gcpercent", default=None,
+                        help="Override poly --gcpercent (1-99)")
+    args, poly_argv = parser.parse_known_args()
+
+    setup_logging(args.verbose, args.log)
+
+    if poly_argv and poly_argv[0] == "--":
+        poly_argv = poly_argv[1:]
+    if not poly_argv:
+        logger.error("No poly command provided")
+        sys.exit(1)
+
+    # Override poly runtime options
+    for opt, val in [("--minheap", args.minheap),
+                     ("--maxheap", args.maxheap),
+                     ("--gcthreads", args.gcthreads),
+                     ("-H", args.initial_heap),
+                     ("--gcpercent", args.gcpercent)]:
+        if val is not None:
+            # Replace existing or append
+            replaced = False
+            for i, a in enumerate(poly_argv):
+                if a == opt and i + 1 < len(poly_argv):
+                    poly_argv[i + 1] = val
+                    replaced = True
+                    break
+            if not replaced:
+                # Insert after the poly binary (argv[0])
+                poly_argv[1:1] = [opt, val]
+            logger.debug(f"Override: {opt} {val}")
+
+    target_isabelle_home = args.target_isabelle_home
+    host = args.host
+    local_isabelle_home = os.environ.get("ISABELLE_HOME", "")
+    local_polyml_home = os.environ.get("POLYML_HOME", "")
+
+    # Derive local ML_PLATFORM from the poly binary path in the command line.
+    # The path looks like: .../contrib/polyml-X.Y.Z/PLATFORM/poly
+    # This is more reliable than reading heap dirs, because ML_system_64
+    # can change the platform at runtime.
+    local_platform = None
+    poly_path = poly_argv[0] if poly_argv else ""
+    poly_match = re.search(r"/polyml-[\d.]+-?\d*/([^/]+)/poly", poly_path)
+    if poly_match:
+        local_platform = poly_match.group(1)
+    target_platform = args.target_ml_platform or local_platform
+    logger.debug(f"Local ML_PLATFORM (from command): {local_platform}")
+    logger.debug(f"Target ML_PLATFORM: {target_platform}")
+
+    local_home = os.path.expanduser("~")
+
+    # Step 1: Query all remote environment in one SSH call
+    env_dump = ssh_run_stdout(host,
+        target_isabelle_home + "/bin/isabelle", "env", "bash", "-c",
+        "echo __HOME__=$HOME; env | grep -E '^(ISABELLE_|ML_|POLYML_)' | sort")
+    if not env_dump:
+        logger.error("Failed to query remote environment")
+        sys.exit(1)
+
+    # Parse into dict; resolve symlink normalization
+    raw_env = {}
+    remote_home = None
+    for line in env_dump.splitlines():
+        if line.startswith("__HOME__="):
+            remote_home = line.split("=", 1)[1]
+        elif "=" in line:
+            k, v = line.split("=", 1)
+            raw_env[k] = v
+
+    if not remote_home:
+        logger.error("Failed to query remote HOME")
+        sys.exit(1)
+
+    resolved_isabelle_home = raw_env.get("ISABELLE_HOME", target_isabelle_home)
+    target_polyml_home = raw_env.get("POLYML_HOME", "")
+    if not target_polyml_home:
+        logger.error("Failed to query POLYML_HOME")
+        sys.exit(1)
+
+    # Normalize resolved symlinks
+    target_env_vars = {}
+    for k, v in raw_env.items():
+        if resolved_isabelle_home and resolved_isabelle_home != target_isabelle_home:
+            v = v.replace(resolved_isabelle_home, target_isabelle_home)
+        target_env_vars[k] = v
+    if resolved_isabelle_home and resolved_isabelle_home != target_isabelle_home:
+        target_polyml_home = target_polyml_home.replace(
+            resolved_isabelle_home, target_isabelle_home)
+    target_env_vars.update({
+        "ISABELLE_HOME": target_isabelle_home,
+        "ML_HOME": target_polyml_home + "/" + target_platform,
+        "ML_PLATFORM": target_platform,
+        "POLYML_HOME": target_polyml_home,
+    })
+
+    remote_components_str = target_env_vars.get("ISABELLE_COMPONENTS", "")
+
+    logger.debug(f"Local  ISABELLE_HOME: {local_isabelle_home}")
+    logger.debug(f"Target ISABELLE_HOME: {target_isabelle_home}")
+    logger.debug(f"Local  HOME: {local_home}")
+    logger.debug(f"Remote HOME: {remote_home}")
+    logger.debug(f"POLYML_HOME: {target_polyml_home}")
+    logger.debug(f"Forwarding {len(target_env_vars)} env vars")
+
+    # Step 2: Rewrite poly command line
+    # The command line contains local paths for the poly binary and session heaps.
+    # We replace ISABELLE_HOME, POLYML_HOME, ML_PLATFORM, and user HOME.
+    new_argv = rewrite_argv(poly_argv, local_isabelle_home, target_isabelle_home,
+                            local_polyml_home, target_polyml_home,
+                            local_platform, target_platform,
+                            local_home, remote_home)
+    logger.debug(f"Command: {new_argv[0]}")
+
+    # Step 2b: Build component path rewrites.
+    local_components = os.environ.get("ISABELLE_COMPONENTS", "").split(":")
+    remote_components = remote_components_str.split(":") if remote_components_str else []
+    remote_comp_by_name = {os.path.basename(c): c for c in remote_components if c}
+    component_rewrites = []  # [(local_path, remote_path)]
+    for lc in local_components:
+        logger.debug(f"Processing local component: {lc}")
+        if not lc:
+            continue
+        if local_isabelle_home and lc.startswith(local_isabelle_home):
+            logger.debug(f"-> Skip (in local_isabelle_home: {local_isabelle_home})")
+            continue
+        name = os.path.basename(lc)
+        rc = remote_comp_by_name.get(name)
+        if rc:
+            component_rewrites.append((lc, rc))
+            logger.debug(f"Component rewrite: {lc} -> {rc}")
+        else:
+            logger.warning(f"Local component {name} ({lc}) has no match on remote")
+
+
+    # Step 3: Extract PIDE channel info from options file
+    local_opts = os.environ.get("ISABELLE_PROCESS_OPTIONS", "")
+    local_init = os.environ.get("ISABELLE_INIT_SESSION", "")
+    opts_data = open(local_opts, "rb").read() if local_opts else b""
+
+    scala_port = extract_channel_port(local_opts) if local_opts else None
+    if not scala_port:
+        logger.error("Cannot extract PIDE port from options file")
+        sys.exit(1)
+    logger.debug(f"Scala PIDE port: {scala_port}")
+
+    pw_match = re.search(
+        rb"system_channel_password[\x05\x06:]+string[\x05\x06:]+([0-9a-f-]{36})", opts_data)
+    scala_password = pw_match.group(1).decode() if pw_match else ""
+
+    # Step 4: Pick a port for the PIDE proxy
+    proxy_server = make_proxy_server()
+    proxy_port = proxy_server.getsockname()[1]
+    logger.debug(f"PIDE proxy port: {proxy_port}")
+
+    # Step 5: Start remote Bash.Server (in background — result needed only for PIDE proxy)
+    bash_server_future = {}
+    def _start_bash_server():
+        bash_server_future["result"] = start_remote_bash_server(host, target_isabelle_home)
+    bash_server_thread = threading.Thread(target=_start_bash_server, daemon=True)
+    bash_server_thread.start()
+
+    # Step 6: Rewrite options file and copy to remote
+    #   - system_channel_address: Scala's port → proxy port
+    #   (bash_process_address is rewritten later via PIDE interception)
+    opts_modified = opts_data.replace(
+        f"127.0.0.1:{scala_port}".encode(),
+        f"127.0.0.1:{proxy_port}".encode())
+    logger.debug(f"ISABELLE_PROCESS_OPTIONS ({len(opts_modified)} bytes, "
+                 f"channel rewritten {scala_port} -> {proxy_port})")
+    # Dump options in human-readable form
+    for name, typ, val in parse_yxml_options(opts_modified):
+        logger.debug(f"  opt: {name} : {typ} = {val}")
+    tmp_opts = tempfile.NamedTemporaryFile(delete=False, prefix="isabelle-proxy-opts-")
+    tmp_opts.write(opts_modified)
+    tmp_opts.close()
+
+    init_modified = None
+    tmp_init = None
+    if local_init:
+        init_data = open(local_init, "rb").read()
+        logger.debug(f"ISABELLE_INIT_SESSION ({len(init_data)} bytes)")
+        init_modified = init_data
+        for lc, rc in component_rewrites:
+            init_modified = init_modified.replace(lc.encode(), rc.encode())
+        if local_isabelle_home:
+            init_modified = init_modified.replace(
+                local_isabelle_home.encode(), target_isabelle_home.encode())
+        if local_home and remote_home and local_home != remote_home:
+            init_modified = init_modified.replace(
+                local_home.encode(), remote_home.encode())
+        tmp_init = tempfile.NamedTemporaryFile(delete=False, prefix="isabelle-proxy-init-")
+        tmp_init.write(init_modified)
+        tmp_init.close()
+
+    # Create remote tmp dir and copy both files in one batch
+    remote_tmp = ssh_run_stdout(host, "mktemp", "-d", "/tmp/isabelle-proxy-XXXXXX")
+    local_files = [tmp_opts.name]
+    if tmp_init:
+        local_files.append(tmp_init.name)
+    subprocess.run(
+        ["rsync", "-az", "-e", "ssh " + " ".join(ssh_control_flags())]
+        + local_files + [f"{host}:{remote_tmp}/"],
+        check=True)
+    remote_opts = f"{remote_tmp}/{os.path.basename(tmp_opts.name)}"
+    remote_init = f"{remote_tmp}/{os.path.basename(tmp_init.name)}" if tmp_init else ""
+    logger.debug(f"Copied {len(local_files)} files to {host}:{remote_tmp}/")
+    os.unlink(tmp_opts.name)
+    if tmp_init:
+        os.unlink(tmp_init.name)
+
+    # Step 8: Build remote command
+    env_parts = [
+        f"ISABELLE_PROCESS_OPTIONS={shlex.quote(remote_opts)}",
+        f"ISABELLE_INIT_SESSION={shlex.quote(remote_init)}",
+        f"ISABELLE_TMP={shlex.quote(remote_tmp)}",
+        f"POLYSTATSDIR={shlex.quote(remote_tmp)}",
+    ]
+    for k, v in target_env_vars.items():
+        env_parts.append(f"{k}={shlex.quote(v)}")
+    remote_cmd = " ".join(env_parts) + " " + " ".join(shlex.quote(a) for a in new_argv)
+
+    # Rewrite the working directory for the remote.
+    # Build processes (e.g. building HOL) use cwd=session_source_dir which is
+    # under ISABELLE_HOME — we translate that to the remote equivalent.
+    # Interactive sessions (jEdit) use the user's project directory as cwd,
+    # which typically doesn't exist on the remote. Since all paths in the
+    # poly command line are absolute, we can safely skip the cd in that case.
+    #
+    # Special case: building a heap for a local session (cwd outside ISABELLE_HOME).
+    # The remote ML process reads theory files from disk, so we rsync the local
+    # directory to a temp dir on the remote, cd into it, and add a path rewrite
+    # so that session_directories in build_session point there.
+    local_cwd = os.getcwd()
+    is_heap_build = any("ML_Heap.save_child" in a for a in poly_argv)
+    remote_src_dir = ""  # set if we rsync sources to remote
+
+    if local_isabelle_home and local_cwd.startswith(local_isabelle_home):
+        # Build inside ISABELLE_HOME (e.g. HOL): translate directly
+        remote_cwd = local_cwd.replace(local_isabelle_home, target_isabelle_home)
+        remote_cmd = f"cd {shlex.quote(remote_cwd)} && " + remote_cmd
+        logger.debug(f"Remote cwd: {remote_cwd}")
+    elif is_heap_build:
+        # Build outside ISABELLE_HOME (e.g. user session): rsync sources to remote
+        remote_src_dir = ssh_run_stdout(host, "mktemp", "-d", "/tmp/isabelle-proxy-src-XXXXXX")
+        logger.info(f"Syncing {local_cwd}/ to {host}:{remote_src_dir}/")
+        subprocess.run(
+            ["rsync", "--copy-links", "-az", "-e", "ssh " + " ".join(ssh_control_flags()),
+             "--chmod=a-w", local_cwd + "/", f"{host}:{remote_src_dir}/"],
+            check=True)
+        remote_cmd = f"cd {shlex.quote(remote_src_dir)} && " + remote_cmd
+        logger.debug(f"Remote cwd (synced): {remote_src_dir}")
+
+    # Build path rewrite table for PIDE protocol interception (build_session).
+    # Order matters: more specific (longer) prefixes first to avoid partial matches.
+    path_rewrites = []
+    if remote_src_dir:
+        # Rewrite local project path to the remote temp dir.
+        # Must come before other rewrites to avoid partial match.
+        path_rewrites.append((local_cwd.encode(), remote_src_dir.encode()))
+    for lc, rc in component_rewrites:
+        # Skip components already covered by the rsync cwd rewrite
+        if remote_src_dir and lc.startswith(local_cwd):
+            continue
+        path_rewrites.append((lc.encode(), rc.encode()))
+    if local_isabelle_home and target_isabelle_home and local_isabelle_home != target_isabelle_home:
+        path_rewrites.append((local_isabelle_home.encode(), target_isabelle_home.encode()))
+    if local_home and remote_home and local_home != remote_home:
+        path_rewrites.append((local_home.encode(), remote_home.encode()))
+
+    # Stats rewrite: (remote_path, local_path) for POLYSTATSDIR
+    local_polystatsdir = os.environ.get("POLYSTATSDIR", "")
+    stats_rewrite = (remote_tmp, local_polystatsdir) if local_polystatsdir else None
+    if stats_rewrite:
+        logger.debug(f"Stats rewrite: {remote_tmp} -> {local_polystatsdir}")
+
+    # Step 9: Wait for Bash.Server, then start PIDE proxy
+    bash_server_thread.join()
+    remote_bash_addr, remote_bash_pw, bash_server_proc = bash_server_future["result"]
+    pide_thread = threading.Thread(
+        target=pide_proxy,
+        args=(proxy_server, scala_port, scala_password,
+              remote_bash_addr, remote_bash_pw, local_isabelle_home,
+              path_rewrites, host, stats_rewrite,
+              target_isabelle_home, target_env_vars.get("ML_HOME", "")),
+        daemon=True)
+    pide_thread.start()
+
+    # Step 10: Launch remote poly via SSH with reverse tunnel
+    ssh_cmd = [
+        "ssh",
+        "-C",
+        "-o", "ServerAliveInterval=15",
+        "-o", "ServerAliveCountMax=86400",
+        "-R", f"{proxy_port}:127.0.0.1:{proxy_port}",
+    ] + ssh_control_flags() + [
+        host,
+        remote_cmd
+    ]
+    logger.debug(f"SSH tunnel: remote:{proxy_port} -> local:{proxy_port} (PIDE proxy)")
+    logger.debug(f"Remote command (first 500 chars): {remote_cmd[:500]}")
+    logger.debug(f"Remote command (last 500 chars): ...{remote_cmd[-500:]}")
+    if args.log:
+        cmd_dump = os.path.splitext(args.log)[0] + "_cmd.txt"
+        with open(cmd_dump, "w") as f:
+            f.write(remote_cmd)
+        logger.debug(f"Full remote command dumped to {cmd_dump}")
+
+    proc = subprocess.Popen(ssh_cmd, stdin=sys.stdin, stdout=sys.stdout, stderr=sys.stderr)
+
+    try:
+        rc = proc.wait()
+    except KeyboardInterrupt:
+        proc.terminate()
+        rc = proc.wait()
+
+    logger.debug(f"Process exited with rc={rc}")
+
+    # If this was a heap build (ML_Heap.save_child in command), copy the
+    # built heap back from the remote to the local expected path.
+    if rc == 0:
+        copy_heap_back(host, new_argv, target_platform, local_platform,
+                       remote_home, local_home, target_isabelle_home, local_isabelle_home)
+
+    # Cleanup
+    cleanup_remote(host, bash_server_proc, remote_opts, remote_init,
+                   remote_tmp, remote_src_dir)
+    ssh_control_cleanup()
+
+    sys.exit(rc)
+
+
+def copy_heap_back(host, new_argv, target_platform, local_platform,
+                   remote_home, local_home, target_isabelle_home, local_isabelle_home):
+    """After a successful heap build, rsync the heap from remote to local.
+
+    Reverses the platform/HOME/ISABELLE_HOME path rewrites to determine
+    the local destination path.
+    """
+    for arg in new_argv:
+        m = re.search(r'ML_Heap\.save_child "([^"]+)"', arg)
+        if m:
+            remote_heap = m.group(1)
+            local_heap = remote_heap
+            if target_platform and local_platform and target_platform != local_platform:
+                local_heap = local_heap.replace(target_platform, local_platform)
+            if remote_home and local_home and remote_home != local_home:
+                local_heap = local_heap.replace(remote_home, local_home)
+            if target_isabelle_home and local_isabelle_home:
+                local_heap = local_heap.replace(target_isabelle_home, local_isabelle_home)
+            local_heap_dir = os.path.dirname(local_heap)
+            os.makedirs(local_heap_dir, exist_ok=True)
+            logger.info(f"Copying built heap from remote: {remote_heap} -> {local_heap}")
+            try:
+                t0 = time.time()
+                subprocess.run(
+                    ["rsync", "-az", "-e", "ssh " + " ".join(ssh_control_flags()),
+                     f"{host}:{remote_heap}", local_heap],
+                    check=True, timeout=300)
+                elapsed = time.time() - t0
+                size = os.path.getsize(local_heap)
+                logger.info(f"Heap copied successfully ({size} bytes, {elapsed:.1f}s)")
+            except (subprocess.CalledProcessError, subprocess.TimeoutExpired) as e:
+                logger.warning(f"Failed to copy heap: {e}")
+
+
+def cleanup_remote(host, bash_server_proc, remote_opts, remote_init,
+                   remote_tmp, remote_src_dir):
+    """Terminate remote Bash.Server and remove temp files."""
+    if bash_server_proc and bash_server_proc.poll() is None:
+        bash_server_proc.terminate()
+        logger.debug("Stopped remote Bash.Server")
+
+    parts = []
+    if remote_opts: parts.append(f"rm -f {shlex.quote(remote_opts)}")
+    if remote_init: parts.append(f"rm -f {shlex.quote(remote_init)}")
+    if remote_tmp: parts.append(f"rm -rf {shlex.quote(remote_tmp)}")
+    if remote_src_dir: parts.append(f"rm -rf {shlex.quote(remote_src_dir)}")
+    if parts:
+        try:
+            ssh_run(host, "; ".join(parts), timeout=5)
+        except Exception:
+            pass
+
+
+if __name__ == "__main__":
+    main()

--- a/ip/setup_aarch64_ubuntu.sh
+++ b/ip/setup_aarch64_ubuntu.sh
@@ -1,0 +1,56 @@
+#!/usr/bin/env bash
+# Setup Isabelle 2025-2 on a remote aarch64 Ubuntu host.
+# Usage: setup_aarch64_ubuntu.sh user@host [install_dir] [64|32] [skip_build]
+set -euo pipefail
+
+REMOTE="${1:?Usage: $0 user@host [install_dir] [64|32] [skip_build]}"
+URL="https://isabelle.in.tum.de/dist/Isabelle2025-2_linux_arm.tar.gz"
+TARBALL="Isabelle2025-2_linux_arm.tar.gz"
+INSTALL_DIR="${2:-Isabelle2025-2}"
+BITS="${3:-64}"
+SKIP_BUILD="${4:-}"
+
+echo "=== Setting up Isabelle on $REMOTE (${BITS}-bit) ==="
+
+ssh "$REMOTE" bash -s "$URL" "$TARBALL" "$INSTALL_DIR" "$BITS" "$SKIP_BUILD" <<'REMOTE_SCRIPT'
+set -euo pipefail
+URL="$1"; TARBALL="$2"; INSTALL_DIR="$3"; BITS="$4"; SKIP_BUILD="$5"
+cd ~
+
+# fontconfig is needed by Isabelle's Java/Scala layer
+sudo apt-get update -qq && sudo apt-get install -y -qq fontconfig
+
+if [ -d "$INSTALL_DIR" ]; then
+  echo "Already installed: ~/$INSTALL_DIR"
+else
+  echo "Downloading $URL ..."
+  curl -fSL -o "$TARBALL" "$URL"
+  echo "Unpacking ..."
+  tar xzf "$TARBALL"
+  rm "$TARBALL"
+  echo "Installed: ~/$INSTALL_DIR"
+fi
+
+# AFP Word_Lib
+AFP_URL="https://www.isa-afp.org/release/afp-Word_Lib-2026-02-06.tar.gz"
+AFP_DIR="$HOME/.isabelle/Isabelle2025-2/AFP"
+if [ -d "$AFP_DIR/Word_Lib" ]; then
+  echo "AFP Word_Lib already installed"
+else
+  echo "Downloading AFP Word_Lib ..."
+  mkdir -p "$AFP_DIR"
+  curl -fSL "$AFP_URL" | tar xz -C "$AFP_DIR"
+  ~/"$INSTALL_DIR"/bin/isabelle components -u "$AFP_DIR/Word_Lib"
+  echo "Registered AFP Word_Lib"
+fi
+
+ML_64_OPT=""
+if [ "$BITS" = "64" ]; then ML_64_OPT="-o ML_system_64=true"; fi
+if [ -z "$SKIP_BUILD" ]; then
+  echo "Building Pure + HOL (${BITS}-bit) ..."
+  ~/"$INSTALL_DIR"/bin/isabelle build -b $ML_64_OPT HOL
+  echo "Done."
+else
+  echo "Skipping heap build (--copy-from-local)"
+fi
+REMOTE_SCRIPT

--- a/ip/setup_al2.sh
+++ b/ip/setup_al2.sh
@@ -1,0 +1,118 @@
+#!/bin/bash
+# Setup Isabelle 2025-2 on a remote Amazon Linux 2 host (aarch64 or x86_64).
+# Builds Poly/ML from source (no pre-built binary available for Amazon Linux 2).
+# Usage: setup_al2.sh user@host [install_dir] [64|32] [skip_build]
+set -euo pipefail
+
+REMOTE="${1:?Usage: $0 user@host [install_dir] [64|32] [skip_build]}"
+INSTALL_DIR="${2:-Isabelle2025-2}"
+BITS="${3:-64}"
+SKIP_BUILD="${4:-}"
+
+# Detect remote architecture and pick the right tarball
+REMOTE_ARCH=$(ssh "$REMOTE" uname -m)
+case "$REMOTE_ARCH" in
+  aarch64)
+    URL="https://isabelle.in.tum.de/dist/Isabelle2025-2_linux_arm.tar.gz"
+    TARBALL="Isabelle2025-2_linux_arm.tar.gz"
+    ;;
+  x86_64)
+    URL="https://isabelle.in.tum.de/dist/Isabelle2025-2_linux.tar.gz"
+    TARBALL="Isabelle2025-2_linux.tar.gz"
+    ;;
+  *)
+    echo "Unsupported architecture: $REMOTE_ARCH" >&2; exit 1
+    ;;
+esac
+
+echo "=== Setting up Isabelle on $REMOTE (Amazon Linux 2, $REMOTE_ARCH, ${BITS}-bit) ==="
+
+ssh "$REMOTE" bash -s "$URL" "$TARBALL" "$INSTALL_DIR" "$BITS" "$SKIP_BUILD" <<'REMOTE_SCRIPT'
+set -euo pipefail
+URL="$1"; TARBALL="$2"; INSTALL_DIR="$3"; BITS="$4"; SKIP_BUILD="${5:-}"
+cd ~
+
+ISABELLE_HOME="$HOME/$INSTALL_DIR"
+NPROC=$(nproc)
+
+# Dependencies for building Poly/ML and running Isabelle
+sudo yum install -y gcc gcc-c++ make gmp-devel fontconfig
+
+if [ -d "$INSTALL_DIR" ]; then
+  echo "Already installed: ~/$INSTALL_DIR"
+else
+  echo "Downloading $URL ..."
+  curl -fSL -o "$TARBALL" "$URL"
+  echo "Unpacking ..."
+  tar xzf "$TARBALL"
+  rm "$TARBALL"
+  echo "Installed: ~/$INSTALL_DIR"
+fi
+
+# AFP Word_Lib
+AFP_URL="https://www.isa-afp.org/release/afp-Word_Lib-2026-02-06.tar.gz"
+AFP_DIR="$HOME/.isabelle/Isabelle2025-2/AFP"
+if [ -d "$AFP_DIR/Word_Lib" ]; then
+  echo "AFP Word_Lib already installed"
+else
+  echo "Downloading AFP Word_Lib ..."
+  mkdir -p "$AFP_DIR"
+  curl -fSL "$AFP_URL" | tar xz -C "$AFP_DIR"
+  "$ISABELLE_HOME/bin/isabelle" components -u "$AFP_DIR/Word_Lib"
+  echo "Registered AFP Word_Lib"
+fi
+
+if [ -z "$SKIP_BUILD" ]; then
+
+POLYML_SRC=$ISABELLE_HOME/contrib/polyml-5.9.2-2/src
+POLYML_DIR=$ISABELLE_HOME/contrib/polyml-5.9.2-2
+ARCH=$(uname -m)
+
+# Map uname -m to Isabelle platform names
+case "$ARCH" in
+  aarch64) PLAT64="arm64-linux"; PLAT32="arm64_32-linux" ;;
+  x86_64)  PLAT64="x86_64-linux"; PLAT32="x86_64_32-linux" ;;
+  *)       echo "Unsupported architecture: $ARCH" >&2; exit 1 ;;
+esac
+
+if [ "$BITS" = "32" ] || [ "$BITS" = "both" ]; then
+  echo "=== Building Poly/ML 32-in-64 ($PLAT32) ==="
+  cd "$POLYML_SRC"
+  make distclean 2>/dev/null || true
+  ./configure --prefix="$POLYML_SRC/target32" \
+      --disable-shared --enable-intinf-as-int --with-gmp --enable-compact32bit
+  make -j "$NPROC"
+  make install
+  mkdir -p "$POLYML_DIR/$PLAT32"
+  cp target32/bin/poly "$POLYML_DIR/$PLAT32/poly"
+  cp target32/bin/polyimport "$POLYML_DIR/$PLAT32/polyimport" 2>/dev/null || true
+fi
+
+if [ "$BITS" = "64" ] || [ "$BITS" = "both" ]; then
+  echo "=== Building Poly/ML native 64-bit ($PLAT64) ==="
+  cd "$POLYML_SRC"
+  make distclean 2>/dev/null || true
+  ./configure --prefix="$POLYML_SRC/target64" \
+      --disable-shared --enable-intinf-as-int --with-gmp
+  make -j "$NPROC"
+  make install
+  mkdir -p "$POLYML_DIR/$PLAT64"
+  cp target64/bin/poly "$POLYML_DIR/$PLAT64/poly"
+  cp target64/bin/polyimport "$POLYML_DIR/$PLAT64/polyimport" 2>/dev/null || true
+fi
+
+ML_64_OPT=""
+if [ "$BITS" = "64" ]; then
+  ML_64_OPT="-o ML_system_64=true"
+fi
+
+echo "=== Building heaps (Pure + HOL, ${BITS}-bit) ==="
+"$ISABELLE_HOME/bin/isabelle" build -b $ML_64_OPT Pure
+"$ISABELLE_HOME/bin/isabelle" build -b $ML_64_OPT HOL
+
+else
+  echo "Skipping Poly/ML build and heap build (--copy-from-local)"
+fi
+
+echo "=== Done ==="
+REMOTE_SCRIPT


### PR DESCRIPTION
Run the Isabelle ML prover (Poly/ML) on a remote machine while keeping Isabelle/jEdit and Scala/PIDE local. No Isabelle source changes required.

Components:
- ml_proxy.py: PIDE protocol proxy interposing between local Scala and remote Poly/ML. Handles path rewriting, Bash.Server forwarding, and ML statistics monitoring.
- configure-remote.py: Setup/configuration tool. Installs Isabelle on the remote, syncs poly binaries and heaps, generates jEdit flags.
- proxy_plugin: jEdit plugin showing remote host throughput in the status bar and forwarding remote ML heap statistics to the built-in Monitor panel.
- setup_aarch64_{ubuntu,al2}.sh: Remote Isabelle installation scripts.
