### PR TITLE
Add :suggest-name action for naming lemmas, theorems, and definitions

### DIFF
--- a/isabelle-assistant/README.md
+++ b/isabelle-assistant/README.md
@@ -130,6 +130,7 @@ Right-click in any `.thy` file to access the **Isabelle Assistant** submenu. Ava
 | **Generation** | Doc Comment | Generate documentation comments | |
 | | Intro/Elim Rules | Generate introduction and elimination rules | |
 | | Test Cases | Generate QuickCheck-style test cases | |
+| | Suggest Name | Suggest descriptive names for definitions/lemmas/theorems | |
 | | Suggest Tactic | Generate Eisbach methods | |
 | **Analysis** | Analyze Patterns | Analyze proof patterns and suggest improvements | |
 | | Find Theorems | Search for matching theorems | ✓ |
@@ -173,6 +174,7 @@ Type `:help` in the chat to see all commands. Commands are prefixed with `:`.
 | `:explain-error` | Explain error at cursor |
 | `:explain-counterexample` | Explain counterexample |
 | `:suggest [target]` | Suggest proof steps |
+| `:suggest-name` | Suggest descriptive names for definitions/lemmas/theorems |
 | `:suggest-strategy` | Recommend proof strategy |
 | `:suggest-tactic` | Generate Eisbach method |
 | `:prove` | Autonomous proof search |

