### PR TITLE
Make Rust-vs-Micro-Rust testing a coverage-auditable CI gate

### DIFF
--- a/.github/actions/setup-isabelle-action/action.yml
+++ b/.github/actions/setup-isabelle-action/action.yml
@@ -19,12 +19,12 @@ runs:
     - name: Set Isabelle home
       shell: bash
       run: |
-        echo "$(/home/isabelle/Isabelle/bin/isabelle getenv ISABELLE_HOME)" >> $GITHUB_ENV
+        echo "ISABELLE_HOME=$(/home/isabelle/Isabelle/bin/isabelle getenv -b ISABELLE_HOME)" >> "$GITHUB_ENV"
 
     - name: Set Isabelle home user
       shell: bash
       run: |
-        echo "$($ISABELLE_HOME/bin/isabelle getenv ISABELLE_HOME_USER)" >> $GITHUB_ENV
+        echo "ISABELLE_HOME_USER=$($ISABELLE_HOME/bin/isabelle getenv -b ISABELLE_HOME_USER)" >> "$GITHUB_ENV"
 
     - name: Cache heap images
       uses: actions/cache@v3

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,14 +16,15 @@ jobs:
     steps:
     - uses: actions/checkout@v4
 
+    - name: Setup Isabelle
+      uses: ./.github/actions/setup-isabelle-action
+
     - name: Install build tools
-      run: apt-get update -qq && apt-get install -y -qq make curl > /dev/null
+      run: apt-get update -qq && apt-get install -y -qq make curl rustc cargo > /dev/null
 
     - name: Set Isabelle environment
       run: |
-        ISABELLE_HOME=$(/home/isabelle/Isabelle/bin/isabelle getenv -b ISABELLE_HOME)
-        echo "ISABELLE_HOME=$ISABELLE_HOME" >> $GITHUB_ENV
-        JAVA_HOME=$(/home/isabelle/Isabelle/bin/isabelle getenv -b JAVA_HOME)
+        JAVA_HOME=$($ISABELLE_HOME/bin/isabelle getenv -b JAVA_HOME)
         echo "JAVA_HOME=$JAVA_HOME" >> $GITHUB_ENV
         echo "$JAVA_HOME/bin" >> $GITHUB_PATH
 
@@ -46,3 +47,7 @@ jobs:
       run: |
         cd ip/ip_plugin
         make build ISABELLE_HOME=$ISABELLE_HOME
+
+    - name: Run conformance gate
+      run: |
+        make conformance ISABELLE_HOME=$ISABELLE_HOME

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,7 @@
 dependencies/
 *.thy~
+
+# Generated conformance artifacts
+Conformance_Testing/rust_harness/src/lib.rs
+Conformance_Testing/rust_harness/coverage_summary.json
+Conformance_Testing/rust_harness/coverage_summary.md

--- a/Conformance_Testing/Conformance_Framework.thy
+++ b/Conformance_Testing/Conformance_Framework.thy
@@ -1,0 +1,36 @@
+(* Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+   SPDX-License-Identifier: MIT *)
+
+(*<*)
+theory Conformance_Framework
+  imports
+    Shallow_Micro_Rust.Numeric_Types
+    "HOL-Library.Code_Target_Numeral"
+begin
+(*>*)
+
+section\<open>Conformance Testing Framework\<close>
+
+text\<open>This theory provides infrastructure for generating Rust conformance tests
+that validate Micro Rust (μRust) semantics against real Rust behaviour.
+
+The workflow is:
+\<^enum> SML generates random test inputs
+\<^enum> HOL computes expected results using the pure function definitions
+\<^enum> SML generates Rust test files with embedded assertions
+\<^enum> @{verbatim \<open>cargo test\<close>} validates that Rust matches the expected behaviour
+
+\<^bold>\<open>Key principle:\<close> Expected values come from HOL evaluation, not SML reimplementation.
+This ensures we're testing the actual formalisation.
+\<close>
+
+subsection\<open>ML Infrastructure\<close>
+
+ML_file "random.ML"
+ML_file "conformance.ML"
+ML_file "rust_codegen.ML"
+ML_file "coverage.ML"
+
+(*<*)
+end
+(*>*)

--- a/Conformance_Testing/README.md
+++ b/Conformance_Testing/README.md
@@ -1,0 +1,174 @@
+# Micro Rust Conformance Testing
+
+This directory contains the conformance framework that checks Micro Rust (μRust) semantics against real Rust execution.
+
+## Purpose
+
+The conformance suite is designed to:
+
+- evaluate expected behaviour from Micro Rust definitions in Isabelle/HOL
+- execute equivalent Rust expressions/tests in `cargo test`
+- fail when HOL and Rust behaviour diverge
+- produce auditable coverage summaries
+- block CI when conformance or coverage gates fail
+
+## Core Strategy
+
+Expected results are computed from HOL evaluation of Micro Rust functions, not from reimplemented expected-value logic in SML.
+
+At a high level:
+
+1. test inputs are generated (edge cases + deterministic random data)
+2. HOL terms are evaluated to compute expected outcomes
+3. Rust tests are generated with embedded expected values/assertions
+4. Rust tests are executed with `cargo test`
+5. coverage summaries are emitted (`json` + `markdown`) and checked for required categories
+
+## Current Test Categories
+
+Unified generation is defined in:
+
+- `Conformance_Testing/Tests/Generate_All.thy`
+
+Required categories currently enforced:
+
+- `arithmetic`
+- `bitwise`
+- `comparison`
+- `conversion`
+- `panic`
+- `stdlibarith`
+- `option`
+- `result`
+- `range`
+- `ordering`
+- `tuple`
+
+Category generators currently included:
+
+- `Conformance_Testing/Tests/Arithmetic_Conformance.thy`
+- `Conformance_Testing/Tests/Bitwise_Conformance.thy`
+- `Conformance_Testing/Tests/Comparison_Conformance.thy`
+- `Conformance_Testing/Tests/Conversion_Conformance.thy`
+- `Conformance_Testing/Tests/Panic_Conformance.thy`
+- `Conformance_Testing/Tests/StdLib_Arithmetic_Conformance.thy`
+- `Conformance_Testing/Tests/Option_Conformance.thy`
+- `Conformance_Testing/Tests/Result_Conformance.thy`
+- `Conformance_Testing/Tests/Range_Conformance.thy`
+- `Conformance_Testing/Tests/Ordering_Conformance.thy`
+- `Conformance_Testing/Tests/Tuple_Conformance.thy`
+
+## API Coverage Status (Current)
+
+### Option
+
+Covered:
+
+- `option_expect`
+- `option_unwrap`
+- `urust_func_option_is_none`
+- `urust_func_option_is_some`
+- `ok_or`
+
+Not yet covered by conformance tests:
+
+- `option_as_mut`
+- `take_mut_ref_option`
+
+### Result
+
+Covered:
+
+- `result_expect`
+- `result_unwrap`
+- `urust_func_result_is_err`
+- `urust_func_result_is_ok`
+- `result_or`
+- `map_err`
+- `ok`
+- `result_unwrap_or`
+
+Not yet covered by conformance tests:
+
+- `result_as_mut`
+
+### Range
+
+All public definitions in:
+
+- `Shallow_Micro_Rust/Range_Type.thy`
+
+are covered, including:
+
+- `range_into_list`
+- `make_iterator_from_range`
+- `range_into_iter`
+- indexing and range-slicing operations with value and abort paths
+
+### Tuple
+
+Covered:
+
+- `list_zip` from `Micro_Rust_Std_Lib/StdLib_Tuple.thy`
+
+## Running
+
+From repository root:
+
+```bash
+make conformance-gen
+make conformance-test
+```
+
+Or run end-to-end:
+
+```bash
+make conformance
+```
+
+## CI Gate
+
+CI runs conformance as a blocking gate via:
+
+- `.github/workflows/ci.yml`
+
+step:
+
+- `make conformance ISABELLE_HOME=$ISABELLE_HOME`
+
+If generation, coverage checks, or Rust conformance tests fail, CI fails.
+
+## Artifacts
+
+Generated outputs:
+
+- `Conformance_Testing/rust_harness/src/lib.rs`
+- `Conformance_Testing/rust_harness/coverage_summary.json`
+- `Conformance_Testing/rust_harness/coverage_summary.md`
+
+These are generated artifacts and not source-of-truth.
+
+## Coverage Summary
+
+Coverage summaries are produced by:
+
+- `Conformance_Testing/coverage.ML`
+
+They include:
+
+- total module/test counts
+- category module/test counts
+- tracked type counts (`u8`, `u16`, `u32`, `u64`)
+- per-module breakdown
+- panic expectation counts for panic modules
+
+## Extending the Suite
+
+To add new conformance material:
+
+1. add a generator theory in `Conformance_Testing/Tests/`
+2. expose `generate_all_tests ctxt num_random`
+3. import the theory in `Generate_All.thy`
+4. wire it into `Conformance_Gen.generate_all_tests`
+5. add its category to `required_categories` if it represents a new required dimension
+6. include the theory in `Conformance_Testing/ROOT`

--- a/Conformance_Testing/ROOT
+++ b/Conformance_Testing/ROOT
@@ -1,0 +1,24 @@
+session Conformance_Testing = HOL +
+  options [document = false]
+  sessions
+    "HOL-Library"
+    "Word_Lib"
+    Shallow_Micro_Rust
+    Micro_Rust_Std_Lib
+  directories
+    "Tests"
+  theories
+    Conformance_Framework
+  theories
+    "Tests/Arithmetic_Conformance"
+    "Tests/Bitwise_Conformance"
+    "Tests/Comparison_Conformance"
+    "Tests/Conversion_Conformance"
+    "Tests/Panic_Conformance"
+    "Tests/StdLib_Arithmetic_Conformance"
+    "Tests/Option_Conformance"
+    "Tests/Result_Conformance"
+    "Tests/Range_Conformance"
+    "Tests/Ordering_Conformance"
+    "Tests/Tuple_Conformance"
+    "Tests/Generate_All"

