### PR TITLE
Fix inclusive range semantics at max-word boundaries

### DIFF
--- a/Micro_Rust_Std_Lib/StdLib_Range.thy
+++ b/Micro_Rust_Std_Lib/StdLib_Range.thy
@@ -10,7 +10,8 @@ begin
 definition is_empty_contract :: \<open>'a::{ord} range \<Rightarrow> ('machine::{sepalg}, bool, 'abort) function_contract\<close> where
   [crush_contracts]: \<open>is_empty_contract r \<equiv>
     let pre  = \<top>;
-        post = \<lambda>res. \<langle>res \<longleftrightarrow> \<not>start r < end r\<rangle>
+        post = \<lambda>res. \<langle>res \<longleftrightarrow>
+          (if end_inclusive r then start r > end r else \<not>start r < end r)\<rangle>
      in make_function_contract pre post\<close>
 ucincl_auto is_empty_contract
 
@@ -21,7 +22,8 @@ by (contract f: is_empty_def contract: is_empty_contract_def) crush_base
 definition contains_contract :: \<open>'a::{ord} range \<Rightarrow> 'a \<Rightarrow> ('machine::{sepalg}, bool, 'abort) function_contract\<close> where
   [crush_contracts]: \<open>contains_contract r e \<equiv>
     let pre  = \<top>;
-        post = \<lambda>res. \<langle>res \<longleftrightarrow> start r \<le> e \<and> e < end r\<rangle>
+        post = \<lambda>res. \<langle>res \<longleftrightarrow>
+          (if end_inclusive r then start r \<le> e \<and> e \<le> end r else start r \<le> e \<and> e < end r)\<rangle>
      in make_function_contract pre post\<close>
 ucincl_auto contains_contract
 
@@ -30,7 +32,9 @@ lemma contains_spec [crush_specs]:
 by (contract f: contains_def contract: contains_contract_def) crush_base
 
 lemma range_into_list_make_range [micro_rust_simps]:
-  shows \<open>range_into_list (make_range s e) = list.map word_of_nat [unat s..<unat e]\<close>
+  shows \<open>range_into_list (make_range s e incl) =
+    (if incl then list.map word_of_nat [unat s..<Suc (unat e)]
+     else list.map word_of_nat [unat s..<unat e])\<close>
 by (clarsimp simp add: range_into_list_def)
 
 (*<*)

--- a/Shallow_Micro_Rust/Micro_Rust_Shallow_Embedding_Tests.thy
+++ b/Shallow_Micro_Rust/Micro_Rust_Shallow_Embedding_Tests.thy
@@ -1165,6 +1165,28 @@ term \<open>\<lbrakk> x..=y \<rbrakk>\<close>
 term \<open>\<lbrakk> let rng = x ..= x+y; rng.is_empty() \<rbrakk>\<close>
 end
 
+subsubsection\<open>Inclusive Range Boundary Behavior\<close>
+
+value[simp]\<open>\<lbrakk>
+  let int_max = \<llangle>255 :: 8 word\<rrangle>;
+  let inclusive = int_max ..= int_max;
+  assert!(!(inclusive.is_empty()));
+  assert!(inclusive.contains(int_max));
+  let exclusive = int_max .. int_max;
+  assert!(exclusive.is_empty());
+  ()
+\<rbrakk>\<close>
+
+value[simp]\<open>\<lbrakk>
+  let mut count = \<llangle>0 :: 8 word\<rrangle>;
+  let int_max = \<llangle>255 :: 8 word\<rrangle>;
+  for i in int_max ..= int_max {
+    count += \<llangle>1 :: 8 word\<rrangle>;
+  };
+  assert!(*count == \<llangle>1 :: 8 word\<rrangle>);
+  ()
+\<rbrakk>\<close>
+
 subsubsection\<open>Range in For Loops\<close>
 
 text\<open>See For Loop with Range subsection above.\<close>

--- a/Shallow_Separation_Logic/Weakest_Precondition.thy
+++ b/Shallow_Separation_Logic/Weakest_Precondition.thy
@@ -670,7 +670,7 @@ lemma wp_funliteral:
 
 lemma wp_range_new [micro_rust_wp_simps]:
   assumes \<open>\<And>r. ucincl (\<phi> r)\<close>
-    shows \<open>\<W>\<P> \<Gamma> (\<langle>\<up>b\<dots>\<up>e\<rangle>) \<phi> \<rho> \<theta> = \<phi> (make_range b e)\<close>
+    shows \<open>\<W>\<P> \<Gamma> (\<langle>\<up>b\<dots>\<up>e\<rangle>) \<phi> \<rho> \<theta> = \<phi> (make_range b e False)\<close>
 using assms by (clarsimp simp add: range_new_def wp_funliteral)
 
 lemma wp_op_eq [micro_rust_wp_simps]:


### PR DESCRIPTION
Replace the `..=` encoding via `end + 1` with an explicit `end_inclusive` flag on `range`. This fixes overflow-driven misbehavior for inclusive ranges (especially `MAX..=MAX`) and aligns `is_empty`, `contains`, iterator/list conversion, slice indexing contracts, and WP lemmas with Rust semantics. Add shallow embedding regression tests for inclusive boundary behavior while preserving existing `..` behavior.

Closes #53.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