--- a/isabelle-assistant/prompts/suggest_name.md
+++ b/isabelle-assistant/prompts/suggest_name.md
@@ -1,0 +1,45 @@
+<!-- Variables: command (required), command_type (required), current_name (optional), existing_names (optional), theory_name (optional), context (optional) -->
+Suggest a descriptive name for this Isabelle {{command_type}}.
+
+**Command:**
+```isabelle
+{{command}}
+```
+
+{{#current_name}}
+**Current name:** `{{current_name}}`
+{{/current_name}}
+
+{{#theory_name}}
+**Theory:** {{theory_name}}
+{{/theory_name}}
+
+{{#existing_names}}
+**Names already in scope (avoid these):**
+{{existing_names}}
+
+{{/existing_names}}
+{{#context}}
+**Surrounding context:**
+```isabelle
+{{context}}
+```
+
+{{/context}}
+**Naming guidelines:**
+- Use lowercase with underscores (snake_case): `my_lemma_name`
+- Be descriptive but concise (2-4 words typically)
+- Reflect the main property or purpose
+- Follow Isabelle conventions:
+  - Theorems/lemmas: describe the property (e.g., `map_append`, `length_rev`)
+  - Functions: verb or noun describing the operation (e.g., `insert_sorted`, `merge_lists`)
+  - Definitions: noun describing what is defined (e.g., `is_sorted`, `list_sum`)
+- Avoid generic names like `lemma1`, `helper`, `aux`
+- Do NOT use names already in scope (listed above)
+
+Provide 3-5 suggested names in this format:
+NAME: suggested_name
+NAME: alternative_name
+NAME: another_name
+
+Do not include explanations, just the NAME: lines.

--- a/isabelle-assistant/resources/actions.xml
+++ b/isabelle-assistant/resources/actions.xml
@@ -5,6 +5,11 @@
 			isabelle.assistant.SuggestAction.suggest(view, view.getBuffer(), view.getTextArea().getCaretPosition());
 		</CODE>
 	</ACTION>
+	<ACTION NAME="assistant-suggest-name">
+		<CODE>
+			isabelle.assistant.SuggestNameAction.suggestName(view);
+		</CODE>
+	</ACTION>
 	<ACTION NAME="assistant-explain">
 		<CODE>
 			String sel = view.getTextArea().getSelectedText();

--- a/isabelle-assistant/src/ChatAction.scala
+++ b/isabelle-assistant/src/ChatAction.scala
@@ -61,6 +61,7 @@ object ChatAction {
     "show-type" -> CommandEntry("Display type information for the symbol at cursor position", (v, _) => ShowTypeAction.showType(v)),
     "sledgehammer" -> CommandEntry("Run Sledgehammer to find automatic proofs using external provers", (v, _) => runSledgehammer(v), needsIQ = true),
     "suggest" -> CommandEntry("Generate proof step suggestions for the current proof state", (v, a) => runSuggest(v, a)),
+    "suggest-name" -> CommandEntry("Suggest a descriptive name for the lemma, theorem, or definition at cursor", (v, _) => SuggestNameAction.chatSuggestName(v)),
     "suggest-strategy" -> CommandEntry("Recommend high-level proof strategies for the current goal", (v, _) => SuggestStrategyAction.suggest(v)),
     "suggest-tactic" -> CommandEntry("Suggest specific tactics to apply at the current proof step", (v, _) => SuggestTacticAction.chatSuggest(v)),
     "summarize" -> CommandEntry("Generate a summary of theory content including key definitions", (v, _) => SummarizeTheoryAction.summarize(v)),

--- a/isabelle-assistant/src/SuggestNameAction.scala
+++ b/isabelle-assistant/src/SuggestNameAction.scala
@@ -1,0 +1,197 @@
+/* Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+   SPDX-License-Identifier: MIT */
+
+package isabelle.assistant
+
+import isabelle._
+import isabelle.jedit._
+import org.gjt.sp.jedit.View
+import org.gjt.sp.jedit.buffer.JEditBuffer
+import java.util.concurrent.{CountDownLatch, TimeUnit}
+
+/**
+ * Suggests descriptive names for Isabelle definitions, lemmas, and theorems.
+ * Uses LLM with context including command body, type, existing names in scope,
+ * and surrounding definitions to propose names that follow Isabelle conventions
+ * and avoid clashes with existing identifiers.
+ */
+object SuggestNameAction {
+
+  private val nameableKeywords = Set(
+    "definition", "fun", "function", "primrec", "abbreviation",
+    "lemma", "theorem", "corollary", "proposition",
+    "datatype", "codatatype", "type_synonym", "record",
+    "inductive", "inductive_set", "coinductive"
+  )
+
+  /** Chat command handler: suggest name for command at cursor. */
+  def chatSuggestName(view: View): Unit = suggestName(view)
+
+  /** Context menu handler: suggest name for command at cursor. */
+  def suggestName(view: View): Unit = {
+    // Echo command to chat (both from context menu and chat command)
+    ChatAction.addMessage("user", ":suggest-name")
+    AssistantDockable.showConversation(ChatAction.getHistory)
+    
+    val buffer = view.getBuffer
+    val offset = view.getTextArea.getCaretPosition
+    
+    // Get command text and keyword
+    val commandTextOpt = CommandExtractor.getCommandAtOffset(buffer, offset)
+    val keywordOpt = CommandExtractor.getCommandKeyword(buffer, offset)
+    
+    (commandTextOpt, keywordOpt) match {
+      case (None, _) =>
+        AssistantDockable.respondInChat("No command at cursor position.")
+      case (_, None) =>
+        AssistantDockable.respondInChat("Could not determine command type.")
+      case (Some(commandText), Some(keyword)) if !nameableKeywords.contains(keyword) =>
+        AssistantDockable.respondInChat(s"Command type '$keyword' does not require naming.")
+      case (Some(commandText), Some(keyword)) =>
+        AssistantDockable.setStatus("Gathering context...")
+        
+        Isabelle_Thread.fork(name = "assistant-suggest-name") {
+          try {
+            // Gather context on background thread
+            val context = gatherContext(view, buffer, offset, commandText, keyword)
+            
+            // Build prompt
+            val subs = buildPromptSubstitutions(commandText, keyword, context)
+            val prompt = PromptLoader.load("suggest_name.md", subs)
+            
+            // Call LLM
+            AssistantDockable.setStatus("Generating name suggestions...")
+            val response = BedrockClient.invokeInContext(prompt)
+            
+            // Parse suggestions
+            val suggestions = parseNameSuggestions(response)
+            
+            GUI_Thread.later {
+              if (suggestions.isEmpty) {
+                AssistantDockable.respondInChat("No name suggestions generated.")
+              } else {
+                displaySuggestions(view, buffer, offset, commandText, keyword, 
+                  context.currentName, suggestions)
+              }
+              AssistantDockable.setStatus(AssistantConstants.STATUS_READY)
+            }
+          } catch {
+            case ex: Exception =>
+              GUI_Thread.later {
+                AssistantDockable.respondInChat(s"Error: ${ErrorHandler.makeUserFriendly(ex.getMessage, "suggest-name")}")
+                AssistantDockable.setStatus(AssistantConstants.STATUS_READY)
+              }
+          }
+        }
+    }
+  }
+
+  private case class NameContext(
+    currentName: Option[String],
+    existingNames: List[String],
+    theoryName: Option[String],
+    surroundingContext: Option[String]
+  )
+
+  private def gatherContext(
+    view: View,
+    buffer: JEditBuffer,
+    offset: Int,
+    commandText: String,
+    keyword: String
+  ): NameContext = {
+    // Extract current name if present
+    val currentName = ExplainAction.extractName(commandText)
+    
+    // Get existing names in scope from PIDE markup
+    val existingNames = if (javax.swing.SwingUtilities.isEventDispatchThread) {
+      Output.warning("[Assistant] gatherContext called from GUI thread — skipping entity extraction")
+      List.empty[String]
+    } else {
+      val latch = new CountDownLatch(1)
+      @volatile var entities: List[(String, String)] = Nil
+      
+      GUI_Thread.later {
+        entities = ContextFetcher.extractEntities(buffer, offset)
+        latch.countDown()
+      }
+      
+      latch.await(2000, TimeUnit.MILLISECONDS)
+      
+      // Extract unique names, filtering out meta-level constants
+      entities.map(_._2).distinct.filter(n => 
+        !n.startsWith("Pure.") && !n.startsWith("HOL.") && 
+        n != "Trueprop" && !n.contains(".")
+      ).sorted
+    }
+    
+    // Get theory name from buffer (via PIDE document model)
+    val theoryName = Document_Model.get_model(buffer).map(_.node_name.theory)
+    
+    // Get surrounding context (commands near cursor) - optional for now
+    val surroundingContext: Option[String] = None
+    
+    NameContext(currentName, existingNames, theoryName, surroundingContext)
+  }
+
+  private def buildPromptSubstitutions(
+    commandText: String,
+    keyword: String,
+    context: NameContext
+  ): Map[String, String] = {
+    var subs = Map(
+      "command" -> commandText,
+      "command_type" -> keyword
+    )
+    
+    context.currentName.foreach { name =>
+      subs = subs + ("current_name" -> name)
+    }
+    
+    if (context.existingNames.nonEmpty) {
+      val namesList = context.existingNames.take(50).map(n => s"- `$n`").mkString("\n")
+      subs = subs + ("existing_names" -> namesList)
+    }
+    
+    context.theoryName.foreach { name =>
+      subs = subs + ("theory_name" -> name)
+    }
+    
+    context.surroundingContext.foreach { ctx =>
+      subs = subs + ("context" -> ctx)
+    }
+    
+    subs
+  }
+
+  private def parseNameSuggestions(response: String): List[String] = {
+    val namePattern = """NAME:\s*([a-zA-Z][a-zA-Z0-9_']*)""".r
+    namePattern.findAllMatchIn(response)
+      .map(_.group(1).trim)
+      .filter(_.nonEmpty)
+      .toList
+      .distinct
+      .take(5)
+  }
+
+  private def displaySuggestions(
+    view: View,
+    buffer: JEditBuffer,
+    offset: Int,
+    commandText: String,
+    keyword: String,
+    currentName: Option[String],
+    suggestions: List[String]
+  ): Unit = {
+    val sb = new StringBuilder()
+    sb.append(s"**Name suggestions for $keyword:**\n\n")
+    
+    for (suggestion <- suggestions) {
+      val actionId = InsertHelper.registerInsertAction(view, suggestion)
+      sb.append(s"- `$suggestion` {{INSERT:$actionId}}\n")
+    }
+    
+    ChatAction.addMessage("assistant", sb.toString)
+    AssistantDockable.showConversation(ChatAction.getHistory)
+  }
+}

--- a/isabelle-assistant/src/assistantContextMenu.scala
+++ b/isabelle-assistant/src/assistantContextMenu.scala
@@ -113,12 +113,13 @@ class AssistantContextMenu extends DynamicContextMenuService {
           // Use PIDE span name for command type detection — no string splitting
           val commandType = GenerateDocAction.detectCommandTypeAtOffset(buffer, offset)
           if (commandType.isDefined) {
-            addItem(genMenu, "Doc Comment") { _ =>
-              commandForDoc.foreach(text =>
-                GenerateDocAction.generate(view, text, commandType.getOrElse("command")))
-            }
+          addItem(genMenu, "Doc Comment") { _ =>
+            commandForDoc.foreach(text =>
+              GenerateDocAction.generate(view, text, commandType.getOrElse("command")))
           }
+        }
 
+          addItem(genMenu, "Suggest Name")(_ => SuggestNameAction.suggestName(view))
           addItem(genMenu, "Tidy Up")(_ => TidyAction.tidy(view))
 
           if (ctx.hasSelection)


### PR DESCRIPTION
Add :suggest-name action for naming lemmas, theorems, and definitions

Implements a new action that generates descriptive name suggestions for
Isabelle commands using LLM with context to follow naming conventions
and avoid identifier clashes.

Features:
- Context-aware: Extracts existing names in scope via PIDE markup to prevent name collisions
- LLM-powered: Generates 3-5 suggestions following Isabelle conventions (snake_case, descriptive, appropriate for construct type)
- Multiple invocation methods: context menu, :suggest-name chat command, and keyboard shortcut binding
- Integrated UX: Echoes commands to chat history and uses standard [Insert] button pattern consistent with other actions

Files added:
- prompts/suggest_name.md: LLM prompt template with naming guidelines
- src/SuggestNameAction.scala: Action implementation with context gathering

Files modified:
- src/ChatAction.scala: Added :suggest-name to command dispatch table
- src/assistantContextMenu.scala: Added "Suggest Name" to Generation menu
- resources/actions.xml: Added assistant-suggest-name action binding

The action provides contextual naming help by including:
- Command body and type (lemma/theorem/definition/etc)
- Current name if present
- Existing entity names in scope (constants, types)
- Theory name for thematic consistency

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