--- a/Conformance_Testing/Tests/Arithmetic_Conformance.thy
+++ b/Conformance_Testing/Tests/Arithmetic_Conformance.thy
@@ -1,0 +1,203 @@
+(* Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+   SPDX-License-Identifier: MIT *)
+
+(*<*)
+theory Arithmetic_Conformance
+  imports "../Conformance_Framework"
+begin
+(*>*)
+
+section\<open>Arithmetic Conformance Tests\<close>
+
+text\<open>This theory generates conformance tests for arithmetic operations across
+multiple unsigned integer types:
+\<^item> u8 (8-bit), u16 (16-bit), u32 (32-bit), u64 (64-bit)
+
+Operations tested:
+\<^item> Addition (@{term word_add_no_wrap_pure})
+\<^item> Subtraction (@{term word_minus_no_wrap_pure})
+\<^item> Multiplication (@{term word_mul_no_wrap_pure})
+\<^item> Division (pure version defined below)
+\<^item> Modulo (pure version defined below)
+
+The tests validate that our HOL definitions match Rust's @{verbatim \<open>checked_*\<close>} methods.
+
+\<^bold>\<open>Key principle:\<close> Expected values are computed by evaluating the HOL definitions,
+not by reimplementing the logic in SML.
+\<close>
+
+subsection\<open>Pure Division and Modulo\<close>
+
+text\<open>The core theory defines division/modulo as expression-level functions that panic
+on division by zero. For conformance testing against Rust's @{verbatim \<open>checked_div\<close>}
+and @{verbatim \<open>checked_rem\<close>}, we need pure versions that return @{typ "'a option"}.\<close>
+
+definition word_div_pure :: \<open>'l::{len} word \<Rightarrow> 'l word \<Rightarrow> 'l word option\<close> where
+  \<open>word_div_pure a b \<equiv> if b = 0 then None else Some (a div b)\<close>
+
+definition word_mod_pure :: \<open>'l::{len} word \<Rightarrow> 'l word \<Rightarrow> 'l word option\<close> where
+  \<open>word_mod_pure a b \<equiv> if b = 0 then None else Some (a mod b)\<close>
+
+subsection\<open>Test Generation Infrastructure\<close>
+
+ML\<open>
+(* Test generation for arithmetic operations on unsigned integer types.
+   Supports u8, u16, u32, u64 with the same HOL definitions (polymorphic). *)
+
+structure Arith_Conformance = struct
+  open Conformance_Random
+  open Conformance
+  open Rust_Codegen
+
+  (* Type information for each unsigned integer type *)
+  datatype uint_type = U8 | U16 | U32 | U64
+
+  fun uint_bits U8 = 8 | uint_bits U16 = 16 | uint_bits U32 = 32 | uint_bits U64 = 64
+  fun uint_rust_suffix U8 = "u8" | uint_rust_suffix U16 = "u16"
+    | uint_rust_suffix U32 = "u32" | uint_rust_suffix U64 = "u64"
+  fun uint_max U8 = 255 : IntInf.int
+    | uint_max U16 = 65535
+    | uint_max U32 = 4294967295
+    | uint_max U64 = 18446744073709551615
+
+  (* Build HOL type for word of given bit width *)
+  fun mk_word_type U8 = \<^typ>\<open>8 word\<close>
+    | mk_word_type U16 = \<^typ>\<open>16 word\<close>
+    | mk_word_type U32 = \<^typ>\<open>32 word\<close>
+    | mk_word_type U64 = \<^typ>\<open>64 word\<close>
+
+  (* Build a HOL term for a word literal of given type *)
+  fun mk_word utype (n : IntInf.int) =
+    HOLogic.mk_number (mk_word_type utype) n
+
+  (* Term constructors for each operation, parameterized by type *)
+  fun mk_add_term utype (a, b) =
+    Const (\<^const_name>\<open>word_add_no_wrap_pure\<close>,
+           mk_word_type utype --> mk_word_type utype --> Type (\<^type_name>\<open>option\<close>, [mk_word_type utype]))
+    $ mk_word utype a $ mk_word utype b
+
+  fun mk_sub_term utype (a, b) =
+    Const (\<^const_name>\<open>word_minus_no_wrap_pure\<close>,
+           mk_word_type utype --> mk_word_type utype --> Type (\<^type_name>\<open>option\<close>, [mk_word_type utype]))
+    $ mk_word utype a $ mk_word utype b
+
+  fun mk_mul_term utype (a, b) =
+    Const (\<^const_name>\<open>word_mul_no_wrap_pure\<close>,
+           mk_word_type utype --> mk_word_type utype --> Type (\<^type_name>\<open>option\<close>, [mk_word_type utype]))
+    $ mk_word utype a $ mk_word utype b
+
+  fun mk_div_term utype (a, b) =
+    Const (\<^const_name>\<open>word_div_pure\<close>,
+           mk_word_type utype --> mk_word_type utype --> Type (\<^type_name>\<open>option\<close>, [mk_word_type utype]))
+    $ mk_word utype a $ mk_word utype b
+
+  fun mk_mod_term utype (a, b) =
+    Const (\<^const_name>\<open>word_mod_pure\<close>,
+           mk_word_type utype --> mk_word_type utype --> Type (\<^type_name>\<open>option\<close>, [mk_word_type utype]))
+    $ mk_word utype a $ mk_word utype b
+
+  (* Evaluate a HOL term and convert the result to Rust syntax *)
+  fun eval_option_to_rust ctxt term =
+    let
+      val result = Value_Command.value ctxt term
+      val test_res = term_to_option_result result
+    in
+      option_result_to_rust test_res
+    end
+
+  (* Generate a single test case *)
+  fun gen_test ctxt utype mk_term rust_op idx (a, b) =
+    let
+      val term = mk_term utype (a, b)
+      val expected = eval_option_to_rust ctxt term
+      val suffix = uint_rust_suffix utype
+      val a_str = IntInf.toString a
+      val b_str = IntInf.toString b
+      val rust_expr = a_str ^ suffix ^ "." ^ rust_op ^ "(" ^ b_str ^ ")"
+      val name = "test_" ^ Int.toString idx
+    in
+      {name = name, rust_expr = rust_expr, expected = expected}
+    end
+
+  (* Edge cases for a given type *)
+  fun arith_edge_cases utype =
+    let val max = uint_max utype
+        val mid = max div 2
+    in [
+      (0, 0), (0, 1), (1, 0), (1, 1),
+      (max, 0), (max, 1), (max - 1, 1),
+      (mid, mid), (mid + 1, mid), (mid + 1, mid + 1)
+    ] end
+
+  fun div_edge_cases utype =
+    let val max = uint_max utype
+        val mid = max div 2
+    in [
+      (0, 1), (1, 1), (10, 3), (10, 0),
+      (max, 1), (max, 2), (max, max),
+      (0, 0), (100 mod (max + 1), 7), (mid, 2)
+    ] end
+
+  (* Generate random pairs for a given type *)
+  fun gen_random_pairs_for utype seed n =
+    case utype of
+      U8 => next_list seed n (fn s =>
+              let val (a, s') = next_word8 s
+                  val (b, s'') = next_word8 s'
+              in ((Word8.toLargeInt a, Word8.toLargeInt b), s'') end)
+    | U16 => next_list seed n (fn s =>
+              let val (a, s') = next_word16 s
+                  val (b, s'') = next_word16 s'
+              in ((Word.toLargeInt a, Word.toLargeInt b), s'') end)
+    | U32 => next_list seed n (fn s =>
+              let val (a, s') = next_word32 s
+                  val (b, s'') = next_word32 s'
+              in ((Word32.toLargeInt a, Word32.toLargeInt b), s'') end)
+    | U64 => next_list seed n (fn s =>
+              let val (a, s') = next_word64 s
+                  val (b, s'') = next_word64 s'
+              in ((Word64.toLargeInt a, Word64.toLargeInt b), s'') end)
+
+  (* Generate all tests for an operation on a type *)
+  fun gen_op_tests ctxt utype mk_term rust_op edge_cases seed num_random =
+    let
+      val (random_pairs, _) = gen_random_pairs_for utype seed num_random
+      val all_pairs = edge_cases @ random_pairs
+    in
+      map_index (fn (i, pair) => gen_test ctxt utype mk_term rust_op i pair) all_pairs
+    end
+
+  (* Generate tests for all operations on a single type *)
+  fun generate_type_tests ctxt utype seed num_random =
+    let
+      val suffix = uint_rust_suffix utype
+      val arith_edges = arith_edge_cases utype
+      val div_edges = div_edge_cases utype
+    in
+      [("arithmetic_" ^ suffix ^ "_add",
+        gen_op_tests ctxt utype mk_add_term "checked_add" arith_edges seed num_random),
+       ("arithmetic_" ^ suffix ^ "_sub",
+        gen_op_tests ctxt utype mk_sub_term "checked_sub" arith_edges seed num_random),
+       ("arithmetic_" ^ suffix ^ "_mul",
+        gen_op_tests ctxt utype mk_mul_term "checked_mul" arith_edges seed num_random),
+       ("arithmetic_" ^ suffix ^ "_div",
+        gen_op_tests ctxt utype mk_div_term "checked_div" div_edges seed num_random),
+       ("arithmetic_" ^ suffix ^ "_mod",
+        gen_op_tests ctxt utype mk_mod_term "checked_rem" div_edges seed num_random)]
+    end
+
+  (* Generate tests for all unsigned types *)
+  fun generate_all_tests ctxt num_random =
+    let
+      val seed = default_seed
+      val types = [U8, U16, U32, U64]
+    in
+      List.concat (map (fn t => generate_type_tests ctxt t seed num_random) types)
+    end
+
+end
+\<close>
+
+(*<*)
+end
+(*>*)

--- a/Conformance_Testing/Tests/Bitwise_Conformance.thy
+++ b/Conformance_Testing/Tests/Bitwise_Conformance.thy
@@ -1,0 +1,307 @@
+(* Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+   SPDX-License-Identifier: MIT *)
+
+(*<*)
+theory Bitwise_Conformance
+  imports "../Conformance_Framework"
+begin
+(*>*)
+
+section\<open>Bitwise Conformance Tests\<close>
+
+text\<open>This theory generates conformance tests for bitwise operations:
+\<^item> AND (@{term word_bitwise_and_pure})
+\<^item> OR (@{term word_bitwise_or_pure})
+\<^item> XOR (@{term word_bitwise_xor_pure})
+\<^item> NOT (@{term word_bitwise_not_pure})
+\<^item> Shift left (@{term word_shift_left_pure})
+\<^item> Shift right (@{term word_shift_right_pure})
+
+Basic bitwise operations never fail. Shifts return @{typ "'a option"} because
+shifting by >= bit width is undefined behaviour in Rust (returns @{term None}).
+\<close>
+
+subsection\<open>Test Generation Infrastructure\<close>
+
+ML\<open>
+(* Test generation for bitwise and shift operations. *)
+
+structure Bitwise_Conformance = struct
+  open Conformance_Random
+  open Conformance
+  open Rust_Codegen
+
+  (* Type information *)
+  datatype uint_type = U8 | U16 | U32 | U64
+
+  fun uint_rust_suffix U8 = "u8" | uint_rust_suffix U16 = "u16"
+    | uint_rust_suffix U32 = "u32" | uint_rust_suffix U64 = "u64"
+  fun uint_max U8 = 255 : IntInf.int
+    | uint_max U16 = 65535
+    | uint_max U32 = 4294967295
+    | uint_max U64 = 18446744073709551615
+  fun uint_bits U8 = 8 | uint_bits U16 = 16 | uint_bits U32 = 32 | uint_bits U64 = 64
+
+  fun mk_word_type U8 = \<^typ>\<open>8 word\<close>
+    | mk_word_type U16 = \<^typ>\<open>16 word\<close>
+    | mk_word_type U32 = \<^typ>\<open>32 word\<close>
+    | mk_word_type U64 = \<^typ>\<open>64 word\<close>
+
+  fun mk_word utype (n : IntInf.int) =
+    HOLogic.mk_number (mk_word_type utype) n
+
+  (* Term constructors for basic bitwise operations *)
+  fun mk_and_term utype (a, b) =
+    Const (\<^const_name>\<open>word_bitwise_and_pure\<close>,
+           mk_word_type utype --> mk_word_type utype --> mk_word_type utype)
+    $ mk_word utype a $ mk_word utype b
+
+  fun mk_or_term utype (a, b) =
+    Const (\<^const_name>\<open>word_bitwise_or_pure\<close>,
+           mk_word_type utype --> mk_word_type utype --> mk_word_type utype)
+    $ mk_word utype a $ mk_word utype b
+
+  fun mk_xor_term utype (a, b) =
+    Const (\<^const_name>\<open>word_bitwise_xor_pure\<close>,
+           mk_word_type utype --> mk_word_type utype --> mk_word_type utype)
+    $ mk_word utype a $ mk_word utype b
+
+  fun mk_not_term utype a =
+    Const (\<^const_name>\<open>word_bitwise_not_pure\<close>,
+           mk_word_type utype --> mk_word_type utype)
+    $ mk_word utype a
+
+  (* Term constructors for shift operations.
+     In HOL: word_shift_left_pure :: 'l0 word => 'l1 word => 'l0 word option
+     The shift amount type ('l1) is fixed to 32 word (matches Rust's u32 shift amount) *)
+  fun mk_shl_term utype (value, shift) =
+    let
+      val result_ty = Type (\<^type_name>\<open>option\<close>, [mk_word_type utype])
+    in
+      Const (\<^const_name>\<open>word_shift_left_pure\<close>,
+             mk_word_type utype --> \<^typ>\<open>32 word\<close> --> result_ty)
+      $ mk_word utype value
+      $ HOLogic.mk_number \<^typ>\<open>32 word\<close> shift
+    end
+
+  fun mk_shr_term utype (value, shift) =
+    let
+      val result_ty = Type (\<^type_name>\<open>option\<close>, [mk_word_type utype])
+    in
+      Const (\<^const_name>\<open>word_shift_right_pure\<close>,
+             mk_word_type utype --> \<^typ>\<open>32 word\<close> --> result_ty)
+      $ mk_word utype value
+      $ HOLogic.mk_number \<^typ>\<open>32 word\<close> shift
+    end
+
+  (* Evaluate a HOL term and extract the word value as a string *)
+  fun eval_word_to_rust ctxt term =
+    let
+      val result = Value_Command.value ctxt term
+    in
+      case extract_word_nat result of
+        SOME n => IntInf.toString n
+      | NONE => "/* extraction failed */"
+    end
+
+  (* Evaluate option term to Rust *)
+  fun eval_option_to_rust ctxt term =
+    let
+      val result = Value_Command.value ctxt term
+      val test_res = term_to_option_result result
+    in
+      option_result_to_rust test_res
+    end
+
+  (* Generate a single binary test case for basic bitwise ops *)
+  fun gen_binary_test ctxt utype mk_term rust_op idx (a, b) =
+    let
+      val term = mk_term utype (a, b)
+      val expected = eval_word_to_rust ctxt term
+      val suffix = uint_rust_suffix utype
+      val a_str = IntInf.toString a
+      val b_str = IntInf.toString b
+      val rust_expr = a_str ^ suffix ^ " " ^ rust_op ^ " " ^ b_str ^ suffix
+      val name = "test_" ^ Int.toString idx
+    in
+      {name = name, rust_expr = rust_expr, expected = expected ^ suffix}
+    end
+
+  (* Generate a single unary test case (for NOT) *)
+  fun gen_unary_test ctxt utype mk_term rust_op idx a =
+    let
+      val term = mk_term utype a
+      val expected = eval_word_to_rust ctxt term
+      val suffix = uint_rust_suffix utype
+      val a_str = IntInf.toString a
+      val rust_expr = rust_op ^ a_str ^ suffix
+      val name = "test_" ^ Int.toString idx
+    in
+      {name = name, rust_expr = rust_expr, expected = expected ^ suffix}
+    end
+
+  (* Generate a single shift test case (returns Option) *)
+  fun gen_shift_test ctxt utype mk_term rust_op idx (value, shift) =
+    let
+      val term = mk_term utype (value, shift)
+      val expected = eval_option_to_rust ctxt term
+      val suffix = uint_rust_suffix utype
+      val val_str = IntInf.toString value
+      val shift_str = IntInf.toString shift
+      val rust_expr = val_str ^ suffix ^ "." ^ rust_op ^ "(" ^ shift_str ^ ")"
+      val name = "test_" ^ Int.toString idx
+    in
+      {name = name, rust_expr = rust_expr, expected = expected}
+    end
+
+  (* Edge cases for bitwise operations *)
+  fun bitwise_edge_cases utype =
+    let val max = uint_max utype
+    in [
+      (0, 0), (0, max), (max, 0), (max, max),
+      (0, 1), (1, 0), (1, 1),
+      (max - 1, 1), (1, max - 1),
+      (max div 2, max div 2 + 1)
+    ] end
+
+  fun unary_edge_cases utype =
+    let val max = uint_max utype
+    in [0, 1, max - 1, max, max div 2, max div 2 + 1] end
+
+  (* Edge cases for shift operations - includes invalid shifts (>= bit width) *)
+  fun shift_edge_cases utype =
+    let
+      val max = uint_max utype
+      val bits = uint_bits utype
+    in [
+      (1, 0),                    (* no shift *)
+      (1, 1),                    (* shift by 1 *)
+      (max, 0),                  (* max, no shift *)
+      (max, 1),                  (* max, shift 1 *)
+      (1, bits - 1),             (* shift to MSB *)
+      (1, bits),                 (* invalid: shift == width *)
+      (1, bits + 1),             (* invalid: shift > width *)
+      (max, bits - 1),           (* max, shift to MSB *)
+      (0, bits),                 (* zero, invalid shift *)
+      (max div 2, bits div 2)    (* mid value, mid shift *)
+    ] end
+
+  (* Generate random pairs for a given type *)
+  fun gen_random_pairs_for utype seed n =
+    case utype of
+      U8 => next_list seed n (fn s =>
+              let val (a, s') = next_word8 s
+                  val (b, s'') = next_word8 s'
+              in ((Word8.toLargeInt a, Word8.toLargeInt b), s'') end)
+    | U16 => next_list seed n (fn s =>
+              let val (a, s') = next_word16 s
+                  val (b, s'') = next_word16 s'
+              in ((Word.toLargeInt a, Word.toLargeInt b), s'') end)
+    | U32 => next_list seed n (fn s =>
+              let val (a, s') = next_word32 s
+                  val (b, s'') = next_word32 s'
+              in ((Word32.toLargeInt a, Word32.toLargeInt b), s'') end)
+    | U64 => next_list seed n (fn s =>
+              let val (a, s') = next_word64 s
+                  val (b, s'') = next_word64 s'
+              in ((Word64.toLargeInt a, Word64.toLargeInt b), s'') end)
+
+  fun gen_random_values_for utype seed n =
+    case utype of
+      U8 => next_list seed n (fn s =>
+              let val (a, s') = next_word8 s in (Word8.toLargeInt a, s') end)
+    | U16 => next_list seed n (fn s =>
+              let val (a, s') = next_word16 s in (Word.toLargeInt a, s') end)
+    | U32 => next_list seed n (fn s =>
+              let val (a, s') = next_word32 s in (Word32.toLargeInt a, s') end)
+    | U64 => next_list seed n (fn s =>
+              let val (a, s') = next_word64 s in (Word64.toLargeInt a, s') end)
+
+  (* Generate random (value, shift) pairs for shift tests *)
+  fun gen_random_shift_pairs_for utype seed n =
+    let
+      val bits = uint_bits utype
+    in
+      case utype of
+        U8 => next_list seed n (fn s =>
+                let val (v, s') = next_word8 s
+                    val (sh, s'') = next_int s' 0 (bits + 5)  (* some invalid *)
+                in ((Word8.toLargeInt v, IntInf.fromInt sh), s'') end)
+      | U16 => next_list seed n (fn s =>
+                let val (v, s') = next_word16 s
+                    val (sh, s'') = next_int s' 0 (bits + 5)
+                in ((Word.toLargeInt v, IntInf.fromInt sh), s'') end)
+      | U32 => next_list seed n (fn s =>
+                let val (v, s') = next_word32 s
+                    val (sh, s'') = next_int s' 0 (bits + 5)
+                in ((Word32.toLargeInt v, IntInf.fromInt sh), s'') end)
+      | U64 => next_list seed n (fn s =>
+                let val (v, s') = next_word64 s
+                    val (sh, s'') = next_int s' 0 (bits + 5)
+                in ((Word64.toLargeInt v, IntInf.fromInt sh), s'') end)
+    end
+
+  (* Generate all tests for a binary operation on a type *)
+  fun gen_binary_op_tests ctxt utype mk_term rust_op seed num_random =
+    let
+      val edges = bitwise_edge_cases utype
+      val (random_pairs, _) = gen_random_pairs_for utype seed num_random
+      val all_pairs = edges @ random_pairs
+    in
+      map_index (fn (i, pair) => gen_binary_test ctxt utype mk_term rust_op i pair) all_pairs
+    end
+
+  (* Generate all tests for NOT on a type *)
+  fun gen_not_tests ctxt utype seed num_random =
+    let
+      val edges = unary_edge_cases utype
+      val (random_values, _) = gen_random_values_for utype seed num_random
+      val all_values = edges @ random_values
+    in
+      map_index (fn (i, v) => gen_unary_test ctxt utype mk_not_term "!" i v) all_values
+    end
+
+  (* Generate all tests for a shift operation on a type *)
+  fun gen_shift_op_tests ctxt utype mk_term rust_op seed num_random =
+    let
+      val edges = shift_edge_cases utype
+      val (random_pairs, _) = gen_random_shift_pairs_for utype seed num_random
+      val all_pairs = edges @ random_pairs
+    in
+      map_index (fn (i, pair) => gen_shift_test ctxt utype mk_term rust_op i pair) all_pairs
+    end
+
+  (* Generate tests for all bitwise operations on a single type *)
+  fun generate_type_tests ctxt utype seed num_random =
+    let
+      val suffix = uint_rust_suffix utype
+    in
+      [("bitwise_" ^ suffix ^ "_and",
+        gen_binary_op_tests ctxt utype mk_and_term "&" seed num_random),
+       ("bitwise_" ^ suffix ^ "_or",
+        gen_binary_op_tests ctxt utype mk_or_term "|" seed num_random),
+       ("bitwise_" ^ suffix ^ "_xor",
+        gen_binary_op_tests ctxt utype mk_xor_term "^" seed num_random),
+       ("bitwise_" ^ suffix ^ "_not",
+        gen_not_tests ctxt utype seed num_random),
+       ("bitwise_" ^ suffix ^ "_shl",
+        gen_shift_op_tests ctxt utype mk_shl_term "checked_shl" seed num_random),
+       ("bitwise_" ^ suffix ^ "_shr",
+        gen_shift_op_tests ctxt utype mk_shr_term "checked_shr" seed num_random)]
+    end
+
+  (* Generate tests for all unsigned types *)
+  fun generate_all_tests ctxt num_random =
+    let
+      val seed = default_seed
+      val types = [U8, U16, U32, U64]
+    in
+      List.concat (map (fn t => generate_type_tests ctxt t seed num_random) types)
+    end
+
+end
+\<close>
+
+(*<*)
+end
+(*>*)

--- a/Conformance_Testing/Tests/Comparison_Conformance.thy
+++ b/Conformance_Testing/Tests/Comparison_Conformance.thy
@@ -1,0 +1,176 @@
+(* Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+   SPDX-License-Identifier: MIT *)
+
+(*<*)
+theory Comparison_Conformance
+  imports "../Conformance_Framework"
+begin
+(*>*)
+
+section\<open>Comparison Conformance Tests\<close>
+
+text\<open>This theory generates conformance tests for comparison operations:
+\<^item> Equality (=) / (==)
+\<^item> Inequality (\<noteq>) / (!=)
+\<^item> Less than (<)
+\<^item> Less than or equal (\<le>) / (<=)
+\<^item> Greater than (>)
+\<^item> Greater than or equal (\<ge>) / (>=)
+
+Comparison operations return @{typ bool}, which maps to Rust's @{verbatim \<open>bool\<close>}.
+\<close>
+
+subsection\<open>Test Generation Infrastructure\<close>
+
+ML\<open>
+(* Test generation for comparison operations. *)
+
+structure Comparison_Conformance = struct
+  open Conformance_Random
+  open Conformance
+  open Rust_Codegen
+
+  (* Type information *)
+  datatype uint_type = U8 | U16 | U32 | U64
+
+  fun uint_rust_suffix U8 = "u8" | uint_rust_suffix U16 = "u16"
+    | uint_rust_suffix U32 = "u32" | uint_rust_suffix U64 = "u64"
+  fun uint_max U8 = 255 : IntInf.int
+    | uint_max U16 = 65535
+    | uint_max U32 = 4294967295
+    | uint_max U64 = 18446744073709551615
+
+  fun mk_word_type U8 = \<^typ>\<open>8 word\<close>
+    | mk_word_type U16 = \<^typ>\<open>16 word\<close>
+    | mk_word_type U32 = \<^typ>\<open>32 word\<close>
+    | mk_word_type U64 = \<^typ>\<open>64 word\<close>
+
+  fun mk_word utype (n : IntInf.int) =
+    HOLogic.mk_number (mk_word_type utype) n
+
+  (* Term constructors for comparison operations *)
+  fun mk_eq_term utype (a, b) =
+    HOLogic.mk_eq (mk_word utype a, mk_word utype b)
+
+  fun mk_neq_term utype (a, b) =
+    HOLogic.mk_not (mk_eq_term utype (a, b))
+
+  fun mk_less_term utype (a, b) =
+    Const (\<^const_name>\<open>less\<close>, mk_word_type utype --> mk_word_type utype --> \<^typ>\<open>bool\<close>)
+    $ mk_word utype a $ mk_word utype b
+
+  fun mk_less_eq_term utype (a, b) =
+    Const (\<^const_name>\<open>less_eq\<close>, mk_word_type utype --> mk_word_type utype --> \<^typ>\<open>bool\<close>)
+    $ mk_word utype a $ mk_word utype b
+
+  fun mk_greater_term utype (a, b) =
+    mk_less_term utype (b, a)  (* a > b is b < a *)
+
+  fun mk_greater_eq_term utype (a, b) =
+    mk_less_eq_term utype (b, a)  (* a >= b is b <= a *)
+
+  (* Evaluate a HOL bool term and convert to Rust syntax *)
+  fun eval_bool_to_rust ctxt term =
+    let
+      val result = Value_Command.value ctxt term
+    in
+      case term_to_bool result of
+        SOME true => "true"
+      | SOME false => "false"
+      | NONE => "/* bool extraction failed */"
+    end
+
+  (* Generate a single comparison test case *)
+  fun gen_cmp_test ctxt utype mk_term rust_op idx (a, b) =
+    let
+      val term = mk_term utype (a, b)
+      val expected = eval_bool_to_rust ctxt term
+      val suffix = uint_rust_suffix utype
+      val a_str = IntInf.toString a
+      val b_str = IntInf.toString b
+      val rust_expr = a_str ^ suffix ^ " " ^ rust_op ^ " " ^ b_str ^ suffix
+      val name = "test_" ^ Int.toString idx
+    in
+      {name = name, rust_expr = rust_expr, expected = expected}
+    end
+
+  (* Edge cases for comparison operations *)
+  fun cmp_edge_cases utype =
+    let val max = uint_max utype
+    in [
+      (0, 0),                    (* equal: min *)
+      (max, max),                (* equal: max *)
+      (0, 1),                    (* less *)
+      (1, 0),                    (* greater *)
+      (0, max),                  (* min vs max *)
+      (max, 0),                  (* max vs min *)
+      (max - 1, max),            (* adjacent *)
+      (max, max - 1),            (* adjacent reversed *)
+      (max div 2, max div 2),    (* equal: mid *)
+      (max div 2, max div 2 + 1) (* mid vs mid+1 *)
+    ] end
+
+  (* Generate random pairs for a given type *)
+  fun gen_random_pairs_for utype seed n =
+    case utype of
+      U8 => next_list seed n (fn s =>
+              let val (a, s') = next_word8 s
+                  val (b, s'') = next_word8 s'
+              in ((Word8.toLargeInt a, Word8.toLargeInt b), s'') end)
+    | U16 => next_list seed n (fn s =>
+              let val (a, s') = next_word16 s
+                  val (b, s'') = next_word16 s'
+              in ((Word.toLargeInt a, Word.toLargeInt b), s'') end)
+    | U32 => next_list seed n (fn s =>
+              let val (a, s') = next_word32 s
+                  val (b, s'') = next_word32 s'
+              in ((Word32.toLargeInt a, Word32.toLargeInt b), s'') end)
+    | U64 => next_list seed n (fn s =>
+              let val (a, s') = next_word64 s
+                  val (b, s'') = next_word64 s'
+              in ((Word64.toLargeInt a, Word64.toLargeInt b), s'') end)
+
+  (* Generate all tests for a comparison operation on a type *)
+  fun gen_cmp_op_tests ctxt utype mk_term rust_op seed num_random =
+    let
+      val edges = cmp_edge_cases utype
+      val (random_pairs, _) = gen_random_pairs_for utype seed num_random
+      val all_pairs = edges @ random_pairs
+    in
+      map_index (fn (i, pair) => gen_cmp_test ctxt utype mk_term rust_op i pair) all_pairs
+    end
+
+  (* Generate tests for all comparison operations on a single type *)
+  fun generate_type_tests ctxt utype seed num_random =
+    let
+      val suffix = uint_rust_suffix utype
+    in
+      [("comparison_" ^ suffix ^ "_eq",
+        gen_cmp_op_tests ctxt utype mk_eq_term "==" seed num_random),
+       ("comparison_" ^ suffix ^ "_ne",
+        gen_cmp_op_tests ctxt utype mk_neq_term "!=" seed num_random),
+       ("comparison_" ^ suffix ^ "_lt",
+        gen_cmp_op_tests ctxt utype mk_less_term "<" seed num_random),
+       ("comparison_" ^ suffix ^ "_le",
+        gen_cmp_op_tests ctxt utype mk_less_eq_term "<=" seed num_random),
+       ("comparison_" ^ suffix ^ "_gt",
+        gen_cmp_op_tests ctxt utype mk_greater_term ">" seed num_random),
+       ("comparison_" ^ suffix ^ "_ge",
+        gen_cmp_op_tests ctxt utype mk_greater_eq_term ">=" seed num_random)]
+    end
+
+  (* Generate tests for all unsigned types *)
+  fun generate_all_tests ctxt num_random =
+    let
+      val seed = default_seed
+      val types = [U8, U16, U32, U64]
+    in
+      List.concat (map (fn t => generate_type_tests ctxt t seed num_random) types)
+    end
+
+end
+\<close>
+
+(*<*)
+end
+(*>*)

--- a/Conformance_Testing/Tests/Conversion_Conformance.thy
+++ b/Conformance_Testing/Tests/Conversion_Conformance.thy
@@ -1,0 +1,148 @@
+(* Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+   SPDX-License-Identifier: MIT *)
+
+(*<*)
+theory Conversion_Conformance
+  imports "../Conformance_Framework"
+begin
+(*>*)
+
+section\<open>Type Conversion Conformance Tests\<close>
+
+text\<open>This theory generates conformance tests for type conversion operations:
+\<^item> Narrowing conversions via @{term word_try_from_pure} (Rust's @{verbatim \<open>TryFrom\<close>} trait)
+
+Narrowing conversions return @{typ "'a option"}: @{term Some} if the value fits
+in the target type, @{term None} if it would overflow.
+
+Conversions tested:
+\<^item> u64 \<rightarrow> u32, u16, u8
+\<^item> u32 \<rightarrow> u16, u8
+\<^item> u16 \<rightarrow> u8
+\<close>
+
+subsection\<open>Test Generation Infrastructure\<close>
+
+ML\<open>
+structure Conversion_Conformance = struct
+  open Conformance_Random
+  open Conformance
+  open Rust_Codegen
+
+  (* Conversion specification: (source_bits, target_bits, rust_method) *)
+  type conversion = {
+    src_bits : int,
+    tgt_bits : int,
+    rust_method : string
+  }
+
+  val conversions : conversion list = [
+    {src_bits = 64, tgt_bits = 32, rust_method = "u32::try_from"},
+    {src_bits = 64, tgt_bits = 16, rust_method = "u16::try_from"},
+    {src_bits = 64, tgt_bits = 8,  rust_method = "u8::try_from"},
+    {src_bits = 32, tgt_bits = 16, rust_method = "u16::try_from"},
+    {src_bits = 32, tgt_bits = 8,  rust_method = "u8::try_from"},
+    {src_bits = 16, tgt_bits = 8,  rust_method = "u8::try_from"}
+  ]
+
+  fun bits_to_rust_suffix 8 = "u8"
+    | bits_to_rust_suffix 16 = "u16"
+    | bits_to_rust_suffix 32 = "u32"
+    | bits_to_rust_suffix 64 = "u64"
+    | bits_to_rust_suffix _ = raise Fail "unsupported bit width"
+
+  fun bits_to_max 8 = 255 : IntInf.int
+    | bits_to_max 16 = 65535
+    | bits_to_max 32 = 4294967295
+    | bits_to_max 64 = 18446744073709551615
+    | bits_to_max _ = raise Fail "unsupported bit width"
+
+  (* Build term string for word_try_from_pure with explicit types *)
+  fun mk_term_string src_bits tgt_bits (v : IntInf.int) =
+    "(word_try_from_pure (" ^ IntInf.toString v ^ " :: " ^
+    Int.toString src_bits ^ " word) :: " ^
+    Int.toString tgt_bits ^ " word option)"
+
+  fun parse_term ctxt s = Syntax.read_term ctxt s
+
+  (* Evaluate and convert to Rust *)
+  fun eval_option_to_rust ctxt term =
+    let
+      val result = Value_Command.value ctxt term
+      val test_res = term_to_option_result result
+    in
+      option_result_to_rust test_res
+    end
+
+  (* Generate a single test case *)
+  fun gen_test ctxt (conv : conversion) idx (v : IntInf.int) =
+    let
+      val term_str = mk_term_string (#src_bits conv) (#tgt_bits conv) v
+      val term = parse_term ctxt term_str
+      val expected = eval_option_to_rust ctxt term
+      val src_suffix = bits_to_rust_suffix (#src_bits conv)
+      val tgt_suffix = bits_to_rust_suffix (#tgt_bits conv)
+      val rust_expr = (#rust_method conv) ^ "(" ^ IntInf.toString v ^ src_suffix ^ ")"
+      (* Add .ok() to convert Result to Option for Rust's TryFrom *)
+      val rust_expr_with_ok = rust_expr ^ ".ok()"
+      val name = "test_" ^ Int.toString idx
+    in
+      {name = name, rust_expr = rust_expr_with_ok, expected = expected}
+    end
+
+  (* Edge cases for conversion testing *)
+  fun conversion_edge_cases (conv : conversion) =
+    let
+      val src_max = bits_to_max (#src_bits conv)
+      val tgt_max = bits_to_max (#tgt_bits conv)
+    in [
+      0,                      (* zero always fits *)
+      1,                      (* small value *)
+      tgt_max - 1,            (* just below target max *)
+      tgt_max,                (* exactly target max (fits) *)
+      tgt_max + 1,            (* just above target max (overflow) *)
+      src_max div 2,          (* mid source range *)
+      src_max - 1,            (* near source max *)
+      src_max                 (* source max (overflow unless same size) *)
+    ] end
+
+  (* Generate random source values *)
+  fun gen_random_values src_bits seed n =
+    case src_bits of
+      8 => next_list seed n (fn s =>
+             let val (w, s') = next_word8 s in (Word8.toLargeInt w, s') end)
+    | 16 => next_list seed n (fn s =>
+              let val (w, s') = next_word16 s in (Word.toLargeInt w, s') end)
+    | 32 => next_list seed n (fn s =>
+              let val (w, s') = next_word32 s in (Word32.toLargeInt w, s') end)
+    | 64 => next_list seed n (fn s =>
+              let val (w, s') = next_word64 s in (Word64.toLargeInt w, s') end)
+    | _ => raise Fail "unsupported bit width"
+
+  (* Generate all tests for a single conversion *)
+  fun gen_conversion_tests ctxt (conv : conversion) seed num_random =
+    let
+      val edges = conversion_edge_cases conv
+      val (randoms, _) = gen_random_values (#src_bits conv) seed num_random
+      val all_values = edges @ randoms
+      val src_suffix = bits_to_rust_suffix (#src_bits conv)
+      val tgt_suffix = bits_to_rust_suffix (#tgt_bits conv)
+      val mod_name = "conversion_" ^ src_suffix ^ "_to_" ^ tgt_suffix
+    in
+      (mod_name, map_index (fn (i, v) => gen_test ctxt conv i v) all_values)
+    end
+
+  (* Generate tests for all conversions *)
+  fun generate_all_tests ctxt num_random =
+    let
+      val seed = default_seed
+    in
+      map (fn conv => gen_conversion_tests ctxt conv seed num_random) conversions
+    end
+
+end
+\<close>
+
+(*<*)
+end
+(*>*)

--- a/Conformance_Testing/Tests/Generate_All.thy
+++ b/Conformance_Testing/Tests/Generate_All.thy
@@ -1,0 +1,119 @@
+(* Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+   SPDX-License-Identifier: MIT *)
+
+(*<*)
+theory Generate_All
+  imports
+    Arithmetic_Conformance
+    Bitwise_Conformance
+    Comparison_Conformance
+    Conversion_Conformance
+    Panic_Conformance
+    StdLib_Arithmetic_Conformance
+    Option_Conformance
+    Result_Conformance
+    Range_Conformance
+    Ordering_Conformance
+    Tuple_Conformance
+begin
+(*>*)
+
+section\<open>Unified Test Generation\<close>
+
+text\<open>This theory imports all conformance test theories and triggers unified
+generation of all Rust tests to a single file.
+
+After loading this theory, all test generators will run and produce
+@{verbatim \<open>rust_harness/src/lib.rs\<close>} containing all conformance tests,
+plus coverage summaries in @{verbatim \<open>rust_harness/coverage_summary.{json,md}\<close>}.
+\<close>
+
+ML\<open>
+(* Unified test generation - explicitly calls each generator *)
+structure Conformance_Gen = struct
+  val output_path = "../rust_harness/src/lib.rs"
+  val coverage_json_path = "../rust_harness/coverage_summary.json"
+  val coverage_markdown_path = "../rust_harness/coverage_summary.md"
+  val num_random = 100
+  val required_categories = [
+    "arithmetic", "bitwise", "comparison", "conversion", "panic", "stdlibarith",
+    "option", "result", "range", "ordering", "tuple"
+  ]
+
+  fun module_test_count modules = length (List.concat (map snd modules))
+
+  fun collect label generator =
+    let
+      val _ = writeln ("[conformance] generating " ^ label)
+      val modules = generator ()
+      val _ = writeln ("[conformance] generated " ^ label ^ " (" ^
+        Int.toString (module_test_count modules) ^ " tests)")
+    in
+      modules
+    end
+
+  fun generate_all_tests ctxt =
+    let
+      val arith_tests = collect "arithmetic" (fn () => Arith_Conformance.generate_all_tests ctxt num_random)
+      val bitwise_tests = collect "bitwise" (fn () => Bitwise_Conformance.generate_all_tests ctxt num_random)
+      val comparison_tests = collect "comparison" (fn () => Comparison_Conformance.generate_all_tests ctxt num_random)
+      val conversion_tests = collect "conversion" (fn () => Conversion_Conformance.generate_all_tests ctxt num_random)
+      val panic_tests = collect "panic" (fn () => Panic_Conformance.generate_all_tests ctxt num_random)
+      val stdlib_arith_tests = collect "stdlibarith" (fn () => StdLib_Arithmetic_Conformance.generate_all_tests ctxt num_random)
+      val option_tests = collect "option" (fn () => Option_Conformance.generate_all_tests ctxt num_random)
+      val result_tests = collect "result" (fn () => Result_Conformance.generate_all_tests ctxt num_random)
+      val range_tests = collect "range" (fn () => Range_Conformance.generate_all_tests ctxt num_random)
+      val ordering_tests = collect "ordering" (fn () => Ordering_Conformance.generate_all_tests ctxt num_random)
+      val tuple_tests = collect "tuple" (fn () => Tuple_Conformance.generate_all_tests ctxt num_random)
+    in
+      arith_tests
+      @ bitwise_tests
+      @ comparison_tests
+      @ conversion_tests
+      @ panic_tests
+      @ stdlib_arith_tests
+      @ option_tests
+      @ result_tests
+      @ range_tests
+      @ ordering_tests
+      @ tuple_tests
+    end
+
+  fun write_all_tests ctxt =
+    let
+      val thy = Proof_Context.theory_of ctxt
+      val modules = generate_all_tests ctxt
+      val _ = Conformance_Coverage.require_categories required_categories modules
+      val content = Rust_Codegen.generate_test_file modules
+      val dir = Resources.master_directory thy
+      val path = Path.append dir (Path.explode output_path)
+      val coverage_json = Path.append dir (Path.explode coverage_json_path)
+      val coverage_markdown = Path.append dir (Path.explode coverage_markdown_path)
+      val path_str = File.platform_path path
+      val coverage_json_str = File.platform_path coverage_json
+      val coverage_markdown_str = File.platform_path coverage_markdown
+      val _ = Rust_Codegen.write_test_file path_str content
+      val _ =
+        Conformance_Coverage.write_summary_files
+          {json_path = coverage_json_str, markdown_path = coverage_markdown_str, modules = modules}
+      val total = length (List.concat (map snd modules))
+    in
+      writeln ("Generated " ^ Int.toString total ^ " total conformance tests");
+      writeln ("Output: " ^ path_str);
+      writeln ("Coverage summary (JSON): " ^ coverage_json_str);
+      writeln ("Coverage summary (Markdown): " ^ coverage_markdown_str)
+    end
+
+  fun regenerate_all ctxt = write_all_tests ctxt
+end
+\<close>
+
+subsection\<open>Generate Tests\<close>
+
+text\<open>Generate all conformance tests when this theory is loaded.\<close>
+
+ML\<open>Conformance_Gen.regenerate_all \<^context>\<close>
+
+(*<*)
+end
+(*>*)

--- a/Conformance_Testing/Tests/Option_Conformance.thy
+++ b/Conformance_Testing/Tests/Option_Conformance.thy
@@ -1,0 +1,267 @@
+(* Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+   SPDX-License-Identifier: MIT *)
+
+(*<*)
+theory Option_Conformance
+  imports
+    "../Conformance_Framework"
+    Micro_Rust_Std_Lib.StdLib_Option
+begin
+(*>*)
+
+section\<open>Option Conformance Tests\<close>
+
+text\<open>This theory generates conformance tests for Option APIs by evaluating the
+actual Micro Rust function bodies (via @{term evaluate} and @{term call}), then
+comparing against real Rust behaviour.\<close>
+
+ML\<open>
+structure Option_Conformance = struct
+  open Conformance_Random
+  open Conformance
+  open Rust_Codegen
+
+  datatype uint_type = U8 | U16 | U32 | U64
+
+  fun uint_bits U8 = 8 | uint_bits U16 = 16 | uint_bits U32 = 32 | uint_bits U64 = 64
+  fun uint_rust_suffix U8 = "u8" | uint_rust_suffix U16 = "u16"
+    | uint_rust_suffix U32 = "u32" | uint_rust_suffix U64 = "u64"
+  fun uint_max U8 = 255 : IntInf.int
+    | uint_max U16 = 65535
+    | uint_max U32 = 4294967295
+    | uint_max U64 = 18446744073709551615
+
+  fun parse_term ctxt s = Syntax.read_term ctxt s
+
+  fun eval_bool_to_rust ctxt term =
+    (case term_to_bool (Value_Command.value ctxt term) of
+      SOME true => "true"
+    | SOME false => "false"
+    | NONE => raise Fail "Failed to extract bool result")
+
+  fun hol_word bits n = "(" ^ IntInf.toString n ^ " :: " ^ Int.toString bits ^ " word)"
+
+  fun hol_option_literal bits NONE =
+        "(None :: " ^ Int.toString bits ^ " word option)"
+    | hol_option_literal bits (SOME v) =
+        "(Some " ^ hol_word bits v ^ ")"
+
+  fun rust_option_literal suffix NONE =
+        "None::<" ^ suffix ^ ">"
+    | rust_option_literal suffix (SOME v) =
+        "Some(" ^ IntInf.toString v ^ suffix ^ ")"
+
+  fun mk_call_bool_term ctxt body =
+    parse_term ctxt
+      ("(case evaluate (call (" ^ body ^ ")) () of Success r _ => r | _ => False)")
+
+  fun mk_call_eq_term ctxt body expected =
+    parse_term ctxt
+      ("(case evaluate (call (" ^ body ^ ")) () of Success r _ => (r = " ^ expected ^ ") | _ => False)")
+
+  fun mk_call_panic_term ctxt body =
+    parse_term ctxt
+      ("(case evaluate (call (" ^ body ^ ")) () of Abort (Panic _) _ => True | _ => False)")
+
+  fun mk_ok_or_is_ok_term ctxt bits opt err =
+    let
+      val opt_str = hol_option_literal bits opt
+      val err_str = hol_word bits err
+      val body = "ok_or " ^ opt_str ^ " " ^ err_str
+    in
+      parse_term ctxt
+        ("(case evaluate (call (" ^ body ^ ")) () of "
+         ^ "Success r _ => (case r of Ok _ => True | Err _ => False) | _ => False)")
+    end
+
+  fun mk_ok_or_ok_value_term ctxt bits opt err =
+    let
+      val opt_str = hol_option_literal bits opt
+      val err_str = hol_word bits err
+      val body = "ok_or " ^ opt_str ^ " " ^ err_str
+      val expected_ok =
+        (case opt of
+          SOME v => hol_word bits v
+        | NONE => hol_word bits 0)
+    in
+      parse_term ctxt
+        ("(case evaluate (call (" ^ body ^ ")) () of "
+         ^ "Success r _ => (case r of Ok v => (v = " ^ expected_ok ^ ") | Err _ => False) "
+         ^ "| _ => False)")
+    end
+
+  fun mk_ok_or_err_value_term ctxt bits opt err =
+    let
+      val opt_str = hol_option_literal bits opt
+      val err_str = hol_word bits err
+      val body = "ok_or " ^ opt_str ^ " " ^ err_str
+    in
+      parse_term ctxt
+        ("(case evaluate (call (" ^ body ^ ")) () of "
+         ^ "Success r _ => (case r of Err e => (e = " ^ err_str ^ ") | Ok _ => False) "
+         ^ "| _ => False)")
+    end
+
+  fun gen_random_values_for utype seed n =
+    (case utype of
+      U8 => next_list seed n (fn s =>
+              let val (a, s') = next_word8 s in (Word8.toLargeInt a, s') end)
+    | U16 => next_list seed n (fn s =>
+              let val (a, s') = next_word16 s in (Word.toLargeInt a, s') end)
+    | U32 => next_list seed n (fn s =>
+              let val (a, s') = next_word32 s in (Word32.toLargeInt a, s') end)
+    | U64 => next_list seed n (fn s =>
+              let val (a, s') = next_word64 s in (Word64.toLargeInt a, s') end))
+
+  fun option_edge_cases utype =
+    let
+      val max = uint_max utype
+    in
+      [NONE, SOME 0, SOME 1, SOME (max - 1), SOME max]
+    end
+
+  fun ok_or_edge_cases utype =
+    let
+      val max = uint_max utype
+    in
+      [(NONE, 0), (NONE, 1), (SOME 0, 0), (SOME 1, max), (SOME max, 1),
+       (SOME (max - 1), max), (NONE, max), (SOME 42, 7), (SOME 7, 42), (NONE, 42)]
+    end
+
+  fun inject_nones values =
+    map_index (fn (i, v) => if i mod 4 = 0 then NONE else SOME v) values
+
+  fun make_ok_or_random_pairs values errs =
+    map (fn (v, e) => (if IntInf.mod (v, 5) = 0 then NONE else SOME v, e))
+      (ListPair.zip (values, errs))
+
+  fun generate_type_tests ctxt utype seed num_random =
+    let
+      val bits = uint_bits utype
+      val suffix = uint_rust_suffix utype
+      val (rand_vals_a, seed') = gen_random_values_for utype seed num_random
+      val (rand_vals_b, _) = gen_random_values_for utype seed' num_random
+
+      val opt_cases = option_edge_cases utype @ inject_nones rand_vals_a
+      val unwrap_values = map_filter I opt_cases
+      val ok_or_cases = ok_or_edge_cases utype @ make_ok_or_random_pairs rand_vals_a rand_vals_b
+
+      fun eval_test mk_expected mk_rust cases =
+        map_index
+          (fn (i, x) =>
+            {name = "test_" ^ Int.toString i,
+             rust_expr = mk_rust x,
+             expected = eval_bool_to_rust ctxt (mk_expected x)})
+          cases
+
+      fun mk_option_body fn_name opt =
+        fn_name ^ " " ^ hol_option_literal bits opt
+
+      val is_none_tests =
+        ("option_" ^ suffix ^ "_is_none",
+         eval_test
+           (fn opt => mk_call_bool_term ctxt (mk_option_body "urust_func_option_is_none" opt))
+           (fn opt => rust_option_literal suffix opt ^ ".is_none()")
+           opt_cases)
+
+      val is_some_tests =
+        ("option_" ^ suffix ^ "_is_some",
+         eval_test
+           (fn opt => mk_call_bool_term ctxt (mk_option_body "urust_func_option_is_some" opt))
+           (fn opt => rust_option_literal suffix opt ^ ".is_some()")
+           opt_cases)
+
+      val unwrap_panic_tests =
+        ("option_" ^ suffix ^ "_unwrap_panics",
+         eval_test
+           (fn opt => mk_call_panic_term ctxt (mk_option_body "option_unwrap" opt))
+           (fn opt => "std::panic::catch_unwind(|| { let _ = "
+                      ^ rust_option_literal suffix opt ^ ".unwrap(); }).is_err()")
+           opt_cases)
+
+      val unwrap_value_tests =
+        ("option_" ^ suffix ^ "_unwrap_value",
+         eval_test
+           (fn v =>
+             mk_call_eq_term ctxt
+               (mk_option_body "option_unwrap" (SOME v))
+               (hol_word bits v))
+           (fn v => "Some(" ^ IntInf.toString v ^ suffix ^ ").unwrap() == " ^ IntInf.toString v ^ suffix)
+           unwrap_values)
+
+      val expect_panic_tests =
+        ("option_" ^ suffix ^ "_expect_panics",
+         eval_test
+           (fn opt =>
+             mk_call_panic_term ctxt
+               ("option_expect " ^ hol_option_literal bits opt ^ " (STR ''expect'')"))
+           (fn opt => "std::panic::catch_unwind(|| { let _ = "
+                      ^ rust_option_literal suffix opt ^ ".expect(\"expect\"); }).is_err()")
+           opt_cases)
+
+      val expect_value_tests =
+        ("option_" ^ suffix ^ "_expect_value",
+         eval_test
+           (fn v =>
+             mk_call_eq_term ctxt
+               ("option_expect " ^ hol_option_literal bits (SOME v) ^ " (STR ''expect'')")
+               (hol_word bits v))
+           (fn v => "Some(" ^ IntInf.toString v ^ suffix ^ ").expect(\"expect\") == "
+                    ^ IntInf.toString v ^ suffix)
+           unwrap_values)
+
+      val ok_or_is_ok_tests =
+        ("option_" ^ suffix ^ "_ok_or_is_ok",
+         eval_test
+           (fn (opt, err) => mk_ok_or_is_ok_term ctxt bits opt err)
+           (fn (opt, err) =>
+              rust_option_literal suffix opt ^ ".ok_or(" ^ IntInf.toString err ^ suffix ^ ").is_ok()")
+           ok_or_cases)
+
+      val ok_or_ok_value_tests =
+        ("option_" ^ suffix ^ "_ok_or_ok_value",
+         eval_test
+           (fn (opt, err) => mk_ok_or_ok_value_term ctxt bits opt err)
+           (fn (opt, err) =>
+              let
+                val expected =
+                  (case opt of SOME v => IntInf.toString v | NONE => "0")
+              in
+                "(match " ^ rust_option_literal suffix opt ^ ".ok_or(" ^ IntInf.toString err ^ suffix ^ ") { "
+                ^ "Ok(v) => v == " ^ expected ^ suffix ^ ", Err(_) => false })"
+              end)
+           ok_or_cases)
+
+      val ok_or_err_value_tests =
+        ("option_" ^ suffix ^ "_ok_or_err_value",
+         eval_test
+           (fn (opt, err) => mk_ok_or_err_value_term ctxt bits opt err)
+           (fn (opt, err) =>
+              "(match " ^ rust_option_literal suffix opt ^ ".ok_or(" ^ IntInf.toString err ^ suffix ^ ") { "
+              ^ "Err(e) => e == " ^ IntInf.toString err ^ suffix ^ ", Ok(_) => false })")
+           ok_or_cases)
+    in
+      [is_none_tests,
+       is_some_tests,
+       unwrap_panic_tests,
+       unwrap_value_tests,
+       expect_panic_tests,
+       expect_value_tests,
+       ok_or_is_ok_tests,
+       ok_or_ok_value_tests,
+       ok_or_err_value_tests]
+    end
+
+  fun generate_all_tests ctxt num_random =
+    let
+      val seed = default_seed
+      val types = [U8, U16, U32, U64]
+    in
+      List.concat (map (fn t => generate_type_tests ctxt t seed num_random) types)
+    end
+end
+\<close>
+
+(*<*)
+end
+(*>*)

--- a/Conformance_Testing/Tests/Ordering_Conformance.thy
+++ b/Conformance_Testing/Tests/Ordering_Conformance.thy
@@ -1,0 +1,148 @@
+(* Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+   SPDX-License-Identifier: MIT *)
+
+(*<*)
+theory Ordering_Conformance
+  imports
+    "../Conformance_Framework"
+begin
+(*>*)
+
+section\<open>Ordering Conformance Tests\<close>
+
+text\<open>This theory generates conformance tests for ordering comparisons via Rust's ordering API.
+\<close>
+
+ML\<open>
+structure Ordering_Conformance = struct
+  open Conformance_Random
+  open Conformance
+  open Rust_Codegen
+
+  datatype uint_type = U8 | U16 | U32 | U64
+
+  fun uint_bits U8 = 8 | uint_bits U16 = 16 | uint_bits U32 = 32 | uint_bits U64 = 64
+  fun uint_rust_suffix U8 = "u8" | uint_rust_suffix U16 = "u16"
+    | uint_rust_suffix U32 = "u32" | uint_rust_suffix U64 = "u64"
+  fun uint_max U8 = 255 : IntInf.int
+    | uint_max U16 = 65535
+    | uint_max U32 = 4294967295
+    | uint_max U64 = 18446744073709551615
+
+  fun parse_term ctxt s = Syntax.read_term ctxt s
+
+  fun eval_bool_to_rust ctxt term =
+    (case term_to_bool (Value_Command.value ctxt term) of
+      SOME true => "true"
+    | SOME false => "false"
+    | NONE => raise Fail "Failed to extract bool result")
+
+  fun mk_cmp_is_less_term ctxt utype (a, b) =
+    let
+      val bits = Int.toString (uint_bits utype)
+      val a_str = IntInf.toString a
+      val b_str = IntInf.toString b
+    in
+      parse_term ctxt
+        ("((" ^ a_str ^ " :: " ^ bits ^ " word) < (" ^ b_str ^ " :: " ^ bits ^ " word))")
+    end
+
+  fun mk_cmp_is_equal_term ctxt utype (a, b) =
+    let
+      val bits = Int.toString (uint_bits utype)
+      val a_str = IntInf.toString a
+      val b_str = IntInf.toString b
+    in
+      parse_term ctxt
+        ("((" ^ a_str ^ " :: " ^ bits ^ " word) = (" ^ b_str ^ " :: " ^ bits ^ " word))")
+    end
+
+  fun mk_cmp_is_greater_term ctxt utype (a, b) =
+    let
+      val bits = Int.toString (uint_bits utype)
+      val a_str = IntInf.toString a
+      val b_str = IntInf.toString b
+    in
+      parse_term ctxt
+        ("((" ^ a_str ^ " :: " ^ bits ^ " word) > (" ^ b_str ^ " :: " ^ bits ^ " word))")
+    end
+
+  fun cmp_edge_cases utype =
+    let
+      val max = uint_max utype
+    in
+      [(0, 0), (0, 1), (1, 0), (max, max), (max - 1, max), (max, max - 1),
+       (0, max), (max, 0), (max div 2, max div 2), (max div 2, max div 2 + 1)]
+    end
+
+  fun gen_random_pairs_for utype seed n =
+    (case utype of
+      U8 =>
+        next_list seed n (fn s =>
+          let
+            val (a, s') = next_word8 s
+            val (b, s'') = next_word8 s'
+          in
+            ((Word8.toLargeInt a, Word8.toLargeInt b), s'')
+          end)
+    | U16 =>
+        next_list seed n (fn s =>
+          let
+            val (a, s') = next_word16 s
+            val (b, s'') = next_word16 s'
+          in
+            ((Word.toLargeInt a, Word.toLargeInt b), s'')
+          end)
+    | U32 =>
+        next_list seed n (fn s =>
+          let
+            val (a, s') = next_word32 s
+            val (b, s'') = next_word32 s'
+          in
+            ((Word32.toLargeInt a, Word32.toLargeInt b), s'')
+          end)
+    | U64 =>
+        next_list seed n (fn s =>
+          let
+            val (a, s') = next_word64 s
+            val (b, s'') = next_word64 s'
+          in
+            ((Word64.toLargeInt a, Word64.toLargeInt b), s'')
+          end))
+
+  fun generate_type_tests ctxt utype seed num_random =
+    let
+      val suffix = uint_rust_suffix utype
+      val edges = cmp_edge_cases utype
+      val (random_pairs, _) = gen_random_pairs_for utype seed num_random
+      val pairs = edges @ random_pairs
+
+      fun mk_tests module_suffix mk_term ord_tag =
+        ("ordering_" ^ suffix ^ "_" ^ module_suffix,
+          map_index
+            (fn (i, pair as (a, b)) =>
+              {name = "test_" ^ Int.toString i,
+               rust_expr =
+                 "matches!(" ^ IntInf.toString a ^ suffix ^ ".cmp(&" ^ IntInf.toString b ^ suffix
+                 ^ "), std::cmp::Ordering::" ^ ord_tag ^ ")",
+               expected = eval_bool_to_rust ctxt (mk_term ctxt utype pair)})
+            pairs)
+    in
+      [mk_tests "cmp_is_less" mk_cmp_is_less_term "Less",
+       mk_tests "cmp_is_equal" mk_cmp_is_equal_term "Equal",
+       mk_tests "cmp_is_greater" mk_cmp_is_greater_term "Greater"]
+    end
+
+  fun generate_all_tests ctxt num_random =
+    let
+      val seed = default_seed
+      val types = [U8, U16, U32, U64]
+    in
+      List.concat (map (fn t => generate_type_tests ctxt t seed num_random) types)
+    end
+end
+\<close>
+
+(*<*)
+end
+(*>*)

--- a/Conformance_Testing/Tests/Panic_Conformance.thy
+++ b/Conformance_Testing/Tests/Panic_Conformance.thy
@@ -1,0 +1,271 @@
+(* Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+   SPDX-License-Identifier: MIT *)
+
+(*<*)
+theory Panic_Conformance
+  imports "../Conformance_Framework"
+begin
+(*>*)
+
+section\<open>Panic Conformance Tests\<close>
+
+text\<open>This theory generates conformance tests for expression-level operations that may panic:
+\<^item> Arithmetic overflow: @{term word_add_no_wrap_core}, @{term word_minus_no_wrap_core}, @{term word_mul_no_wrap_core}
+\<^item> Division/modulo by zero: @{term word_udiv_core}, @{term word_umod_core}
+\<^item> Invalid shifts: @{term word_shift_left_core}, @{term word_shift_right_core}
+
+For each generated test case:
+\<^enum> HOL evaluates the corresponding \<^emph>\<open>expression-level\<close> term using @{term evaluate}
+\<^enum> We extract whether the result has shape @{verbatim \<open>Abort (Panic msg) \<sigma>\<close>}
+\<^enum> Rust checks panic behaviour via @{verbatim \<open>std::panic::catch_unwind\<close>}
+
+This directly validates panic-path conformance, not only successful executions.
+\<close>
+
+subsection\<open>Test Generation Infrastructure\<close>
+
+ML\<open>
+structure Panic_Conformance = struct
+  open Conformance_Random
+  open Conformance
+  open Rust_Codegen
+
+  datatype uint_type = U8 | U16 | U32 | U64
+  datatype panic_op = Add | Sub | Mul | Div | Mod | Shl | Shr
+
+  fun uint_bits U8 = 8 | uint_bits U16 = 16 | uint_bits U32 = 32 | uint_bits U64 = 64
+  fun uint_rust_suffix U8 = "u8" | uint_rust_suffix U16 = "u16"
+    | uint_rust_suffix U32 = "u32" | uint_rust_suffix U64 = "u64"
+  fun uint_max U8 = 255 : IntInf.int
+    | uint_max U16 = 65535
+    | uint_max U32 = 4294967295
+    | uint_max U64 = 18446744073709551615
+
+  fun op_suffix Add = "add"
+    | op_suffix Sub = "sub"
+    | op_suffix Mul = "mul"
+    | op_suffix Div = "div"
+    | op_suffix Mod = "mod"
+    | op_suffix Shl = "shl"
+    | op_suffix Shr = "shr"
+
+  fun is_shift_op Shl = true
+    | is_shift_op Shr = true
+    | is_shift_op _ = false
+
+  fun mk_term_string op_kind bits (a : IntInf.int, b : IntInf.int) =
+    let
+      val bits_str = Int.toString bits
+      val a_str = IntInf.toString a
+      val b_str = IntInf.toString b
+      val core_call =
+        (case op_kind of
+          Add => "word_add_no_wrap_core (" ^ a_str ^ " :: " ^ bits_str ^ " word) (" ^ b_str ^ " :: " ^ bits_str ^ " word)"
+        | Sub => "word_minus_no_wrap_core (" ^ a_str ^ " :: " ^ bits_str ^ " word) (" ^ b_str ^ " :: " ^ bits_str ^ " word)"
+        | Mul => "word_mul_no_wrap_core (" ^ a_str ^ " :: " ^ bits_str ^ " word) (" ^ b_str ^ " :: " ^ bits_str ^ " word)"
+        | Div => "word_udiv_core (" ^ a_str ^ " :: " ^ bits_str ^ " word) (" ^ b_str ^ " :: " ^ bits_str ^ " word)"
+        | Mod => "word_umod_core (" ^ a_str ^ " :: " ^ bits_str ^ " word) (" ^ b_str ^ " :: " ^ bits_str ^ " word)"
+        | Shl => "word_shift_left_core (" ^ a_str ^ " :: " ^ bits_str ^ " word) (" ^ b_str ^ " :: 32 word)"
+        | Shr => "word_shift_right_core (" ^ a_str ^ " :: " ^ bits_str ^ " word) (" ^ b_str ^ " :: 32 word)")
+    in
+      "(evaluate (" ^ core_call ^ " :: (unit, " ^ bits_str ^ " word, unit, unit, unit, unit) expression) ())"
+    end
+
+  fun parse_term ctxt s = Syntax.read_term ctxt s
+
+  fun eval_panic_to_rust ctxt term =
+    (case term_to_panic_abort (Value_Command.value ctxt term) of
+      SOME true => "true"
+    | SOME false => "false"
+    | NONE => raise Fail "Failed to extract panic result from continuation term")
+
+  fun mk_checked_expr op_kind suffix (a : IntInf.int, b : IntInf.int) =
+    let
+      val a_str = IntInf.toString a
+      val b_str = IntInf.toString b
+    in
+      (case op_kind of
+        Add => a_str ^ suffix ^ ".checked_add(" ^ b_str ^ suffix ^ ").unwrap()"
+      | Sub => a_str ^ suffix ^ ".checked_sub(" ^ b_str ^ suffix ^ ").unwrap()"
+      | Mul => a_str ^ suffix ^ ".checked_mul(" ^ b_str ^ suffix ^ ").unwrap()"
+      | Div => a_str ^ suffix ^ ".checked_div(" ^ b_str ^ suffix ^ ").unwrap()"
+      | Mod => a_str ^ suffix ^ ".checked_rem(" ^ b_str ^ suffix ^ ").unwrap()"
+      | Shl => a_str ^ suffix ^ ".checked_shl(" ^ b_str ^ "u32).unwrap()"
+      | Shr => a_str ^ suffix ^ ".checked_shr(" ^ b_str ^ "u32).unwrap()")
+    end
+
+  fun mk_rust_panic_check_expr op_kind suffix pair =
+    "std::panic::catch_unwind(|| { let _ = " ^ mk_checked_expr op_kind suffix pair ^ "; }).is_err()"
+
+  fun overflow_edge_cases utype =
+    let
+      val max = uint_max utype
+      val mid = max div 2
+    in
+      [(0, 0), (1, 1), (max, 0), (max, 1), (max, max), (max, max - 1),
+       (mid, mid), (mid + 1, mid + 1), (0, max), (1, max)]
+    end
+
+  fun underflow_edge_cases utype =
+    let
+      val max = uint_max utype
+      val mid = max div 2
+    in
+      [(0, 0), (0, 1), (1, 0), (max, max), (max, 1), (1, max),
+       (mid, mid + 1), (mid + 1, mid), (max, 0), (0, max)]
+    end
+
+  fun div_mod_edge_cases utype =
+    let
+      val max = uint_max utype
+      val mid = max div 2
+    in
+      [(0, 1), (1, 1), (10, 3), (10, 0), (max, 1), (max, max),
+       (0, 0), (1, 0), (max, 0), (mid, 2)]
+    end
+
+  fun shift_edge_cases utype =
+    let
+      val max = uint_max utype
+      val bits = IntInf.fromInt (uint_bits utype)
+    in
+      [(1, 0), (1, 1), (1, bits - 1), (1, bits), (1, bits + 1),
+       (max, 0), (max, 1), (max, bits - 1), (max, bits), (max, bits + 2)]
+    end
+
+  fun edge_cases_for op_kind utype =
+    (case op_kind of
+      Add => overflow_edge_cases utype
+    | Sub => underflow_edge_cases utype
+    | Mul => overflow_edge_cases utype
+    | Div => div_mod_edge_cases utype
+    | Mod => div_mod_edge_cases utype
+    | Shl => shift_edge_cases utype
+    | Shr => shift_edge_cases utype)
+
+  fun gen_random_pairs_for utype seed n =
+    (case utype of
+      U8 =>
+        next_list seed n (fn s =>
+          let
+            val (a, s') = next_word8 s
+            val (b, s'') = next_word8 s'
+          in
+            ((Word8.toLargeInt a, Word8.toLargeInt b), s'')
+          end)
+    | U16 =>
+        next_list seed n (fn s =>
+          let
+            val (a, s') = next_word16 s
+            val (b, s'') = next_word16 s'
+          in
+            ((Word.toLargeInt a, Word.toLargeInt b), s'')
+          end)
+    | U32 =>
+        next_list seed n (fn s =>
+          let
+            val (a, s') = next_word32 s
+            val (b, s'') = next_word32 s'
+          in
+            ((Word32.toLargeInt a, Word32.toLargeInt b), s'')
+          end)
+    | U64 =>
+        next_list seed n (fn s =>
+          let
+            val (a, s') = next_word64 s
+            val (b, s'') = next_word64 s'
+          in
+            ((Word64.toLargeInt a, Word64.toLargeInt b), s'')
+          end))
+
+  fun gen_random_shift_pairs_for utype seed n =
+    let
+      val bits = uint_bits utype
+    in
+      (case utype of
+        U8 =>
+          next_list seed n (fn s =>
+            let
+              val (value, s') = next_word8 s
+              val (shift, s'') = next_int s' 0 (bits + 5)
+            in
+              ((Word8.toLargeInt value, IntInf.fromInt shift), s'')
+            end)
+      | U16 =>
+          next_list seed n (fn s =>
+            let
+              val (value, s') = next_word16 s
+              val (shift, s'') = next_int s' 0 (bits + 5)
+            in
+              ((Word.toLargeInt value, IntInf.fromInt shift), s'')
+            end)
+      | U32 =>
+          next_list seed n (fn s =>
+            let
+              val (value, s') = next_word32 s
+              val (shift, s'') = next_int s' 0 (bits + 5)
+            in
+              ((Word32.toLargeInt value, IntInf.fromInt shift), s'')
+            end)
+      | U64 =>
+          next_list seed n (fn s =>
+            let
+              val (value, s') = next_word64 s
+              val (shift, s'') = next_int s' 0 (bits + 5)
+            in
+              ((Word64.toLargeInt value, IntInf.fromInt shift), s'')
+            end))
+    end
+
+  fun gen_test ctxt utype op_kind idx pair =
+    let
+      val bits = uint_bits utype
+      val suffix = uint_rust_suffix utype
+      val term = parse_term ctxt (mk_term_string op_kind bits pair)
+      val expected = eval_panic_to_rust ctxt term
+      val rust_expr = mk_rust_panic_check_expr op_kind suffix pair
+      val name = "test_" ^ Int.toString idx
+    in
+      {name = name, rust_expr = rust_expr, expected = expected}
+    end
+
+  fun gen_op_tests ctxt utype op_kind seed num_random =
+    let
+      val edges = edge_cases_for op_kind utype
+      val (random_pairs, _) =
+        if is_shift_op op_kind
+        then gen_random_shift_pairs_for utype seed num_random
+        else gen_random_pairs_for utype seed num_random
+      val all_pairs = edges @ random_pairs
+    in
+      map_index (fn (i, pair) => gen_test ctxt utype op_kind i pair) all_pairs
+    end
+
+  fun generate_type_tests ctxt utype seed num_random =
+    let
+      val suffix = uint_rust_suffix utype
+      fun mod_name op_kind = "panic_" ^ suffix ^ "_" ^ op_suffix op_kind
+      fun tests op_kind = gen_op_tests ctxt utype op_kind seed num_random
+    in
+      [(mod_name Add, tests Add),
+       (mod_name Sub, tests Sub),
+       (mod_name Mul, tests Mul),
+       (mod_name Div, tests Div),
+       (mod_name Mod, tests Mod),
+       (mod_name Shl, tests Shl),
+       (mod_name Shr, tests Shr)]
+    end
+
+  fun generate_all_tests ctxt num_random =
+    let
+      val seed = default_seed
+      val types = [U8, U16, U32, U64]
+    in
+      List.concat (map (fn t => generate_type_tests ctxt t seed num_random) types)
+    end
+end
+\<close>
+
+(*<*)
+end
+(*>*)

--- a/Conformance_Testing/Tests/Range_Conformance.thy
+++ b/Conformance_Testing/Tests/Range_Conformance.thy
@@ -1,0 +1,527 @@
+(* Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+   SPDX-License-Identifier: MIT *)
+
+(*<*)
+theory Range_Conformance
+  imports
+    "../Conformance_Framework"
+    Shallow_Micro_Rust.Range_Type
+begin
+(*>*)
+
+section\<open>Range Conformance Tests\<close>
+
+text\<open>This theory generates conformance tests for Range/slice APIs by evaluating the
+actual Micro Rust function bodies (via @{term evaluate} and @{term call}), then
+comparing against real Rust behaviour.\<close>
+
+ML\<open>
+structure Range_Conformance = struct
+  open Conformance_Random
+  open Conformance
+  open Rust_Codegen
+
+  datatype uint_type = U8 | U16 | U32 | U64
+
+  fun uint_bits U8 = 8 | uint_bits U16 = 16 | uint_bits U32 = 32 | uint_bits U64 = 64
+  fun uint_rust_suffix U8 = "u8" | uint_rust_suffix U16 = "u16"
+    | uint_rust_suffix U32 = "u32" | uint_rust_suffix U64 = "u64"
+  fun uint_max U8 = 255 : IntInf.int
+    | uint_max U16 = 65535
+    | uint_max U32 = 4294967295
+    | uint_max U64 = 18446744073709551615
+
+  val container_len = 5
+
+  fun parse_term ctxt s = Syntax.read_term ctxt s
+
+  fun eval_bool_to_rust ctxt term =
+    (case term_to_bool (Value_Command.value ctxt term) of
+      SOME true => "true"
+    | SOME false => "false"
+    | NONE => raise Fail "Failed to extract bool result")
+
+  fun hol_word bits n = "(" ^ IntInf.toString n ^ " :: " ^ Int.toString bits ^ " word)"
+
+  fun hol_word_list bits xs =
+    "[" ^ String.concatWith ", " (map (hol_word bits) xs) ^ "]"
+
+  fun rust_array suffix xs =
+    "[" ^ String.concatWith ", " (map (fn x => IntInf.toString x ^ suffix) xs) ^ "]"
+
+  fun rust_vec suffix xs =
+    "vec![" ^ String.concatWith ", " (map (fn x => IntInf.toString x ^ suffix) xs) ^ "]"
+
+  fun mk_call_bool_term ctxt body =
+    parse_term ctxt
+      ("(case evaluate (call (" ^ body ^ ")) () of Success r _ => r | _ => False)")
+
+  fun mk_call_eq_term ctxt body expected =
+    parse_term ctxt
+      ("(case evaluate (call (" ^ body ^ ")) () of Success r _ => (r = " ^ expected ^ ") | _ => False)")
+
+  fun mk_call_dangling_term ctxt body =
+    parse_term ctxt
+      ("(case evaluate (call (" ^ body ^ ")) () of Abort DanglingPointer _ => True | _ => False)")
+
+  fun gen_random_values_for utype seed n =
+    (case utype of
+      U8 => next_list seed n (fn s =>
+              let val (a, s') = next_word8 s in (Word8.toLargeInt a, s') end)
+    | U16 => next_list seed n (fn s =>
+              let val (a, s') = next_word16 s in (Word.toLargeInt a, s') end)
+    | U32 => next_list seed n (fn s =>
+              let val (a, s') = next_word32 s in (Word32.toLargeInt a, s') end)
+    | U64 => next_list seed n (fn s =>
+              let val (a, s') = next_word64 s in (Word64.toLargeInt a, s') end))
+
+  fun gen_random_small_values seed n upper =
+    next_list seed n (fn s =>
+      let
+        val (i, s') = next_int s 0 upper
+      in
+        (IntInf.fromInt i, s')
+      end)
+
+  fun zip3 (x :: xs, y :: ys, z :: zs) = (x, y, z) :: zip3 (xs, ys, zs)
+    | zip3 _ = []
+
+  fun base_values_for utype =
+    let
+      val max = uint_max utype
+      val cap = fn n => if n > max then max else n
+    in
+      [cap 11, cap 22, cap 33, cap 44, cap 55]
+    end
+
+  fun slice_list xs s e =
+    let
+      val s_nat = IntInf.toInt s
+      val e_nat = IntInf.toInt e
+    in
+      List.take (List.drop (xs, s_nat), e_nat - s_nat)
+    end
+
+  fun range_values s e =
+    let
+      val s_nat = IntInf.toInt s
+      val e_nat = IntInf.toInt e
+    in
+      if s_nat >= e_nat then []
+      else List.tabulate (e_nat - s_nat, fn i => IntInf.fromInt (s_nat + i))
+    end
+
+  fun clamp_for_eq_new utype e =
+    let
+      val max = uint_max utype
+    in
+      if e = max then max - 1 else e
+    end
+
+  fun generate_type_tests ctxt utype seed num_random =
+    let
+      val bits = uint_bits utype
+      val bits_str = Int.toString bits
+      val suffix = uint_rust_suffix utype
+      val values = base_values_for utype
+      val values_list_hol = hol_word_list bits values
+      val values_array_hol = "(array_of_list " ^ values_list_hol ^ " :: (" ^ bits_str ^ " word, 5) array)"
+      val values_vector_hol = "(vector_of_list " ^ values_list_hol ^ " :: (" ^ bits_str ^ " word, 5) vector)"
+      val values_rust_array = rust_array suffix values
+      val values_rust_vec = rust_vec suffix values
+
+      val random_small = Int.min (num_random, 30)
+      val (rand_a, seed') = gen_random_values_for utype seed num_random
+      val (rand_b, seed'') = gen_random_values_for utype seed' num_random
+      val (rand_c, seed''') = gen_random_values_for utype seed'' num_random
+      val (rand_idx_a, seed'''') = gen_random_small_values seed''' random_small 8
+      val (rand_idx_b, _) = gen_random_small_values seed'''' random_small 8
+
+      val range_edge_pairs =
+        let
+          val max = uint_max utype
+        in
+          [(0, 0), (0, 1), (1, 1), (1, 2), (2, 1), (max - 1, max), (max, max), (0, max), (max, 0)]
+        end
+      val contains_edge_triples =
+        let
+          val max = uint_max utype
+        in
+          [(0, 0, 0), (0, 1, 0), (0, 1, 1), (1, 3, 2), (1, 3, 3),
+           (5, 9, 7), (5, 9, 9), (max - 2, max, max - 1), (max - 2, max, max)]
+        end
+
+      val range_pairs = range_edge_pairs @ ListPair.zip (rand_a, rand_b)
+      val contains_triples = contains_edge_triples @ zip3 (rand_a, rand_b, rand_c)
+
+      val idx_value_cases = [0, 1, 2, 3, 4] @ rand_idx_a
+      val idx_abort_cases = [5, 6, 7, 8] @ rand_idx_a
+
+      val range_value_cases =
+        [(0, 0), (0, 1), (1, 3), (2, 5), (4, 5), (0, 5), (3, 3)]
+        @ List.filter (fn (s, e) => s <= e andalso e <= 5) (ListPair.zip (rand_idx_a, rand_idx_b))
+
+      val range_abort_cases =
+        [(3, 2), (0, 6), (5, 6), (6, 6), (7, 1), (8, 0)]
+        @ List.filter (fn (s, e) => s > e orelse e > 5) (ListPair.zip (rand_idx_a, rand_idx_b))
+
+      val range_iter_cases =
+        [(0, 0), (0, 1), (0, 5), (1, 4), (2, 2), (4, 5), (5, 5), (0, 8), (7, 8)]
+        @ List.filter (fn (s, e) => s <= e andalso e <= 8) (ListPair.zip (rand_idx_a, rand_idx_b))
+
+      fun eval_test mk_expected mk_rust cases =
+        map_index
+          (fn (i, x) =>
+            {name = "test_" ^ Int.toString i,
+             rust_expr = mk_rust x,
+             expected = eval_bool_to_rust ctxt (mk_expected x)})
+          cases
+
+      val is_empty_tests =
+        ("range_" ^ suffix ^ "_is_empty",
+         eval_test
+           (fn (s, e) =>
+             mk_call_bool_term ctxt
+               ("is_empty (make_range " ^ hol_word bits s ^ " " ^ hol_word bits e ^ ")"))
+           (fn (s, e) =>
+             "(" ^ IntInf.toString s ^ suffix ^ ".." ^ IntInf.toString e ^ suffix ^ ").is_empty()")
+           range_pairs)
+
+      val contains_tests =
+        ("range_" ^ suffix ^ "_contains",
+         eval_test
+           (fn (s, e, x) =>
+             mk_call_bool_term ctxt
+               ("contains (make_range " ^ hol_word bits s ^ " " ^ hol_word bits e ^ ") " ^ hol_word bits x))
+           (fn (s, e, x) =>
+             "(" ^ IntInf.toString s ^ suffix ^ ".." ^ IntInf.toString e ^ suffix ^ ").contains(&"
+             ^ IntInf.toString x ^ suffix ^ ")")
+           contains_triples)
+
+      val range_new_tests =
+        ("range_" ^ suffix ^ "_new_roundtrip",
+         eval_test
+           (fn (s, e) =>
+             mk_call_eq_term ctxt
+               ("range_new " ^ hol_word bits s ^ " " ^ hol_word bits e)
+               ("make_range " ^ hol_word bits s ^ " " ^ hol_word bits e))
+           (fn (s, e) =>
+             "{ let r = " ^ IntInf.toString s ^ suffix ^ ".." ^ IntInf.toString e ^ suffix
+             ^ "; r.start == " ^ IntInf.toString s ^ suffix ^ " && r.end == " ^ IntInf.toString e ^ suffix ^ " }")
+           range_pairs)
+
+      val range_eq_new_contains_tests =
+        ("range_" ^ suffix ^ "_eq_new_contains",
+         eval_test
+           (fn (s, e0, x) =>
+             let
+               val e = clamp_for_eq_new utype e0
+             in
+               parse_term ctxt
+                 ("(case evaluate (call (range_eq_new " ^ hol_word bits s ^ " " ^ hol_word bits e ^ ")) () of "
+                  ^ "Success r _ => (case evaluate (call (contains r " ^ hol_word bits x ^ ")) () of "
+                  ^ "Success b _ => b | _ => False) | _ => False)")
+             end)
+           (fn (s, e0, x) =>
+             let
+               val e = clamp_for_eq_new utype e0
+             in
+               "(" ^ IntInf.toString s ^ suffix ^ "..=" ^ IntInf.toString e ^ suffix ^ ").contains(&"
+               ^ IntInf.toString x ^ suffix ^ ")"
+             end)
+           contains_triples)
+
+      val range_into_list_tests =
+        ("range_" ^ suffix ^ "_into_list",
+         eval_test
+           (fn (s, e) =>
+             let
+               val els = range_values s e
+             in
+               parse_term ctxt
+                 ("(range_into_list (make_range " ^ hol_word bits s ^ " " ^ hol_word bits e ^ ") = "
+                  ^ hol_word_list bits els ^ ")")
+             end)
+           (fn (s, e) =>
+             let
+               val els = range_values s e
+             in
+               "{ let v = (" ^ IntInf.toString s ^ suffix ^ ".." ^ IntInf.toString e ^ suffix
+               ^ ").collect::<Vec<" ^ suffix ^ ">>(); v == " ^ rust_vec suffix els ^ " }"
+             end)
+           range_iter_cases)
+
+      val make_iterator_from_range_collect_tests =
+        ("range_" ^ suffix ^ "_make_iterator_collect",
+         eval_test
+           (fn (s, e) =>
+             let
+               val els = range_values s e
+             in
+               mk_call_eq_term ctxt
+                 ("collect (make_iterator_from_range (make_range " ^ hol_word bits s ^ " " ^ hol_word bits e ^ "))")
+                 (hol_word_list bits els)
+             end)
+           (fn (s, e) =>
+             let
+               val els = range_values s e
+             in
+               "{ let v = (" ^ IntInf.toString s ^ suffix ^ ".." ^ IntInf.toString e ^ suffix
+               ^ ").collect::<Vec<" ^ suffix ^ ">>(); v == " ^ rust_vec suffix els ^ " }"
+             end)
+           range_iter_cases)
+
+      val range_into_iter_collect_tests =
+        ("range_" ^ suffix ^ "_into_iter_collect",
+         eval_test
+           (fn (s, e) =>
+             let
+               val els = range_values s e
+             in
+               parse_term ctxt
+                 ("(case evaluate (call (range_into_iter (make_range " ^ hol_word bits s ^ " " ^ hol_word bits e
+                  ^ "))) () of Success it _ => "
+                  ^ "(case evaluate (call (collect it)) () of Success xs _ => (xs = "
+                  ^ hol_word_list bits els ^ ") | _ => False) "
+                  ^ "| _ => False)")
+             end)
+           (fn (s, e) =>
+             let
+               val els = range_values s e
+             in
+               "{ let v = (" ^ IntInf.toString s ^ suffix ^ ".." ^ IntInf.toString e ^ suffix
+               ^ ").collect::<Vec<" ^ suffix ^ ">>(); v == " ^ rust_vec suffix els ^ " }"
+             end)
+           range_iter_cases)
+
+      val len_tests =
+        ("range_" ^ suffix ^ "_len",
+         eval_test
+           (fn _ => mk_call_eq_term ctxt ("len " ^ values_list_hol) "(5 :: 64 word)")
+           (fn _ => "(" ^ values_rust_array ^ ".len() as u64) == 5u64")
+           [()])
+
+      val list_index_value_tests =
+        ("range_" ^ suffix ^ "_list_index_value",
+         eval_test
+           (fn i =>
+             let
+               val i_nat = IntInf.toInt i mod container_len
+               val expected = List.nth (values, i_nat)
+             in
+               mk_call_eq_term ctxt
+                 ("list_index " ^ values_list_hol ^ " " ^ hol_word bits i)
+                 (hol_word bits expected)
+             end)
+           (fn i =>
+             let
+               val i_nat = IntInf.toInt i mod container_len
+               val expected = List.nth (values, i_nat)
+             in
+               "{ let arr = " ^ values_rust_array ^ "; let idx = " ^ Int.toString i_nat ^ "usize; arr[idx] == "
+               ^ IntInf.toString expected ^ suffix ^ " }"
+             end)
+           idx_value_cases)
+
+      val list_index_abort_tests =
+        ("range_" ^ suffix ^ "_list_index_abort",
+         eval_test
+           (fn i => mk_call_dangling_term ctxt ("list_index " ^ values_list_hol ^ " " ^ hol_word bits i))
+           (fn i =>
+             "std::panic::catch_unwind(|| { let arr = " ^ values_rust_array ^ "; let idx = std::hint::black_box("
+             ^ IntInf.toString i ^ " as usize); let _ = arr[idx]; }).is_err()")
+           idx_abort_cases)
+
+      val array_index_value_tests =
+        ("range_" ^ suffix ^ "_array_index_value",
+         eval_test
+           (fn i =>
+             let
+               val i_nat = IntInf.toInt i mod container_len
+               val expected = List.nth (values, i_nat)
+             in
+               mk_call_eq_term ctxt
+                 ("array_index " ^ values_array_hol ^ " " ^ hol_word bits i)
+                 (hol_word bits expected)
+             end)
+           (fn i =>
+             let
+               val i_nat = IntInf.toInt i mod container_len
+               val expected = List.nth (values, i_nat)
+             in
+               "{ let arr = " ^ values_rust_array ^ "; let idx = " ^ Int.toString i_nat ^ "usize; arr[idx] == "
+               ^ IntInf.toString expected ^ suffix ^ " }"
+             end)
+           idx_value_cases)
+
+      val array_index_abort_tests =
+        ("range_" ^ suffix ^ "_array_index_abort",
+         eval_test
+           (fn i => mk_call_dangling_term ctxt ("array_index " ^ values_array_hol ^ " " ^ hol_word bits i))
+           (fn i =>
+             "std::panic::catch_unwind(|| { let arr = " ^ values_rust_array ^ "; let idx = std::hint::black_box("
+             ^ IntInf.toString i ^ " as usize); let _ = arr[idx]; }).is_err()")
+           idx_abort_cases)
+
+      val vector_index_value_tests =
+        ("range_" ^ suffix ^ "_vector_index_value",
+         eval_test
+           (fn i =>
+             let
+               val i_nat = IntInf.toInt i mod container_len
+               val expected = List.nth (values, i_nat)
+             in
+               mk_call_eq_term ctxt
+                 ("vector_index " ^ values_vector_hol ^ " " ^ hol_word bits i)
+                 (hol_word bits expected)
+             end)
+           (fn i =>
+             let
+               val i_nat = IntInf.toInt i mod container_len
+               val expected = List.nth (values, i_nat)
+             in
+               "{ let v = " ^ values_rust_vec ^ "; let idx = " ^ Int.toString i_nat ^ "usize; v[idx] == "
+               ^ IntInf.toString expected ^ suffix ^ " }"
+             end)
+           idx_value_cases)
+
+      val vector_index_abort_tests =
+        ("range_" ^ suffix ^ "_vector_index_abort",
+         eval_test
+           (fn i => mk_call_dangling_term ctxt ("vector_index " ^ values_vector_hol ^ " " ^ hol_word bits i))
+           (fn i =>
+             "std::panic::catch_unwind(|| { let v = " ^ values_rust_vec ^ "; let idx = std::hint::black_box("
+             ^ IntInf.toString i ^ " as usize); let _ = v[idx]; }).is_err()")
+           idx_abort_cases)
+
+      val list_index_range_value_tests =
+        ("range_" ^ suffix ^ "_list_index_range_value",
+         eval_test
+           (fn (s, e) =>
+             let
+               val sub = slice_list values s e
+               val expected = hol_word_list bits sub
+             in
+               mk_call_eq_term ctxt
+                 ("list_index_range " ^ values_list_hol ^ " (make_range " ^ hol_word bits s ^ " " ^ hol_word bits e ^ ")")
+                 expected
+             end)
+           (fn (s, e) =>
+             let
+               val sub = slice_list values s e
+             in
+               "{ let arr = " ^ values_rust_array ^ "; let s = " ^ IntInf.toString s ^ "usize; let e = "
+               ^ IntInf.toString e ^ "usize; arr[s..e].to_vec() == " ^ rust_vec suffix sub ^ " }"
+             end)
+           range_value_cases)
+
+      val list_index_range_abort_tests =
+        ("range_" ^ suffix ^ "_list_index_range_abort",
+         eval_test
+           (fn (s, e) =>
+             mk_call_dangling_term ctxt
+               ("list_index_range " ^ values_list_hol ^ " (make_range " ^ hol_word bits s ^ " " ^ hol_word bits e ^ ")"))
+           (fn (s, e) =>
+             "std::panic::catch_unwind(|| { let arr = " ^ values_rust_array ^ "; let s = "
+             ^ IntInf.toString s ^ "usize; let e = " ^ IntInf.toString e ^ "usize; let _ = &arr[s..e]; }).is_err()")
+           range_abort_cases)
+
+      val array_index_range_value_tests =
+        ("range_" ^ suffix ^ "_array_index_range_value",
+         eval_test
+           (fn (s, e) =>
+             let
+               val sub = slice_list values s e
+               val expected = hol_word_list bits sub
+             in
+               mk_call_eq_term ctxt
+                 ("array_index_range " ^ values_array_hol ^ " (make_range " ^ hol_word bits s ^ " " ^ hol_word bits e ^ ")")
+                 expected
+             end)
+           (fn (s, e) =>
+             let
+               val sub = slice_list values s e
+             in
+               "{ let arr = " ^ values_rust_array ^ "; let s = " ^ IntInf.toString s ^ "usize; let e = "
+               ^ IntInf.toString e ^ "usize; arr[s..e].to_vec() == " ^ rust_vec suffix sub ^ " }"
+             end)
+           range_value_cases)
+
+      val array_index_range_abort_tests =
+        ("range_" ^ suffix ^ "_array_index_range_abort",
+         eval_test
+           (fn (s, e) =>
+             mk_call_dangling_term ctxt
+               ("array_index_range " ^ values_array_hol ^ " (make_range " ^ hol_word bits s ^ " " ^ hol_word bits e ^ ")"))
+           (fn (s, e) =>
+             "std::panic::catch_unwind(|| { let arr = " ^ values_rust_array ^ "; let s = "
+             ^ IntInf.toString s ^ "usize; let e = " ^ IntInf.toString e ^ "usize; let _ = &arr[s..e]; }).is_err()")
+           range_abort_cases)
+
+      val vector_index_range_value_tests =
+        ("range_" ^ suffix ^ "_vector_index_range_value",
+         eval_test
+           (fn (s, e) =>
+             let
+               val sub = slice_list values s e
+               val expected = hol_word_list bits sub
+             in
+               mk_call_eq_term ctxt
+                 ("vector_index_range " ^ values_vector_hol ^ " (make_range " ^ hol_word bits s ^ " " ^ hol_word bits e ^ ")")
+                 expected
+             end)
+           (fn (s, e) =>
+             let
+               val sub = slice_list values s e
+             in
+               "{ let v = " ^ values_rust_vec ^ "; let s = " ^ IntInf.toString s ^ "usize; let e = "
+               ^ IntInf.toString e ^ "usize; v[s..e].to_vec() == " ^ rust_vec suffix sub ^ " }"
+             end)
+           range_value_cases)
+
+      val vector_index_range_abort_tests =
+        ("range_" ^ suffix ^ "_vector_index_range_abort",
+         eval_test
+           (fn (s, e) =>
+             mk_call_dangling_term ctxt
+               ("vector_index_range " ^ values_vector_hol ^ " (make_range " ^ hol_word bits s ^ " " ^ hol_word bits e ^ ")"))
+           (fn (s, e) =>
+             "std::panic::catch_unwind(|| { let v = " ^ values_rust_vec ^ "; let s = "
+             ^ IntInf.toString s ^ "usize; let e = " ^ IntInf.toString e ^ "usize; let _ = &v[s..e]; }).is_err()")
+           range_abort_cases)
+    in
+      [is_empty_tests,
+       contains_tests,
+       range_new_tests,
+       range_eq_new_contains_tests,
+       range_into_list_tests,
+       make_iterator_from_range_collect_tests,
+       range_into_iter_collect_tests,
+       len_tests,
+       list_index_value_tests,
+       list_index_abort_tests,
+       array_index_value_tests,
+       array_index_abort_tests,
+       vector_index_value_tests,
+       vector_index_abort_tests,
+       list_index_range_value_tests,
+       list_index_range_abort_tests,
+       array_index_range_value_tests,
+       array_index_range_abort_tests,
+       vector_index_range_value_tests,
+       vector_index_range_abort_tests]
+    end
+
+  fun generate_all_tests ctxt num_random =
+    let
+      val seed = default_seed
+      val types = [U8, U16, U32, U64]
+    in
+      List.concat (map (fn t => generate_type_tests ctxt t seed num_random) types)
+    end
+end
+\<close>
+
+(*<*)
+end
+(*>*)

--- a/Conformance_Testing/Tests/Result_Conformance.thy
+++ b/Conformance_Testing/Tests/Result_Conformance.thy
@@ -1,0 +1,398 @@
+(* Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+   SPDX-License-Identifier: MIT *)
+
+(*<*)
+theory Result_Conformance
+  imports
+    "../Conformance_Framework"
+    Micro_Rust_Std_Lib.StdLib_Result
+begin
+(*>*)
+
+section\<open>Result Conformance Tests\<close>
+
+text\<open>This theory generates conformance tests for Result APIs by evaluating the
+actual Micro Rust function bodies (via @{term evaluate} and @{term call}), then
+comparing against real Rust behaviour.\<close>
+
+ML\<open>
+structure Result_Conformance = struct
+  open Conformance_Random
+  open Conformance
+  open Rust_Codegen
+
+  datatype uint_type = U8 | U16 | U32 | U64
+  datatype res_case = OK of IntInf.int | ERR of IntInf.int
+
+  fun uint_bits U8 = 8 | uint_bits U16 = 16 | uint_bits U32 = 32 | uint_bits U64 = 64
+  fun uint_rust_suffix U8 = "u8" | uint_rust_suffix U16 = "u16"
+    | uint_rust_suffix U32 = "u32" | uint_rust_suffix U64 = "u64"
+  fun uint_max U8 = 255 : IntInf.int
+    | uint_max U16 = 65535
+    | uint_max U32 = 4294967295
+    | uint_max U64 = 18446744073709551615
+
+  fun parse_term ctxt s = Syntax.read_term ctxt s
+
+  fun eval_bool_to_rust ctxt term =
+    (case term_to_bool (Value_Command.value ctxt term) of
+      SOME true => "true"
+    | SOME false => "false"
+    | NONE => raise Fail "Failed to extract bool result")
+
+  fun hol_word bits n = "(" ^ IntInf.toString n ^ " :: " ^ Int.toString bits ^ " word)"
+
+  fun hol_result_literal bits (OK v) =
+        "(Ok " ^ hol_word bits v ^ " :: (" ^ Int.toString bits ^ " word, "
+        ^ Int.toString bits ^ " word) result)"
+    | hol_result_literal bits (ERR e) =
+        "(Err " ^ hol_word bits e ^ " :: (" ^ Int.toString bits ^ " word, "
+        ^ Int.toString bits ^ " word) result)"
+
+  fun rust_result_literal suffix (OK v) =
+        "Ok::<" ^ suffix ^ ", " ^ suffix ^ ">(" ^ IntInf.toString v ^ suffix ^ ")"
+    | rust_result_literal suffix (ERR e) =
+        "Err::<" ^ suffix ^ ", " ^ suffix ^ ">(" ^ IntInf.toString e ^ suffix ^ ")"
+
+  fun mk_call_bool_term ctxt body =
+    parse_term ctxt
+      ("(case evaluate (call (" ^ body ^ ")) () of Success r _ => r | _ => False)")
+
+  fun mk_call_eq_term ctxt body expected =
+    parse_term ctxt
+      ("(case evaluate (call (" ^ body ^ ")) () of Success r _ => (r = " ^ expected ^ ") | _ => False)")
+
+  fun mk_call_panic_term ctxt body =
+    parse_term ctxt
+      ("(case evaluate (call (" ^ body ^ ")) () of Abort (Panic _) _ => True | _ => False)")
+
+  fun mk_result_is_ok_term ctxt bits res =
+    let
+      val res_str = hol_result_literal bits res
+    in
+      parse_term ctxt
+        ("(case evaluate (call (urust_func_result_is_ok " ^ res_str ^ ")) () of "
+         ^ "Success r _ => r | _ => False)")
+    end
+
+  fun mk_result_is_err_term ctxt bits res =
+    let
+      val res_str = hol_result_literal bits res
+    in
+      parse_term ctxt
+        ("(case evaluate (call (urust_func_result_is_err " ^ res_str ^ ")) () of "
+         ^ "Success r _ => r | _ => False)")
+    end
+
+  fun mk_result_ok_is_some_term ctxt bits res =
+    let
+      val res_str = hol_result_literal bits res
+    in
+      parse_term ctxt
+        ("(case evaluate (call (ok " ^ res_str ^ ")) () of "
+         ^ "Success r _ => (case r of Some _ => True | None => False) | _ => False)")
+    end
+
+  fun mk_result_ok_value_term ctxt bits res =
+    let
+      val res_str = hol_result_literal bits res
+      val expected =
+        (case res of
+          OK v => hol_word bits v
+        | ERR _ => hol_word bits 0)
+    in
+      parse_term ctxt
+        ("(case evaluate (call (ok " ^ res_str ^ ")) () of "
+         ^ "Success r _ => (case r of Some v => (v = " ^ expected ^ ") | None => False) | _ => False)")
+    end
+
+  fun mk_result_or_is_ok_term ctxt bits (res, fallback) =
+    let
+      val res_str = hol_result_literal bits res
+      val fb_str = hol_result_literal bits fallback
+    in
+      parse_term ctxt
+        ("(case evaluate (call (result_or " ^ res_str ^ " " ^ fb_str ^ ")) () of "
+         ^ "Success r _ => (case r of Ok _ => True | Err _ => False) | _ => False)")
+    end
+
+  fun mk_result_or_ok_value_term ctxt bits (res, fallback) =
+    let
+      val res_str = hol_result_literal bits res
+      val fb_str = hol_result_literal bits fallback
+      val expected =
+        (case res of
+          OK v => SOME v
+        | ERR _ => (case fallback of OK v => SOME v | ERR _ => NONE))
+      val expected_str =
+        (case expected of
+          SOME v => hol_word bits v
+        | NONE => hol_word bits 0)
+    in
+      parse_term ctxt
+        ("(case evaluate (call (result_or " ^ res_str ^ " " ^ fb_str ^ ")) () of "
+         ^ "Success r _ => (case r of Ok v => (v = " ^ expected_str ^ ") | Err _ => False) | _ => False)")
+    end
+
+  fun mk_result_or_err_value_term ctxt bits (res, fallback) =
+    let
+      val res_str = hol_result_literal bits res
+      val fb_str = hol_result_literal bits fallback
+      val expected =
+        (case res of
+          OK _ => NONE
+        | ERR _ => (case fallback of OK _ => NONE | ERR e => SOME e))
+      val expected_str =
+        (case expected of
+          SOME e => hol_word bits e
+        | NONE => hol_word bits 0)
+    in
+      parse_term ctxt
+        ("(case evaluate (call (result_or " ^ res_str ^ " " ^ fb_str ^ ")) () of "
+         ^ "Success r _ => (case r of Err e => (e = " ^ expected_str ^ ") | Ok _ => False) | _ => False)")
+    end
+
+  fun mk_unwrap_or_term ctxt bits (res, fallback) =
+    let
+      val res_str = hol_result_literal bits res
+      val fb_str = hol_word bits fallback
+      val expected =
+        (case res of OK v => hol_word bits v | ERR _ => fb_str)
+    in
+      parse_term ctxt
+        ("(case evaluate (call (result_unwrap_or " ^ res_str ^ " " ^ fb_str ^ ")) () of "
+         ^ "Success r _ => (r = " ^ expected ^ ") | _ => False)")
+    end
+
+  fun mk_map_err_term ctxt bits res =
+    let
+      val res_str = hol_result_literal bits res
+      val mapper = "(%e. FunctionBody (literal (e + (1 :: " ^ Int.toString bits ^ " word))))"
+      val expected_ok =
+        (case res of OK v => SOME v | ERR _ => NONE)
+      val expected_err =
+        (case res of ERR e => SOME e | OK _ => NONE)
+      val ok_case =
+        (case expected_ok of
+          SOME v => "Ok v => (v = " ^ hol_word bits v ^ ")"
+        | NONE => "Ok _ => False")
+      val err_case =
+        (case expected_err of
+          SOME e => "Err e => (e = (" ^ hol_word bits e ^ " + (1 :: " ^ Int.toString bits ^ " word)))"
+        | NONE => "Err _ => False")
+    in
+      parse_term ctxt
+        ("(case evaluate (call (map_err " ^ res_str ^ " " ^ mapper ^ ")) () of "
+         ^ "Success r _ => (case r of " ^ ok_case ^ " | " ^ err_case ^ ") | _ => False)")
+    end
+
+  fun gen_random_values_for utype seed n =
+    (case utype of
+      U8 => next_list seed n (fn s =>
+              let val (a, s') = next_word8 s in (Word8.toLargeInt a, s') end)
+    | U16 => next_list seed n (fn s =>
+              let val (a, s') = next_word16 s in (Word.toLargeInt a, s') end)
+    | U32 => next_list seed n (fn s =>
+              let val (a, s') = next_word32 s in (Word32.toLargeInt a, s') end)
+    | U64 => next_list seed n (fn s =>
+              let val (a, s') = next_word64 s in (Word64.toLargeInt a, s') end))
+
+  fun result_edge_cases utype =
+    let
+      val max = uint_max utype
+    in
+      [OK 0, OK 1, OK max, ERR 0, ERR 1, ERR max]
+    end
+
+  fun result_pair_edge_cases utype =
+    let
+      val max = uint_max utype
+    in
+      [(OK 1, OK 2), (OK max, ERR 7), (ERR 3, OK 4), (ERR 5, ERR 6),
+       (OK 0, ERR max), (ERR max, OK 0), (OK max, OK max), (ERR 0, ERR max),
+       (ERR 1, OK max), (OK 7, ERR 8)]
+    end
+
+  fun inject_results values =
+    map_index (fn (i, v) => if i mod 2 = 0 then OK v else ERR v) values
+
+  fun make_result_pairs vals_a vals_b =
+    map_index
+      (fn (i, (a, b)) =>
+        (if i mod 2 = 0 then OK a else ERR a, if i mod 3 = 0 then OK b else ERR b))
+      (ListPair.zip (vals_a, vals_b))
+
+  fun generate_type_tests ctxt utype seed num_random =
+    let
+      val bits = uint_bits utype
+      val suffix = uint_rust_suffix utype
+      val (rand_a, seed') = gen_random_values_for utype seed num_random
+      val (rand_b, _) = gen_random_values_for utype seed' num_random
+
+      val res_cases = result_edge_cases utype @ inject_results rand_a
+      val unwrap_ok_values = map_filter (fn r => case r of OK v => SOME v | ERR _ => NONE) res_cases
+      val res_pairs = result_pair_edge_cases utype @ make_result_pairs rand_a rand_b
+      val unwrap_or_pairs = ListPair.zip (res_cases, rand_b)
+
+      fun eval_test mk_expected mk_rust cases =
+        map_index
+          (fn (i, x) =>
+            {name = "test_" ^ Int.toString i,
+             rust_expr = mk_rust x,
+             expected = eval_bool_to_rust ctxt (mk_expected x)})
+          cases
+
+      val is_ok_tests =
+        ("result_" ^ suffix ^ "_is_ok",
+         eval_test
+           (fn res => mk_result_is_ok_term ctxt bits res)
+           (fn res => rust_result_literal suffix res ^ ".is_ok()")
+           res_cases)
+
+      val is_err_tests =
+        ("result_" ^ suffix ^ "_is_err",
+         eval_test
+           (fn res => mk_result_is_err_term ctxt bits res)
+           (fn res => rust_result_literal suffix res ^ ".is_err()")
+           res_cases)
+
+      val ok_is_some_tests =
+        ("result_" ^ suffix ^ "_ok_is_some",
+         eval_test
+           (fn res => mk_result_ok_is_some_term ctxt bits res)
+           (fn res => rust_result_literal suffix res ^ ".ok().is_some()")
+           res_cases)
+
+      val ok_value_tests =
+        ("result_" ^ suffix ^ "_ok_value",
+         eval_test
+           (fn res => mk_result_ok_value_term ctxt bits res)
+           (fn res =>
+              "(match " ^ rust_result_literal suffix res ^ ".ok() { Some(v) => "
+              ^ (case res of OK v => "v == " ^ IntInf.toString v ^ suffix | ERR _ => "false")
+              ^ ", None => false })")
+           res_cases)
+
+      val or_is_ok_tests =
+        ("result_" ^ suffix ^ "_or_is_ok",
+         eval_test
+           (fn pair => mk_result_or_is_ok_term ctxt bits pair)
+           (fn (r, fb) => rust_result_literal suffix r ^ ".or(" ^ rust_result_literal suffix fb ^ ").is_ok()")
+           res_pairs)
+
+      val or_ok_value_tests =
+        ("result_" ^ suffix ^ "_or_ok_value",
+         eval_test
+           (fn pair => mk_result_or_ok_value_term ctxt bits pair)
+           (fn (r, fb) =>
+              "(match " ^ rust_result_literal suffix r ^ ".or(" ^ rust_result_literal suffix fb ^ ") { "
+              ^ "Ok(v) => "
+              ^ (case r of
+                  OK v => "v == " ^ IntInf.toString v ^ suffix
+                | ERR _ => (case fb of OK v => "v == " ^ IntInf.toString v ^ suffix | ERR _ => "false"))
+              ^ ", Err(_) => false })")
+           res_pairs)
+
+      val or_err_value_tests =
+        ("result_" ^ suffix ^ "_or_err_value",
+         eval_test
+           (fn pair => mk_result_or_err_value_term ctxt bits pair)
+           (fn (r, fb) =>
+              "(match " ^ rust_result_literal suffix r ^ ".or(" ^ rust_result_literal suffix fb ^ ") { "
+              ^ "Err(e) => "
+              ^ (case r of
+                  OK _ => "false"
+                | ERR _ => (case fb of ERR e => "e == " ^ IntInf.toString e ^ suffix | OK _ => "false"))
+              ^ ", Ok(_) => false })")
+           res_pairs)
+
+      val unwrap_panic_tests =
+        ("result_" ^ suffix ^ "_unwrap_panics",
+         eval_test
+           (fn res => mk_call_panic_term ctxt ("result_unwrap " ^ hol_result_literal bits res))
+           (fn res => "std::panic::catch_unwind(|| { let _ = "
+                      ^ rust_result_literal suffix res ^ ".unwrap(); }).is_err()")
+           res_cases)
+
+      val unwrap_value_tests =
+        ("result_" ^ suffix ^ "_unwrap_value",
+         eval_test
+           (fn v => mk_call_eq_term ctxt
+                        ("result_unwrap " ^ hol_result_literal bits (OK v))
+                        (hol_word bits v))
+           (fn v => "Ok::<" ^ suffix ^ ", " ^ suffix ^ ">(" ^ IntInf.toString v ^ suffix ^ ").unwrap() == "
+                    ^ IntInf.toString v ^ suffix)
+           unwrap_ok_values)
+
+      val expect_panic_tests =
+        ("result_" ^ suffix ^ "_expect_panics",
+         eval_test
+           (fn res => mk_call_panic_term ctxt ("result_expect " ^ hol_result_literal bits res ^ " (STR ''expect'')"))
+           (fn res => "std::panic::catch_unwind(|| { let _ = "
+                      ^ rust_result_literal suffix res ^ ".expect(\"expect\"); }).is_err()")
+           res_cases)
+
+      val expect_value_tests =
+        ("result_" ^ suffix ^ "_expect_value",
+         eval_test
+           (fn v => mk_call_eq_term ctxt
+                        ("result_expect " ^ hol_result_literal bits (OK v) ^ " (STR ''expect'')")
+                        (hol_word bits v))
+           (fn v => "Ok::<" ^ suffix ^ ", " ^ suffix ^ ">(" ^ IntInf.toString v ^ suffix ^ ").expect(\"expect\") == "
+                    ^ IntInf.toString v ^ suffix)
+           unwrap_ok_values)
+
+      val unwrap_or_tests =
+        ("result_" ^ suffix ^ "_unwrap_or",
+         eval_test
+           (fn pair => mk_unwrap_or_term ctxt bits pair)
+           (fn (res, fallback) =>
+              rust_result_literal suffix res ^ ".unwrap_or(" ^ IntInf.toString fallback ^ suffix ^ ") == "
+              ^ (case res of OK v => IntInf.toString v | ERR _ => IntInf.toString fallback) ^ suffix)
+           unwrap_or_pairs)
+
+      val map_err_tests =
+        ("result_" ^ suffix ^ "_map_err",
+         eval_test
+           (fn res => mk_map_err_term ctxt bits res)
+           (fn res =>
+              "(match " ^ rust_result_literal suffix res ^ ".map_err(|e| e.wrapping_add(1" ^ suffix ^ ")) { "
+              ^ "Ok(v) => "
+              ^ (case res of
+                  OK v => "v == " ^ IntInf.toString v ^ suffix
+                | ERR _ => "false")
+              ^ ", Err(e) => "
+              ^ (case res of
+                  ERR e => "e == " ^ IntInf.toString ((e + 1) mod (uint_max utype + 1)) ^ suffix
+                | OK _ => "false")
+              ^ " })")
+           res_cases)
+    in
+      [is_ok_tests,
+       is_err_tests,
+       ok_is_some_tests,
+       ok_value_tests,
+       or_is_ok_tests,
+       or_ok_value_tests,
+       or_err_value_tests,
+       unwrap_panic_tests,
+       unwrap_value_tests,
+       expect_panic_tests,
+       expect_value_tests,
+       unwrap_or_tests,
+       map_err_tests]
+    end
+
+  fun generate_all_tests ctxt num_random =
+    let
+      val seed = default_seed
+      val types = [U8, U16, U32, U64]
+    in
+      List.concat (map (fn t => generate_type_tests ctxt t seed num_random) types)
+    end
+end
+\<close>
+
+(*<*)
+end
+(*>*)

--- a/Conformance_Testing/Tests/StdLib_Arithmetic_Conformance.thy
+++ b/Conformance_Testing/Tests/StdLib_Arithmetic_Conformance.thy
@@ -1,0 +1,351 @@
+(* Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+   SPDX-License-Identifier: MIT *)
+
+(*<*)
+theory StdLib_Arithmetic_Conformance
+  imports
+    "../Conformance_Framework"
+begin
+(*>*)
+
+section\<open>Stdlib Arithmetic Conformance Tests\<close>
+
+text\<open>This theory generates conformance tests for arithmetic APIs in the Micro Rust standard
+library, including overflow-reporting, checked, wrapping, saturating, and NonZero operations.
+\<close>
+
+ML\<open>
+structure StdLib_Arithmetic_Conformance = struct
+  open Conformance_Random
+  open Conformance
+  open Rust_Codegen
+
+  datatype uint_type = U8 | U16 | U32 | U64
+
+  fun uint_bits U8 = 8 | uint_bits U16 = 16 | uint_bits U32 = 32 | uint_bits U64 = 64
+  fun uint_rust_suffix U8 = "u8" | uint_rust_suffix U16 = "u16"
+    | uint_rust_suffix U32 = "u32" | uint_rust_suffix U64 = "u64"
+  fun uint_max U8 = 255 : IntInf.int
+    | uint_max U16 = 65535
+    | uint_max U32 = 4294967295
+    | uint_max U64 = 18446744073709551615
+
+  fun parse_term ctxt s = Syntax.read_term ctxt s
+
+  fun eval_word_to_rust ctxt term =
+    (case extract_word_nat (Value_Command.value ctxt term) of
+      SOME n => IntInf.toString n
+    | NONE => raise Fail "Failed to extract word result")
+
+  fun eval_bool_to_rust ctxt term =
+    (case term_to_bool (Value_Command.value ctxt term) of
+      SOME true => "true"
+    | SOME false => "false"
+    | NONE => raise Fail "Failed to extract bool result")
+
+  fun eval_option_to_rust ctxt term =
+    option_result_to_rust (term_to_option_result (Value_Command.value ctxt term))
+
+  fun mk_overflowing_add_value_term ctxt utype (a, b) =
+    let
+      val bits = Int.toString (uint_bits utype)
+      val a_str = IntInf.toString a
+      val b_str = IntInf.toString b
+      val a_word = "(" ^ a_str ^ " :: " ^ bits ^ " word)"
+      val b_word = "(" ^ b_str ^ " :: " ^ bits ^ " word)"
+    in
+      parse_term ctxt ("(" ^ a_word ^ " + " ^ b_word ^ ")")
+    end
+
+  fun mk_overflowing_add_overflow_term ctxt utype (a, b) =
+    let
+      val bits = Int.toString (uint_bits utype)
+      val a_str = IntInf.toString a
+      val b_str = IntInf.toString b
+      val a_word = "(" ^ a_str ^ " :: " ^ bits ^ " word)"
+      val b_word = "(" ^ b_str ^ " :: " ^ bits ^ " word)"
+    in
+      parse_term ctxt
+        ("(unat " ^ a_word ^ " + unat " ^ b_word ^ " >= 2^" ^ bits ^ ")")
+    end
+
+  fun mk_overflowing_mul_value_term ctxt utype (a, b) =
+    let
+      val bits = Int.toString (uint_bits utype)
+      val a_str = IntInf.toString a
+      val b_str = IntInf.toString b
+      val a_word = "(" ^ a_str ^ " :: " ^ bits ^ " word)"
+      val b_word = "(" ^ b_str ^ " :: " ^ bits ^ " word)"
+    in
+      parse_term ctxt ("(" ^ a_word ^ " * " ^ b_word ^ ")")
+    end
+
+  fun mk_overflowing_mul_overflow_term ctxt utype (a, b) =
+    let
+      val bits = Int.toString (uint_bits utype)
+      val a_str = IntInf.toString a
+      val b_str = IntInf.toString b
+      val a_word = "(" ^ a_str ^ " :: " ^ bits ^ " word)"
+      val b_word = "(" ^ b_str ^ " :: " ^ bits ^ " word)"
+    in
+      parse_term ctxt
+        ("(unat " ^ a_word ^ " * unat " ^ b_word ^ " >= 2^" ^ bits ^ ")")
+    end
+
+  fun mk_wrapping_add_term ctxt utype (a, b) =
+    let
+      val bits = Int.toString (uint_bits utype)
+      val a_str = IntInf.toString a
+      val b_str = IntInf.toString b
+      val a_word = "(" ^ a_str ^ " :: " ^ bits ^ " word)"
+      val b_word = "(" ^ b_str ^ " :: " ^ bits ^ " word)"
+    in
+      parse_term ctxt ("(" ^ a_word ^ " + " ^ b_word ^ ")")
+    end
+
+  fun mk_saturating_sub_term ctxt utype (a, b) =
+    let
+      val bits = Int.toString (uint_bits utype)
+      val a_str = IntInf.toString a
+      val b_str = IntInf.toString b
+      val a_word = "(" ^ a_str ^ " :: " ^ bits ^ " word)"
+      val b_word = "(" ^ b_str ^ " :: " ^ bits ^ " word)"
+    in
+      parse_term ctxt
+        ("(if " ^ b_word ^ " <= " ^ a_word ^ " then " ^ a_word ^ " - " ^ b_word
+         ^ " else (0 :: " ^ bits ^ " word))")
+    end
+
+  fun mk_checked_add_term ctxt utype (a, b) =
+    let
+      val bits = Int.toString (uint_bits utype)
+      val a_str = IntInf.toString a
+      val b_str = IntInf.toString b
+      val a_word = "(" ^ a_str ^ " :: " ^ bits ^ " word)"
+      val b_word = "(" ^ b_str ^ " :: " ^ bits ^ " word)"
+    in
+      parse_term ctxt ("(word_add_no_wrap_pure " ^ a_word ^ " " ^ b_word ^ ")")
+    end
+
+  fun mk_checked_mul_term ctxt utype (a, b) =
+    let
+      val bits = Int.toString (uint_bits utype)
+      val a_str = IntInf.toString a
+      val b_str = IntInf.toString b
+      val a_word = "(" ^ a_str ^ " :: " ^ bits ^ " word)"
+      val b_word = "(" ^ b_str ^ " :: " ^ bits ^ " word)"
+    in
+      parse_term ctxt ("(word_mul_no_wrap_pure " ^ a_word ^ " " ^ b_word ^ ")")
+    end
+
+  fun mk_div_ceil_term ctxt utype (a, b) =
+    let
+      val bits = Int.toString (uint_bits utype)
+      val a_str = IntInf.toString a
+      val b_str = IntInf.toString b
+      val a_word = "(" ^ a_str ^ " :: " ^ bits ^ " word)"
+      val b_word = "(" ^ b_str ^ " :: " ^ bits ^ " word)"
+    in
+      parse_term ctxt
+        ("(word_of_nat ((unat " ^ a_word ^ " + unat " ^ b_word ^ " - 1) div unat "
+         ^ b_word ^ ") :: " ^ bits ^ " word)")
+    end
+
+  fun mk_nonzero_new_is_some_term ctxt n =
+    let
+      val n_str = IntInf.toString n
+    in
+      parse_term ctxt ("((" ^ n_str ^ " :: 64 word) ~= (0 :: 64 word))")
+    end
+
+  fun mk_nonzero_get_roundtrip_term ctxt n =
+    let
+      val n_str = IntInf.toString n
+    in
+      parse_term ctxt ("((" ^ n_str ^ " :: 64 word) ~= (0 :: 64 word))")
+    end
+
+  fun arith_edge_cases utype =
+    let
+      val max = uint_max utype
+      val mid = max div 2
+    in
+      [(0, 0), (0, 1), (1, 0), (1, 1), (max, 0), (max, 1),
+       (max, max), (max - 1, max), (mid, mid), (mid + 1, mid)]
+    end
+
+  fun div_ceil_edge_cases utype =
+    let
+      val max = uint_max utype
+      val mid = max div 2
+    in
+      [(0, 1), (1, 1), (2, 1), (5, 2), (10, 3), (max, 1),
+       (max, 2), (mid, 2), (mid + 1, 2), (max - 1, max)]
+    end
+
+  fun nonzero_edge_values () =
+    [0 : IntInf.int, 1, 2, 3, 18446744073709551615]
+
+  fun positive_u64_edge_values () =
+    [1 : IntInf.int, 2, 3, 4, 18446744073709551615, 18446744073709551614]
+
+  fun gen_random_pairs_for utype seed n =
+    (case utype of
+      U8 =>
+        next_list seed n (fn s =>
+          let
+            val (a, s') = next_word8 s
+            val (b, s'') = next_word8 s'
+          in
+            ((Word8.toLargeInt a, Word8.toLargeInt b), s'')
+          end)
+    | U16 =>
+        next_list seed n (fn s =>
+          let
+            val (a, s') = next_word16 s
+            val (b, s'') = next_word16 s'
+          in
+            ((Word.toLargeInt a, Word.toLargeInt b), s'')
+          end)
+    | U32 =>
+        next_list seed n (fn s =>
+          let
+            val (a, s') = next_word32 s
+            val (b, s'') = next_word32 s'
+          in
+            ((Word32.toLargeInt a, Word32.toLargeInt b), s'')
+          end)
+    | U64 =>
+        next_list seed n (fn s =>
+          let
+            val (a, s') = next_word64 s
+            val (b, s'') = next_word64 s'
+          in
+            ((Word64.toLargeInt a, Word64.toLargeInt b), s'')
+          end))
+
+  fun gen_random_nonzero_pairs_for utype seed n =
+    let
+      val (pairs, st) = gen_random_pairs_for utype seed n
+      val fixed = map (fn (a, b) => if b = 0 then (a, 1) else (a, b)) pairs
+    in
+      (fixed, st)
+    end
+
+  fun gen_random_u64_values seed n =
+    next_list seed n (fn s =>
+      let
+        val (w, s') = next_word64 s
+      in
+        (Word64.toLargeInt w, s')
+      end)
+
+  fun gen_binary_tests ctxt utype mk_term eval_expected rust_expr edge_cases random_pairs =
+    let
+      val suffix = uint_rust_suffix utype
+      val all_pairs = edge_cases @ random_pairs
+    in
+      map_index
+        (fn (i, pair) =>
+          let
+            val expected = eval_expected ctxt (mk_term ctxt utype pair)
+            val name = "test_" ^ Int.toString i
+          in
+            {name = name, rust_expr = rust_expr suffix pair, expected = expected}
+          end)
+        all_pairs
+    end
+
+  fun gen_u64_value_tests ctxt mk_term eval_expected rust_expr edge_values random_values =
+    let
+      val values = edge_values @ random_values
+    in
+      map_index
+        (fn (i, n) =>
+          let
+            val expected = eval_expected ctxt (mk_term ctxt n)
+            val name = "test_" ^ Int.toString i
+          in
+            {name = name, rust_expr = rust_expr n, expected = expected}
+          end)
+        values
+    end
+
+  fun generate_type_tests ctxt utype seed num_random =
+    let
+      val suffix = uint_rust_suffix utype
+      val (random_pairs, _) = gen_random_pairs_for utype seed num_random
+      val (random_div_pairs, _) = gen_random_nonzero_pairs_for utype seed num_random
+      val arith_edges = arith_edge_cases utype
+      val div_edges = div_ceil_edge_cases utype
+
+      fun mk_method_expr method suffix' (a, b) =
+        IntInf.toString a ^ suffix' ^ "." ^ method ^ "(" ^ IntInf.toString b ^ suffix' ^ ")"
+
+      fun mk_overflow_expr method field suffix' pair =
+        mk_method_expr method suffix' pair ^ "." ^ field
+    in
+      [("stdlibarith_" ^ suffix ^ "_overflowing_add_value",
+        gen_binary_tests ctxt utype mk_overflowing_add_value_term eval_word_to_rust
+          (mk_overflow_expr "overflowing_add" "0") arith_edges random_pairs),
+       ("stdlibarith_" ^ suffix ^ "_overflowing_add_overflow",
+        gen_binary_tests ctxt utype mk_overflowing_add_overflow_term eval_bool_to_rust
+          (mk_overflow_expr "overflowing_add" "1") arith_edges random_pairs),
+       ("stdlibarith_" ^ suffix ^ "_overflowing_mul_value",
+        gen_binary_tests ctxt utype mk_overflowing_mul_value_term eval_word_to_rust
+          (mk_overflow_expr "overflowing_mul" "0") arith_edges random_pairs),
+       ("stdlibarith_" ^ suffix ^ "_overflowing_mul_overflow",
+        gen_binary_tests ctxt utype mk_overflowing_mul_overflow_term eval_bool_to_rust
+          (mk_overflow_expr "overflowing_mul" "1") arith_edges random_pairs),
+       ("stdlibarith_" ^ suffix ^ "_wrapping_add",
+        gen_binary_tests ctxt utype mk_wrapping_add_term eval_word_to_rust
+          (mk_method_expr "wrapping_add") arith_edges random_pairs),
+       ("stdlibarith_" ^ suffix ^ "_saturating_sub",
+        gen_binary_tests ctxt utype mk_saturating_sub_term eval_word_to_rust
+          (mk_method_expr "saturating_sub") arith_edges random_pairs),
+       ("stdlibarith_" ^ suffix ^ "_checked_add",
+        gen_binary_tests ctxt utype mk_checked_add_term eval_option_to_rust
+          (mk_method_expr "checked_add") arith_edges random_pairs),
+       ("stdlibarith_" ^ suffix ^ "_checked_mul",
+        gen_binary_tests ctxt utype mk_checked_mul_term eval_option_to_rust
+          (mk_method_expr "checked_mul") arith_edges random_pairs),
+       ("stdlibarith_" ^ suffix ^ "_div_ceil",
+        gen_binary_tests ctxt utype mk_div_ceil_term eval_word_to_rust
+          (mk_method_expr "div_ceil") div_edges random_div_pairs)]
+    end
+
+  fun generate_u64_nonzero_tests ctxt seed num_random =
+    let
+      val (random_values, _) = gen_random_u64_values seed num_random
+      val all_edges = nonzero_edge_values ()
+      val positive_edges = positive_u64_edge_values ()
+      val random_positive = map (fn n => if n = 0 then 1 else n) random_values
+      fun rust_new_is_some n =
+        "std::num::NonZeroU64::new(" ^ IntInf.toString n ^ "u64).is_some()"
+      fun rust_get_roundtrip n =
+        "std::num::NonZeroU64::new(" ^ IntInf.toString n ^ "u64).unwrap().get() == "
+        ^ IntInf.toString n ^ "u64"
+    in
+      [("stdlibarith_u64_nonzerou64_new_is_some",
+        gen_u64_value_tests ctxt mk_nonzero_new_is_some_term eval_bool_to_rust
+          rust_new_is_some all_edges random_values),
+       ("stdlibarith_u64_nonzerou64_get_roundtrip",
+        gen_u64_value_tests ctxt mk_nonzero_get_roundtrip_term eval_bool_to_rust
+          rust_get_roundtrip positive_edges random_positive)]
+    end
+
+  fun generate_all_tests ctxt num_random =
+    let
+      val seed = default_seed
+      val types = [U8, U16, U32, U64]
+      val type_modules = List.concat (map (fn t => generate_type_tests ctxt t seed num_random) types)
+      val nonzero_modules = generate_u64_nonzero_tests ctxt seed num_random
+    in
+      type_modules @ nonzero_modules
+    end
+end
+\<close>
+
+(*<*)
+end
+(*>*)

--- a/Conformance_Testing/Tests/Tuple_Conformance.thy
+++ b/Conformance_Testing/Tests/Tuple_Conformance.thy
@@ -1,0 +1,162 @@
+(* Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+   SPDX-License-Identifier: MIT *)
+
+(*<*)
+theory Tuple_Conformance
+  imports
+    "../Conformance_Framework"
+    Micro_Rust_Std_Lib.StdLib_Tuple
+begin
+(*>*)
+
+section\<open>Tuple Conformance Tests\<close>
+
+text\<open>This theory generates conformance tests for tuple/list zipping APIs by
+evaluating the actual Micro Rust function body, then comparing to real Rust
+behaviour.\<close>
+
+ML\<open>
+structure Tuple_Conformance = struct
+  open Conformance_Random
+  open Conformance
+  open Rust_Codegen
+
+  datatype uint_type = U8 | U16 | U32 | U64
+
+  fun uint_bits U8 = 8 | uint_bits U16 = 16 | uint_bits U32 = 32 | uint_bits U64 = 64
+  fun uint_rust_suffix U8 = "u8" | uint_rust_suffix U16 = "u16"
+    | uint_rust_suffix U32 = "u32" | uint_rust_suffix U64 = "u64"
+
+  fun parse_term ctxt s = Syntax.read_term ctxt s
+
+  fun eval_bool_to_rust ctxt term =
+    (case term_to_bool (Value_Command.value ctxt term) of
+      SOME true => "true"
+    | SOME false => "false"
+    | NONE => raise Fail "Failed to extract bool result")
+
+  fun hol_word bits n = "(" ^ IntInf.toString n ^ " :: " ^ Int.toString bits ^ " word)"
+
+  fun hol_word_list bits xs =
+    "[" ^ String.concatWith ", " (map (hol_word bits) xs) ^ "]"
+
+  fun rust_vec suffix xs =
+    "vec![" ^ String.concatWith ", " (map (fn x => IntInf.toString x ^ suffix) xs) ^ "]"
+
+  fun zip_short (x :: xs) (y :: ys) = (x, y) :: zip_short xs ys
+    | zip_short _ _ = []
+
+  fun hol_tuple3_list bits pairs =
+    let
+      fun elem (a, b) = "(" ^ hol_word bits a ^ ", " ^ hol_word bits b ^ ", TNil)"
+    in
+      "[" ^ String.concatWith ", " (map elem pairs) ^ "]"
+    end
+
+  fun rust_pair_vec suffix pairs =
+    let
+      fun elem (a, b) = "(" ^ IntInf.toString a ^ suffix ^ ", " ^ IntInf.toString b ^ suffix ^ ")"
+    in
+      "vec![" ^ String.concatWith ", " (map elem pairs) ^ "]"
+    end
+
+  fun mk_call_eq_term ctxt body expected =
+    parse_term ctxt
+      ("(case evaluate (call (" ^ body ^ ")) () of Success r _ => (r = " ^ expected ^ ") | _ => False)")
+
+  fun next_random_value utype seed =
+    (case utype of
+      U8 => let val (v, s') = next_word8 seed in (Word8.toLargeInt v, s') end
+    | U16 => let val (v, s') = next_word16 seed in (Word.toLargeInt v, s') end
+    | U32 => let val (v, s') = next_word32 seed in (Word32.toLargeInt v, s') end
+    | U64 => let val (v, s') = next_word64 seed in (Word64.toLargeInt v, s') end)
+
+  fun gen_random_list utype seed max_len =
+    let
+      val (len, seed') = next_int seed 0 max_len
+      fun go 0 acc s = (rev acc, s)
+        | go n acc s =
+            let
+              val (v, s') = next_random_value utype s
+            in
+              go (n - 1) (v :: acc) s'
+            end
+    in
+      go len [] seed'
+    end
+
+  fun gen_random_list_pairs utype seed n =
+    next_list seed n (fn s =>
+      let
+        val (xs, s') = gen_random_list utype s 6
+        val (ys, s'') = gen_random_list utype s' 6
+      in
+        ((xs, ys), s'')
+      end)
+
+  fun edge_pairs utype =
+    let
+      val bits = uint_bits utype
+      val one = 1 : IntInf.int
+      val two = 2 : IntInf.int
+      val three = 3 : IntInf.int
+      val max =
+        (case utype of
+          U8 => 255
+        | U16 => 65535
+        | U32 => 4294967295
+        | U64 => 18446744073709551615)
+      val cap = fn n => if n > max then max else n
+      val _ = bits
+    in
+      [([], []),
+       ([cap one], []),
+       ([], [cap two]),
+       ([cap one], [cap two]),
+       ([cap one, cap two, cap three], [cap three, cap two, cap one]),
+       ([cap 10, cap 20, cap 30, cap 40], [cap 1, cap 2]),
+       ([cap 5], [cap 6, cap 7, cap 8, cap 9]),
+       ([cap max, cap (max - 1)], [cap 0, cap 1])]
+    end
+
+  fun generate_type_tests ctxt utype seed num_random =
+    let
+      val bits = uint_bits utype
+      val suffix = uint_rust_suffix utype
+      val (random_pairs, _) = gen_random_list_pairs utype seed num_random
+      val cases = edge_pairs utype @ random_pairs
+
+      val tests =
+        map_index
+          (fn (i, (xs, ys)) =>
+            let
+              val zipped = zip_short xs ys
+              val body = "list_zip " ^ hol_word_list bits xs ^ " " ^ hol_word_list bits ys
+              val expected = hol_tuple3_list bits zipped
+              val rust_expr =
+                "{ let xs = " ^ rust_vec suffix xs ^ "; let ys = " ^ rust_vec suffix ys ^ "; "
+                ^ "xs.into_iter().zip(ys.into_iter()).collect::<Vec<(" ^ suffix ^ ", " ^ suffix ^ ")>>() == "
+                ^ rust_pair_vec suffix zipped ^ " }"
+            in
+              {name = "test_" ^ Int.toString i,
+               rust_expr = rust_expr,
+               expected = eval_bool_to_rust ctxt (mk_call_eq_term ctxt body expected)}
+            end)
+          cases
+    in
+      [("tuple_" ^ suffix ^ "_list_zip", tests)]
+    end
+
+  fun generate_all_tests ctxt num_random =
+    let
+      val seed = default_seed
+      val types = [U8, U16, U32, U64]
+    in
+      List.concat (map (fn t => generate_type_tests ctxt t seed num_random) types)
+    end
+end
+\<close>
+
+(*<*)
+end
+(*>*)

--- a/Conformance_Testing/conformance.ML
+++ b/Conformance_Testing/conformance.ML
@@ -1,0 +1,136 @@
+(* Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+   SPDX-License-Identifier: MIT *)
+
+(* Core conformance testing infrastructure.
+   Provides result type representation, HOL term evaluation, and conversion utilities.
+
+   The main workflow is:
+   1. Generate random test inputs (word values)
+   2. Construct HOL terms representing function applications
+   3. Evaluate terms using Isabelle's code evaluation
+   4. Extract results and serialize to Rust syntax
+*)
+
+signature CONFORMANCE = sig
+  (* Result representation matching HOL's option type *)
+  datatype 'a test_result = Some of 'a | None
+
+  (* Convert test_result to Rust syntax *)
+  val option_result_to_rust : string test_result -> string
+
+  (* Convert a boolean to Rust syntax *)
+  val bool_to_rust : bool -> string
+
+  (* Word value formatting for different sizes *)
+  val word32_to_rust : Word32.word -> string -> string  (* value, type_suffix *)
+  val word64_to_rust : Word64.word -> string -> string
+
+  (* Evaluate a HOL term and extract the result *)
+  val eval_term : Proof.context -> term -> term
+
+  (* Extract word value from evaluated term *)
+  val extract_word_nat : term -> IntInf.int option
+
+  (* Convert evaluated option term to test_result *)
+  val term_to_option_result : term -> string test_result
+
+  (* Convert evaluated bool term to bool *)
+  val term_to_bool : term -> bool option
+
+  (* Detect whether an evaluated continuation term is an Abort *)
+  val term_to_abort : term -> bool option
+
+  (* Detect whether an evaluated continuation term is specifically Abort (Panic _) *)
+  val term_to_panic_abort : term -> bool option
+
+  (* Type utilities *)
+  val rust_type_suffix : int -> string  (* bit width to Rust suffix *)
+end
+
+structure Conformance : CONFORMANCE = struct
+  datatype 'a test_result = Some of 'a | None
+
+  fun option_result_to_rust None = "None"
+    | option_result_to_rust (Some v) = "Some(" ^ v ^ ")"
+
+  fun bool_to_rust true = "true"
+    | bool_to_rust false = "false"
+
+  fun rust_type_suffix 8 = "u8"
+    | rust_type_suffix 16 = "u16"
+    | rust_type_suffix 32 = "u32"
+    | rust_type_suffix 64 = "u64"
+    | rust_type_suffix n = raise Fail ("Unsupported bit width: " ^ Int.toString n)
+
+  fun word32_to_rust w suffix =
+    Word32.fmt StringCvt.DEC w ^ suffix
+
+  fun word64_to_rust w suffix =
+    Word64.fmt StringCvt.DEC w ^ suffix
+
+  (* Evaluate a term using Isabelle's code evaluation *)
+  fun eval_term ctxt t =
+    Value_Command.value ctxt t
+
+  (* Try to extract a natural number from a numeral term *)
+  fun extract_numeral t =
+    case t of
+      Const (@{const_name "Groups.zero_class.zero"}, _) => SOME 0
+    | Const (@{const_name "Groups.one_class.one"}, _) => SOME 1
+    | Const (@{const_name "Num.numeral_class.numeral"}, _) $ num =>
+        SOME (HOLogic.dest_numeral num)
+    | _ $ Const (@{const_name "Groups.zero_class.zero"}, _) => SOME 0
+    | _ $ Const (@{const_name "Groups.one_class.one"}, _) => SOME 1
+    | _ $ (Const (@{const_name "Num.numeral_class.numeral"}, _) $ num) =>
+        SOME (HOLogic.dest_numeral num)
+    | _ => NONE
+    handle TERM _ => NONE
+
+  (* Extract the nat value from a word term *)
+  fun extract_word_nat t =
+    case t of
+      (* Direct numeral *)
+      _ => extract_numeral t
+    handle TERM _ => NONE
+
+  (* Convert an evaluated option term to test_result *)
+  fun term_to_option_result t =
+    case t of
+      Const (@{const_name "Option.option.None"}, _) => None
+    | Const (@{const_name "Option.option.Some"}, _) $ v =>
+        (case extract_word_nat v of
+          SOME n => Some (IntInf.toString n)
+        | NONE => None)  (* Fall back to None if we can't extract *)
+    | _ => None
+
+  (* Convert an evaluated bool term to bool *)
+  fun term_to_bool t =
+    case t of
+      @{term "True"} => SOME true
+    | @{term "False"} => SOME false
+    | Const (@{const_name "HOL.True"}, _) => SOME true
+    | Const (@{const_name "HOL.False"}, _) => SOME false
+    | _ => NONE
+
+  (* Convert an evaluated continuation term to an abort flag *)
+  fun term_to_abort t =
+    case t of
+      Const (@{const_name Success}, _) $ _ $ _ => SOME false
+    | Const (@{const_name Return}, _) $ _ $ _ => SOME false
+    | Const (@{const_name Abort}, _) $ _ $ _ => SOME true
+    | _ => NONE
+
+  (* Convert an evaluated continuation term to a panic-abort flag *)
+  fun term_to_panic_abort t =
+    case t of
+      Const (@{const_name Success}, _) $ _ $ _ => SOME false
+    | Const (@{const_name Return}, _) $ _ $ _ => SOME false
+    | Const (@{const_name Abort}, _) $ abort_reason $ _ =>
+        (case abort_reason of
+          Const (@{const_name Panic}, _) $ _ => SOME true
+        | _ => SOME false)
+    | _ => NONE
+end
+
+(* Open the structure for easy access *)
+open Conformance

--- a/Conformance_Testing/coverage.ML
+++ b/Conformance_Testing/coverage.ML
@@ -1,0 +1,203 @@
+(* Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+   SPDX-License-Identifier: MIT *)
+
+(* Conformance coverage summary generation.
+   Produces machine-readable JSON and human-readable Markdown audit artifacts. *)
+
+signature CONFORMANCE_COVERAGE = sig
+  val require_categories : string list -> (string * Rust_Codegen.test_case list) list -> unit
+  val write_summary_files :
+    {json_path : string, markdown_path : string, modules : (string * Rust_Codegen.test_case list) list} -> unit
+end
+
+structure Conformance_Coverage : CONFORMANCE_COVERAGE = struct
+  type module_summary = {
+    name : string,
+    category : string,
+    test_count : int,
+    panic_true_count : int,
+    panic_false_count : int
+  }
+
+  val tracked_types = ["u8", "u16", "u32", "u64"]
+
+  fun add_assoc key delta [] = [(key, delta)]
+    | add_assoc key delta ((k, v) :: rest) =
+        if k = key then (k, v + delta) :: rest
+        else (k, v) :: add_assoc key delta rest
+
+  fun get_assoc key [] = 0
+    | get_assoc key ((k, v) :: rest) =
+        if k = key then v else get_assoc key rest
+
+  fun module_category name =
+    (case String.tokens (fn c => c = #"_") name of
+      category :: _ => category
+    | [] => "uncategorized")
+
+  fun module_mentions_type ty name =
+    List.exists (fn tok => tok = ty) (String.tokens (fn c => c = #"_") name)
+
+  fun count_expected needle tests =
+    length (List.filter (fn (tc : Rust_Codegen.test_case) => #expected tc = needle) tests)
+
+  fun summarize_module (name, tests) =
+    let
+      val category = module_category name
+      val test_count = length tests
+      val panic_true_count = if category = "panic" then count_expected "true" tests else 0
+      val panic_false_count = if category = "panic" then count_expected "false" tests else 0
+    in
+      {
+        name = name,
+        category = category,
+        test_count = test_count,
+        panic_true_count = panic_true_count,
+        panic_false_count = panic_false_count
+      }
+    end
+
+  fun sort_counts counts =
+    sort (fn ((a, _), (b, _)) => String.compare (a, b)) counts
+
+  fun json_escape s =
+    String.translate
+      (fn #"\"" => "\\\""
+        | #"\\" => "\\\\"
+        | #"\n" => "\\n"
+        | #"\r" => "\\r"
+        | #"\t" => "\\t"
+        | c => String.str c) s
+
+  fun json_string s = "\"" ^ json_escape s ^ "\""
+
+  fun module_to_json {name, category, test_count, panic_true_count, panic_false_count} =
+    "{"
+    ^ "\"name\":" ^ json_string name
+    ^ ",\"category\":" ^ json_string category
+    ^ ",\"test_count\":" ^ Int.toString test_count
+    ^ ",\"panic_true_count\":" ^ Int.toString panic_true_count
+    ^ ",\"panic_false_count\":" ^ Int.toString panic_false_count
+    ^ "}"
+
+  fun count_to_json (key, value) =
+    "{"
+    ^ "\"name\":" ^ json_string key
+    ^ ",\"count\":" ^ Int.toString value
+    ^ "}"
+
+  fun write_file path content =
+    let
+      val out = TextIO.openOut path
+    in
+      TextIO.output (out, content);
+      TextIO.closeOut out
+    end
+
+  fun require_categories required_categories modules =
+    let
+      val category_module_counts =
+        fold (fn (name, _) => fn acc => add_assoc (module_category name) 1 acc) modules []
+      val missing =
+        List.filter (fn category => get_assoc category category_module_counts = 0) required_categories
+    in
+      if null missing then ()
+      else
+        raise Fail
+          ("Missing required conformance coverage categories: "
+           ^ String.concatWith ", " missing)
+    end
+
+  fun write_summary_files {json_path, markdown_path, modules} =
+    let
+      val summaries = map summarize_module modules
+      val total_modules = length summaries
+      val total_tests = fold (fn s => fn acc => #test_count s + acc) summaries 0
+      val total_panic_true = fold (fn s => fn acc => #panic_true_count s + acc) summaries 0
+      val total_panic_false = fold (fn s => fn acc => #panic_false_count s + acc) summaries 0
+
+      val category_module_counts =
+        sort_counts (fold (fn s => add_assoc (#category s) 1) summaries [])
+      val category_test_counts =
+        sort_counts (fold (fn s => add_assoc (#category s) (#test_count s)) summaries [])
+
+      val type_test_counts =
+        let
+          fun bump_types s acc =
+            List.foldl
+              (fn (ty, a) =>
+                if module_mentions_type ty (#name s) then add_assoc ty (#test_count s) a else a)
+              acc
+              tracked_types
+        in
+          sort_counts (fold bump_types summaries [])
+        end
+
+      val generated_at = Time.toString (Time.now ())
+
+      val modules_json =
+        String.concatWith ",\n    " (map module_to_json summaries)
+      val category_modules_json =
+        String.concatWith ",\n    " (map count_to_json category_module_counts)
+      val category_tests_json =
+        String.concatWith ",\n    " (map count_to_json category_test_counts)
+      val type_tests_json =
+        String.concatWith ",\n    "
+          (map (fn ty => count_to_json (ty, get_assoc ty type_test_counts)) tracked_types)
+
+      val json_content =
+        "{\n"
+        ^ "  \"generated_at\": " ^ json_string generated_at ^ ",\n"
+        ^ "  \"total_modules\": " ^ Int.toString total_modules ^ ",\n"
+        ^ "  \"total_tests\": " ^ Int.toString total_tests ^ ",\n"
+        ^ "  \"panic_true_count\": " ^ Int.toString total_panic_true ^ ",\n"
+        ^ "  \"panic_false_count\": " ^ Int.toString total_panic_false ^ ",\n"
+        ^ "  \"category_module_counts\": [\n    " ^ category_modules_json ^ "\n  ],\n"
+        ^ "  \"category_test_counts\": [\n    " ^ category_tests_json ^ "\n  ],\n"
+        ^ "  \"type_test_counts\": [\n    " ^ type_tests_json ^ "\n  ],\n"
+        ^ "  \"modules\": [\n    " ^ modules_json ^ "\n  ]\n"
+        ^ "}\n"
+
+      fun category_row (name, module_count) =
+        let
+          val tests = get_assoc name category_test_counts
+        in
+          "| " ^ name ^ " | " ^ Int.toString module_count ^ " | " ^ Int.toString tests ^ " |"
+        end
+
+      fun type_row ty =
+        "| " ^ ty ^ " | " ^ Int.toString (get_assoc ty type_test_counts) ^ " |"
+
+      fun module_row {name, category, test_count, panic_true_count, panic_false_count} =
+        "| " ^ name ^ " | " ^ category ^ " | "
+        ^ Int.toString test_count ^ " | "
+        ^ Int.toString panic_true_count ^ " | "
+        ^ Int.toString panic_false_count ^ " |"
+
+      val markdown_content =
+        "# Conformance Coverage Summary\n\n"
+        ^ "Generated at: `" ^ generated_at ^ "`\n\n"
+        ^ "## Totals\n\n"
+        ^ "- Modules: " ^ Int.toString total_modules ^ "\n"
+        ^ "- Tests: " ^ Int.toString total_tests ^ "\n"
+        ^ "- Panic assertions expecting panic (`true`): " ^ Int.toString total_panic_true ^ "\n"
+        ^ "- Panic assertions expecting no panic (`false`): " ^ Int.toString total_panic_false ^ "\n\n"
+        ^ "## Category Coverage\n\n"
+        ^ "| Category | Modules | Tests |\n"
+        ^ "|---|---:|---:|\n"
+        ^ String.concatWith "\n" (map category_row category_module_counts) ^ "\n\n"
+        ^ "## Type Coverage (tests touching type)\n\n"
+        ^ "| Type | Tests |\n"
+        ^ "|---|---:|\n"
+        ^ String.concatWith "\n" (map type_row tracked_types) ^ "\n\n"
+        ^ "## Module Breakdown\n\n"
+        ^ "| Module | Category | Tests | panic=true | panic=false |\n"
+        ^ "|---|---|---:|---:|---:|\n"
+        ^ String.concatWith "\n" (map module_row summaries) ^ "\n"
+    in
+      write_file json_path json_content;
+      write_file markdown_path markdown_content
+    end
+end
+
+open Conformance_Coverage

--- a/Conformance_Testing/random.ML
+++ b/Conformance_Testing/random.ML
@@ -1,0 +1,160 @@
+(* Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+   SPDX-License-Identifier: MIT *)
+
+(* Deterministic random number generation for conformance testing.
+   Uses a linear congruential generator with fixed seed for reproducibility.
+
+   The default seed is 42, ensuring tests are deterministic across runs.
+*)
+
+signature CONFORMANCE_RANDOM = sig
+  type seed
+
+  (* Initialize with a seed value (default: 42) *)
+  val init : int -> seed
+  val default_seed : seed
+
+  (* Generate random integers in range [lo, hi] *)
+  val next_int : seed -> int -> int -> int * seed
+
+  (* Generate random word values for different sizes *)
+  val next_word8 : seed -> Word8.word * seed
+  val next_word16 : seed -> Word.word * seed  (* 16-bit *)
+  val next_word32 : seed -> Word32.word * seed
+  val next_word64 : seed -> Word64.word * seed
+
+  (* Generate lists of random values *)
+  val next_list : seed -> int -> (seed -> 'a * seed) -> 'a list * seed
+
+  (* Generate pairs of random values *)
+  val next_pair : seed -> (seed -> 'a * seed) -> (seed -> 'b * seed) -> ('a * 'b) * seed
+
+  (* Boundary values for testing edge cases *)
+  val word8_boundaries : Word8.word list
+  val word16_boundaries : Word.word list
+  val word32_boundaries : Word32.word list
+  val word64_boundaries : Word64.word list
+
+  (* Generate a mix of boundary and random values *)
+  val word32_test_values : seed -> int -> Word32.word list * seed
+  val word64_test_values : seed -> int -> Word64.word list * seed
+end
+
+structure Conformance_Random : CONFORMANCE_RANDOM = struct
+  type seed = Word64.word
+
+  (* LCG parameters (same as glibc) *)
+  val a : Word64.word = 0w1103515245
+  val c : Word64.word = 0w12345
+  val m : Word64.word = 0wx80000000 (* 2^31 *)
+
+  fun init s = Word64.fromInt s
+  val default_seed = init 42
+
+  fun next seed =
+    Word64.mod (Word64.+ (Word64.* (seed, a), c), m)
+
+  fun next_int seed lo hi =
+    let
+      val seed' = next seed
+      val range = hi - lo + 1
+      val value = lo + Word64.toInt (Word64.mod (seed', Word64.fromInt range))
+    in (value, seed') end
+
+  fun next_word8 seed =
+    let
+      val seed' = next seed
+      val w = Word8.fromInt (Word64.toInt (Word64.mod (seed', 0w256)))
+    in (w, seed') end
+
+  fun next_word16 seed =
+    let
+      val seed' = next seed
+      val w = Word.fromInt (Word64.toInt (Word64.mod (seed', 0w65536)))
+    in (w, seed') end
+
+  fun next_word32 seed =
+    let
+      val seed1 = next seed
+      val seed2 = next seed1
+      val lo = Word32.fromInt (Word64.toInt (Word64.mod (seed1, 0wx10000)))
+      val hi = Word32.fromInt (Word64.toInt (Word64.mod (seed2, 0wx10000)))
+      val w = Word32.orb (lo, Word32.<< (hi, 0w16))
+    in (w, seed2) end
+
+  fun next_word64 seed =
+    let
+      val seed1 = next seed
+      val seed2 = next seed1
+      val seed3 = next seed2
+      val seed4 = next seed3
+      val w0 = Word64.mod (seed1, 0wx10000)
+      val w1 = Word64.mod (seed2, 0wx10000)
+      val w2 = Word64.mod (seed3, 0wx10000)
+      val w3 = Word64.mod (seed4, 0wx10000)
+      val lo = Word64.orb (w0, Word64.<< (w1, 0w16))
+      val hi = Word64.orb (w2, Word64.<< (w3, 0w16))
+      val w = Word64.orb (lo, Word64.<< (hi, 0w32))
+    in (w, seed4) end
+
+  fun next_list seed 0 _ = ([], seed)
+    | next_list seed n gen =
+        let
+          val (x, seed') = gen seed
+          val (xs, seed'') = next_list seed' (n - 1) gen
+        in (x :: xs, seed'') end
+
+  fun next_pair seed gen_a gen_b =
+    let
+      val (a, seed') = gen_a seed
+      val (b, seed'') = gen_b seed'
+    in ((a, b), seed'') end
+
+  (* Boundary values for edge case testing *)
+  val word8_boundaries : Word8.word list = [
+    0w0,              (* min *)
+    0w1,              (* min + 1 *)
+    0w127,            (* mid-1 *)
+    0w128,            (* mid (2^7) *)
+    0w254,            (* max - 1 *)
+    0w255             (* max *)
+  ]
+
+  val word16_boundaries : Word.word list = [
+    0w0,              (* min *)
+    0w1,              (* min + 1 *)
+    0w32767,          (* mid-1 *)
+    0w32768,          (* mid (2^15) *)
+    0w65534,          (* max - 1 *)
+    0w65535           (* max *)
+  ]
+
+  val word32_boundaries : Word32.word list = [
+    0w0,              (* min *)
+    0w1,              (* min + 1 *)
+    0w2147483647,     (* mid-1 (2^31 - 1) *)
+    0w2147483648,     (* mid (2^31) *)
+    0w4294967294,     (* max - 1 *)
+    0w4294967295      (* max *)
+  ]
+
+  val word64_boundaries : Word64.word list = [
+    0w0,                          (* min *)
+    0w1,                          (* min + 1 *)
+    0w9223372036854775807,        (* mid-1 (2^63 - 1) *)
+    0w9223372036854775808,        (* mid (2^63) *)
+    0w18446744073709551614,       (* max - 1 *)
+    0w18446744073709551615        (* max *)
+  ]
+
+  (* Generate test values: all boundaries plus n random values *)
+  fun word32_test_values seed n =
+    let
+      val (randoms, seed') = next_list seed n next_word32
+    in (word32_boundaries @ randoms, seed') end
+
+  fun word64_test_values seed n =
+    let
+      val (randoms, seed') = next_list seed n next_word64
+    in (word64_boundaries @ randoms, seed') end
+end

--- a/Conformance_Testing/rust_codegen.ML
+++ b/Conformance_Testing/rust_codegen.ML
@@ -1,0 +1,111 @@
+(* Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+   SPDX-License-Identifier: MIT *)
+
+(* Rust test code generation for conformance testing.
+
+   This module generates Rust test files with embedded assertions that
+   validate μRust semantics against real Rust behaviour.
+
+   Example output:
+   ```rust
+   #[test]
+   fn test_add_u32_5_3() {
+       assert_eq!(5u32.checked_add(3), Some(8));
+   }
+   ```
+*)
+
+signature RUST_CODEGEN = sig
+  (* A single test case *)
+  type test_case = {
+    name : string,
+    rust_expr : string,
+    expected : string
+  }
+
+  (* Generate a Rust test function *)
+  val test_to_rust : test_case -> string
+
+  (* Generate a Rust test module *)
+  val generate_test_module : string -> test_case list -> string
+
+  (* Generate complete file with multiple modules *)
+  val generate_test_file : (string * test_case list) list -> string
+
+  (* Write to file *)
+  val write_test_file : string -> string -> unit
+
+  (* File header *)
+  val file_header : string
+
+  (* Helper: sanitize names for Rust identifiers *)
+  val sanitize_name : string -> string
+
+  (* Helper: generate test name from operation and operands *)
+  val make_test_name : string -> string -> string -> string -> string
+end
+
+structure Rust_Codegen : RUST_CODEGEN = struct
+  type test_case = {
+    name : string,
+    rust_expr : string,
+    expected : string
+  }
+
+  val file_header =
+    "// Auto-generated conformance tests\n\
+    \// DO NOT EDIT - regenerate via Isabelle\n\
+    \//\n\
+    \// This file validates that Micro Rust (μRust) semantics match real Rust behaviour.\n\
+    \// Each test embeds expected values computed by Isabelle/HOL.\n\
+    \//\n\
+    \// Run with: cargo test\n\n\
+    \#![allow(clippy::eq_op)]\n\n"
+
+  (* Convert non-alphanumeric characters to underscores *)
+  fun sanitize_name s =
+    String.translate (fn c =>
+      if Char.isAlphaNum c orelse c = #"_" then String.str c
+      else "_") s
+
+  (* Generate a unique test name *)
+  fun make_test_name op_name rust_type a b =
+    "test_" ^ op_name ^ "_" ^ rust_type ^ "_" ^
+    sanitize_name a ^ "_" ^ sanitize_name b
+
+  fun test_to_rust {name, rust_expr, expected} =
+    "    #[test]\n\
+    \    fn " ^ name ^ "() {\n\
+    \        assert_eq!(" ^ rust_expr ^ ", " ^ expected ^ ");\n\
+    \    }\n"
+
+  fun generate_test_module mod_name tests =
+    let
+      val tests_str = String.concatWith "\n" (map test_to_rust tests)
+    in
+      "#[cfg(test)]\n\
+      \mod " ^ mod_name ^ " {\n" ^
+      tests_str ^
+      "}\n"
+    end
+
+  fun generate_test_file modules =
+    let
+      val modules_str = String.concatWith "\n" (
+        map (fn (name, tests) => generate_test_module name tests) modules
+      )
+    in
+      file_header ^ modules_str
+    end
+
+  fun write_test_file path content =
+    let
+      val os = TextIO.openOut path
+    in
+      TextIO.output (os, content);
+      TextIO.closeOut os
+    end
+end
+
+(* Open the structure for easy access *)
+open Rust_Codegen

--- a/Conformance_Testing/rust_harness/.gitignore
+++ b/Conformance_Testing/rust_harness/.gitignore
@@ -1,0 +1,2 @@
+/target/
+Cargo.lock

--- a/Conformance_Testing/rust_harness/Cargo.toml
+++ b/Conformance_Testing/rust_harness/Cargo.toml
@@ -1,0 +1,13 @@
+[package]
+name = "micro_rust_conformance"
+version = "0.1.0"
+edition = "2021"
+description = "Conformance tests for Micro Rust (μRust) semantics"
+publish = false
+
+[lib]
+path = "src/lib.rs"
+
+[dependencies]
+
+[dev-dependencies]

--- a/Makefile
+++ b/Makefile
@@ -8,10 +8,11 @@
 ######################################################################
 
 .DEFAULT_GOAL: jedit
-.PHONY: register-afp-components build jedit
+.PHONY: register-afp-components build jedit conformance-gen conformance-test conformance conformance-clean
 
-# Set this to the directory containing the Isabelle2025-2 binary
+# Set this to the Isabelle installation root or bin directory
 ISABELLE_HOME?=/Applications/Isabelle2025-2.app/bin
+ISABELLE?=$(if $(wildcard $(ISABELLE_HOME)/bin/isabelle),$(ISABELLE_HOME)/bin/isabelle,$(ISABELLE_HOME)/isabelle)
 # Set this to your home directory
 USER_HOME?=$(HOME)
 # Set this to where you maintain, or want to maintain, AFP dependencies
@@ -37,10 +38,35 @@ ISABELLE_FLAGS?=-b -j 1 -o "threads=$(AVAILABLE_CORES)" -v
 ISABELLE_JEDIT_FLAGS?=
 
 jedit: register-afp-components
-	$(ISABELLE_HOME)/isabelle jedit $(ISABELLE_JEDIT_FLAGS) -l HOL -d . ./AutoCorrode.thy  &
+	$(ISABELLE) jedit $(ISABELLE_JEDIT_FLAGS) -l HOL -d . ./AutoCorrode.thy  &
 
 register-afp-components:
-	$(ISABELLE_HOME)/isabelle components -u $(AFP_COMPONENT_BASE)/Word_Lib
+	@if [ ! -d "$(AFP_COMPONENT_BASE)/Word_Lib" ]; then \
+		echo "Error: AFP component directory not found: $(AFP_COMPONENT_BASE)/Word_Lib"; \
+		echo "Hint: checkout AFP and set AFP_COMPONENT_BASE to the AFP theories root (for example: afp/thys)."; \
+		exit 1; \
+	fi
+	$(ISABELLE) components -u $(AFP_COMPONENT_BASE)/Word_Lib
 
 build: register-afp-components
-	$(ISABELLE_HOME)/isabelle build $(ISABELLE_FLAGS) -d . AutoCorrode
+	$(ISABELLE) build $(ISABELLE_FLAGS) -d . AutoCorrode
+
+# Conformance Testing targets
+# These validate that μRust HOL semantics match real Rust behaviour
+
+conformance-gen: register-afp-components
+	@echo "Generating conformance tests from HOL definitions..."
+	$(ISABELLE) build $(ISABELLE_FLAGS) -d . Conformance_Testing
+
+conformance-test:
+	@echo "Running conformance tests against Rust..."
+	cd Conformance_Testing/rust_harness && cargo test
+
+conformance: conformance-gen conformance-test
+	@echo "Conformance testing complete."
+
+conformance-clean: register-afp-components
+	@echo "Cleaning conformance test artifacts..."
+	rm -rf Conformance_Testing/rust_harness/target
+	rm -f Conformance_Testing/rust_harness/src/lib.rs
+	$(ISABELLE) build -c -d . Conformance_Testing || true

--- a/README.md
+++ b/README.md
@@ -41,6 +41,38 @@ You can interactively explore AutoCorrode using `make jedit`, which opens the Au
 
 To non-interactively check all material in AutoCorrode, run `make build`, which starts a batch-build in Isabelle.
 
+## Conformance Testing
+
+AutoCorrode includes a conformance-testing pipeline that validates Micro Rust semantics against real Rust execution.
+
+From the repository root:
+
+```bash
+make conformance-gen
+make conformance-test
+```
+
+Or end-to-end:
+
+```bash
+make conformance
+```
+
+This pipeline:
+
+1. generates Rust tests from HOL-evaluated expectations
+2. runs them with `cargo test`
+3. emits coverage summaries for auditing
+
+Coverage summaries are generated at:
+
+- `Conformance_Testing/rust_harness/coverage_summary.json`
+- `Conformance_Testing/rust_harness/coverage_summary.md`
+
+Conformance is CI-blocking in `.github/workflows/ci.yml` via `make conformance`.
+
+For full details (categories, API coverage status, and extension workflow), see `Conformance_Testing/README.md`.
+
 ## Citing AutoCorrode
 
 If you want to cite AutoCorrode, consider using the following BibTeX entry:

--- a/ROOTS
+++ b/ROOTS
@@ -8,6 +8,7 @@ Misc
 Separation_Lenses
 Shallow_Micro_Rust
 Shallow_Separation_Logic
+Conformance_Testing
 Micro_Rust_Examples
 Micro_Rust_Parsing_Frontend
 Micro_Rust_Interfaces_Core

--- a/Shallow_Micro_Rust/Eval.thy
+++ b/Shallow_Micro_Rust/Eval.thy
@@ -593,9 +593,25 @@ lemma urust_eval_action_add_no_wrap [urust_eval_action_simps]:
     and \<open>((\<Gamma>, \<lbrakk> x + y \<rbrakk>) \<diamondop>\<^sub>v \<sigma>) =
             (if (unat x + unat y < 2 ^ LENGTH('l)) then {(x + y, \<sigma>)} else {})\<close>
     and \<open>((\<Gamma>, \<lbrakk> x + y \<rbrakk>) \<diamondop>\<^sub>r \<sigma>) = {}\<close>
-  by (auto simp add: word_add_no_wrap_def urust_eval_action_bind micro_rust_simps
-    urust_eval_action_literal urust_eval_action_abort  word_add_no_wrap_core_def Let_def
-    word_add_no_wrap_as_urust_def urust_eval_action_call word_op_no_wrap_pure_def option_unwrap_expr_def)
+proof -
+  show \<open>((\<Gamma>, \<lbrakk> x + y \<rbrakk>) \<diamondop>\<^sub>a \<sigma>) =
+      (if (unat x + unat y < 2 ^ LENGTH('l)) then {} else { (Panic overflow_err_msg, \<sigma>) })\<close>
+    by (simp add: word_add_no_wrap_def urust_eval_action_bind micro_rust_simps
+      urust_eval_action_literal urust_eval_action_abort word_add_no_wrap_core_def Let_def
+      word_add_no_wrap_as_urust_def urust_eval_action_call word_add_no_wrap_pure_def
+      word_op_no_wrap_pure_def option_unwrap_expr_def split: option.splits if_splits)
+  show \<open>((\<Gamma>, \<lbrakk> x + y \<rbrakk>) \<diamondop>\<^sub>v \<sigma>) =
+      (if (unat x + unat y < 2 ^ LENGTH('l)) then {(x + y, \<sigma>)} else {})\<close>
+    by (simp add: word_add_no_wrap_def urust_eval_action_bind micro_rust_simps
+      urust_eval_action_literal urust_eval_action_abort word_add_no_wrap_core_def Let_def
+      word_add_no_wrap_as_urust_def urust_eval_action_call word_add_no_wrap_pure_def
+      word_op_no_wrap_pure_def option_unwrap_expr_def split: option.splits if_splits)
+  show \<open>((\<Gamma>, \<lbrakk> x + y \<rbrakk>) \<diamondop>\<^sub>r \<sigma>) = {}\<close>
+    by (simp add: word_add_no_wrap_def urust_eval_action_bind micro_rust_simps
+      urust_eval_action_literal urust_eval_action_abort word_add_no_wrap_core_def Let_def
+      word_add_no_wrap_as_urust_def urust_eval_action_call word_add_no_wrap_pure_def
+      word_op_no_wrap_pure_def option_unwrap_expr_def split: option.splits if_splits)
+qed
 
 corollary urust_eval_predicate_add_no_wrap [urust_eval_predicate_simps]:
   fixes x y :: \<open>'l::{len} word\<close>
@@ -611,9 +627,25 @@ lemma urust_eval_action_mul_no_wrap [urust_eval_action_simps]:
     and \<open>((\<Gamma>, \<lbrakk> x * y \<rbrakk>) \<diamondop>\<^sub>v \<sigma>) =
             (if (unat x * unat y < 2 ^ LENGTH('l)) then {(x * y, \<sigma>)} else {})\<close>
     and \<open>((\<Gamma>, \<lbrakk> x * y \<rbrakk>) \<diamondop>\<^sub>r \<sigma>) = {}\<close>
-by (auto simp add: word_mul_no_wrap_def urust_eval_action_bind micro_rust_simps
-  urust_eval_action_literal urust_eval_action_abort word_mul_no_wrap_core_def Let_def
-  word_mul_no_wrap_as_urust_def urust_eval_action_call word_op_no_wrap_pure_def option_unwrap_expr_def)
+proof -
+  show \<open>((\<Gamma>, \<lbrakk> x * y \<rbrakk>) \<diamondop>\<^sub>a \<sigma>) =
+      (if (unat x * unat y < 2 ^ LENGTH('l)) then {} else { (Panic overflow_err_msg, \<sigma>) })\<close>
+    by (simp add: word_mul_no_wrap_def urust_eval_action_bind micro_rust_simps
+      urust_eval_action_literal urust_eval_action_abort word_mul_no_wrap_core_def Let_def
+      word_mul_no_wrap_as_urust_def urust_eval_action_call word_mul_no_wrap_pure_def
+      word_op_no_wrap_pure_def option_unwrap_expr_def split: option.splits if_splits)
+  show \<open>((\<Gamma>, \<lbrakk> x * y \<rbrakk>) \<diamondop>\<^sub>v \<sigma>) =
+      (if (unat x * unat y < 2 ^ LENGTH('l)) then {(x * y, \<sigma>)} else {})\<close>
+    by (simp add: word_mul_no_wrap_def urust_eval_action_bind micro_rust_simps
+      urust_eval_action_literal urust_eval_action_abort word_mul_no_wrap_core_def Let_def
+      word_mul_no_wrap_as_urust_def urust_eval_action_call word_mul_no_wrap_pure_def
+      word_op_no_wrap_pure_def option_unwrap_expr_def split: option.splits if_splits)
+  show \<open>((\<Gamma>, \<lbrakk> x * y \<rbrakk>) \<diamondop>\<^sub>r \<sigma>) = {}\<close>
+    by (simp add: word_mul_no_wrap_def urust_eval_action_bind micro_rust_simps
+      urust_eval_action_literal urust_eval_action_abort word_mul_no_wrap_core_def Let_def
+      word_mul_no_wrap_as_urust_def urust_eval_action_call word_mul_no_wrap_pure_def
+      word_op_no_wrap_pure_def option_unwrap_expr_def split: option.splits if_splits)
+qed
 
 corollary urust_eval_predicate_mul_no_wrap [urust_eval_predicate_simps]:
   fixes x y :: \<open>'l::{len} word\<close>

--- a/Shallow_Micro_Rust/Numeric_Types.thy
+++ b/Shallow_Micro_Rust/Numeric_Types.thy
@@ -63,10 +63,10 @@ definition word_minus_no_wrap_pure :: \<open>'l::{len} word \<Rightarrow> 'l wor
      else
        None\<close>
 
-abbreviation word_add_no_wrap_pure :: \<open>'l::{len} word \<Rightarrow> 'l word \<Rightarrow> ('l word) option\<close> where
+definition word_add_no_wrap_pure :: \<open>'l::{len} word \<Rightarrow> 'l word \<Rightarrow> ('l word) option\<close> where
   \<open>word_add_no_wrap_pure \<equiv> word_op_no_wrap_pure ((+) :: nat \<Rightarrow> nat \<Rightarrow> nat)\<close>
 
-abbreviation word_mul_no_wrap_pure :: \<open>'l::{len} word \<Rightarrow> 'l word \<Rightarrow> ('l word) option\<close> where
+definition word_mul_no_wrap_pure :: \<open>'l::{len} word \<Rightarrow> 'l word \<Rightarrow> ('l word) option\<close> where
   \<open>word_mul_no_wrap_pure \<equiv> word_op_no_wrap_pure ((*) :: nat \<Rightarrow> nat \<Rightarrow> nat)\<close>
 
 text\<open>We lift this to Micro Rust expressions by panicking in case of an arithmetic overflow.\<close>


### PR DESCRIPTION
Establish a full conformance testing strategy that validates Rust behaviour against evaluated Micro Rust definitions and blocks CI on coverage regressions.

- expand the conformance suite across core categories: arithmetic, bitwise, comparison, conversion, panic behaviour, stdlib arithmetic, option, result, range, ordering, and tuple
- generate a single Rust harness from HOL-driven expectations rather than handwritten expected semantics
- add/standardize panic-path testing so failure behaviour is checked, not only success paths
- introduce unified generation orchestration and required-category checks
- add coverage reporting infrastructure with machine-readable JSON and human-readable Markdown summaries
- wire conformance coverage verification into CI so missing ownership/coverage fails the pipeline
- update framework/session wiring and docs to reflect the conformance strategy and audit process

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
