### PR TITLE
Harden I/Q line/offset helpers and add regression tests for edge cases

### DIFF
--- a/iq/Makefile
+++ b/iq/Makefile
@@ -13,6 +13,7 @@ JEDIT_DIR := $(shell ls -d $(ISABELLE_HOME)/contrib/jedit-* 2>/dev/null | head -
 JEDIT_JAR ?= $(JEDIT_DIR)/jedit5.7.0-patched/jedit.jar
 SCALA_HOME ?= $(ISABELLE_HOME)/contrib/scala-3.3.4
 SCALAC ?= $(SCALA_HOME)/bin/scalac
+SCALA ?= $(SCALA_HOME)/bin/scala
 ISABELLE_JAR ?= $(ISABELLE_HOME)/lib/classes/isabelle.jar
 JAVA_HOME ?= $(shell $(ISABELLE) getenv -b JAVA_HOME 2>/dev/null)
 JAVA ?= $(if $(JAVA_HOME),$(JAVA_HOME)/bin/java,java)
@@ -22,11 +23,13 @@ JAVA_ENV = $(if $(JAVA_HOME),JAVA_HOME="$(JAVA_HOME)" PATH="$(JAVA_HOME)/bin:$$P
 # Output directories (configurable via environment variables)
 BUILD_DIR ?= $(PLUGIN_DIR)/build
 CLASSES_DIR ?= $(BUILD_DIR)/classes
+TEST_CLASSES_DIR ?= $(BUILD_DIR)/test-classes
 JAR_FILE ?= $(BUILD_DIR)/iq_plugin.jar
 INSTALL_DIR ?= $(HOME)/.isabelle/Isabelle2025/jedit/jars
 
 # Source files
 SCALA_SOURCES := $(wildcard src/*.scala)
+TEST_SOURCES := $(wildcard test/*.scala)
 RESOURCE_FILES := $(wildcard resources/*)
 
 # Default target
@@ -41,10 +44,19 @@ build: $(JAR_FILE)
 	echo "Plugin built successfully!"
 	echo "JAR file: $(JAR_FILE)"
 
+# Test target
+.PHONY: test
+test: build $(TEST_CLASSES_DIR)/.compiled
+	echo "Running I/Q line/offset tests..."
+	JAVA_HOME="$(JAVA_HOME)" PATH="$(JAVA_HOME)/bin:$$PATH" $(SCALA) \
+		-classpath "$(CLASSES_DIR):$(TEST_CLASSES_DIR):$(JEDIT_JAR):$(ISABELLE_JAR)" \
+		IQLineOffsetUtilsTest
+	echo "I/Q tests passed."
+
 # Create JAR file
 $(JAR_FILE): $(CLASSES_DIR)/.compiled $(CLASSES_DIR)/.resources
 	echo "Creating JAR file..."
-	cd $(CLASSES_DIR) && $(JAR) cf $(JAR_FILE) .
+	JAVA_HOME="$(JAVA_HOME)" PATH="$(JAVA_HOME)/bin:$$PATH" cd $(CLASSES_DIR) && $(JAR) cf $(JAR_FILE) .
 
 # Compile Scala sources
 $(CLASSES_DIR)/.compiled: $(SCALA_SOURCES) | $(CLASSES_DIR)
@@ -64,6 +76,17 @@ $(CLASSES_DIR)/.resources: $(RESOURCE_FILES) | $(CLASSES_DIR)
 # Create build directories
 $(CLASSES_DIR):
 	mkdir -p $(CLASSES_DIR)
+
+$(TEST_CLASSES_DIR):
+	mkdir -p $(TEST_CLASSES_DIR)
+
+$(TEST_CLASSES_DIR)/.compiled: $(TEST_SOURCES) $(CLASSES_DIR)/.compiled | $(TEST_CLASSES_DIR)
+	echo "Compiling I/Q tests..."
+	JAVA_HOME="$(JAVA_HOME)" PATH="$(JAVA_HOME)/bin:$$PATH" $(SCALAC) \
+		-classpath "$(CLASSES_DIR):$(JEDIT_JAR):$(ISABELLE_JAR)" \
+		-d $(TEST_CLASSES_DIR) \
+		$(TEST_SOURCES)
+	touch $@
 
 # Install target
 .PHONY: install
@@ -102,6 +125,7 @@ help:
 	echo "Available targets:"
 	echo "  all       - Build the plugin (default)"
 	echo "  build     - Build the plugin JAR file"
+	echo "  test      - Build and run line/offset regression tests"
 	echo "  install   - Build and install the plugin"
 	echo "  clean     - Remove build directory"
 	echo "  uninstall - Remove installed plugin"

--- a/iq/test/IQLineOffsetUtilsTest.scala
+++ b/iq/test/IQLineOffsetUtilsTest.scala
@@ -1,0 +1,101 @@
+/* Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+   SPDX-License-Identifier: MIT */
+
+object IQLineOffsetUtilsTest {
+  private def requireThat(condition: Boolean, message: String): Unit = {
+    if (!condition) throw new RuntimeException(message)
+  }
+
+  private def verifyBounds(text: String): Unit = {
+    val totalLines = IQLineOffsetUtils.splitLines(text).length
+    for (line <- -(totalLines + 5) to (totalLines + 5)) {
+      val offsets = List(
+        IQLineOffsetUtils.lineNumberToOffset(text, line),
+        IQLineOffsetUtils.lineNumberToOffset(text, line, increment = true),
+        IQLineOffsetUtils.lineNumberToOffset(text, line, increment = true, withLastNewLine = false)
+      )
+      offsets.foreach { offset =>
+        requireThat(offset >= 0, s"offset must be non-negative (text='$text', line=$line, offset=$offset)")
+        requireThat(offset <= text.length, s"offset must be <= text length (text='$text', line=$line, offset=$offset)")
+      }
+    }
+  }
+
+  private def verifyMonotonicity(text: String): Unit = {
+    val totalLines = IQLineOffsetUtils.splitLines(text).length
+    val positiveLines = (1 to (totalLines + 5)).toList
+    val negativeLines = (-(totalLines + 5) to -1).toList
+
+    val positiveOffsets = positiveLines.map(line => IQLineOffsetUtils.lineNumberToOffset(text, line))
+    val positiveOffsetsInc = positiveLines.map(line => IQLineOffsetUtils.lineNumberToOffset(text, line, increment = true))
+    val positiveOffsetsTrimmed = positiveLines.map(line =>
+      IQLineOffsetUtils.lineNumberToOffset(text, line, increment = true, withLastNewLine = false))
+
+    val negativeOffsets = negativeLines.map(line => IQLineOffsetUtils.lineNumberToOffset(text, line))
+    val negativeOffsetsInc = negativeLines.map(line => IQLineOffsetUtils.lineNumberToOffset(text, line, increment = true))
+    val negativeOffsetsTrimmed = negativeLines.map(line =>
+      IQLineOffsetUtils.lineNumberToOffset(text, line, increment = true, withLastNewLine = false))
+
+    requireThat(positiveOffsets == positiveOffsets.sorted, s"positive offsets must be monotonic for text='$text'")
+    requireThat(positiveOffsetsInc == positiveOffsetsInc.sorted, s"positive increment offsets must be monotonic for text='$text'")
+    requireThat(positiveOffsetsTrimmed == positiveOffsetsTrimmed.sorted, s"positive trimmed offsets must be monotonic for text='$text'")
+    requireThat(negativeOffsets == negativeOffsets.sorted, s"negative offsets must be monotonic for text='$text'")
+    requireThat(negativeOffsetsInc == negativeOffsetsInc.sorted, s"negative increment offsets must be monotonic for text='$text'")
+    requireThat(negativeOffsetsTrimmed == negativeOffsetsTrimmed.sorted, s"negative trimmed offsets must be monotonic for text='$text'")
+  }
+
+  private def verifyFormattingSafety(): Unit = {
+    val empty = IQLineOffsetUtils.formatLinesWithNumbers(Array.empty[String], 0, 0, None)
+    requireThat(empty.isEmpty, "formatting empty lines must return empty string")
+
+    val lines = Array("alpha", "beta", "gamma")
+    val inverted = IQLineOffsetUtils.formatLinesWithNumbers(lines, 2, 0, None)
+    requireThat(inverted.isEmpty, "inverted range must not throw and should return empty string")
+
+    val clamped = IQLineOffsetUtils.formatLinesWithNumbers(lines, -10, 100, Some(1))
+    requireThat(clamped.contains("1:alpha"), "clamped output should include first line")
+    requireThat(clamped.contains("2:beta"), "clamped output should include middle line")
+    requireThat(clamped.contains("3:gamma"), "clamped output should include last line")
+  }
+
+  private def randomText(random: scala.util.Random): String = {
+    val length = random.nextInt(120)
+    val builder = new StringBuilder()
+    for (_ <- 0 until length) {
+      val ch =
+        if (random.nextInt(6) == 0) '\n'
+        else ('a' + random.nextInt(26)).toChar
+      builder.append(ch)
+    }
+    builder.toString()
+  }
+
+  def main(args: Array[String]): Unit = {
+    val fixedCases = List(
+      "",
+      "a",
+      "\n",
+      "a\n",
+      "a\nb",
+      "a\nb\n",
+      "\n\n",
+      "alpha\nbeta\ngamma",
+      "alpha\nbeta\ngamma\n"
+    )
+
+    fixedCases.foreach { text =>
+      verifyBounds(text)
+      verifyMonotonicity(text)
+    }
+
+    val random = new scala.util.Random(0L)
+    for (_ <- 1 to 300) {
+      val text = randomText(random)
+      verifyBounds(text)
+      verifyMonotonicity(text)
+    }
+
+    verifyFormattingSafety()
+    println("IQLineOffsetUtilsTest passed")
+  }
+}


### PR DESCRIPTION
Fix issue #91 by making line/offset conversion and line-range formatting defensive against invalid inputs and boundary conditions.

- add IQLineOffsetUtils for centralized normalization/clamping:
  - normalize line indices/ranges to valid bounds
  - clamp/sort offset ranges to [0, text.length]
  - prevent negative offsets in lineNumberToOffset
  - handle newline-trim behavior safely at boundaries
  - make line formatting bounds-safe for empty/inverted ranges
- update IQServer call sites to use normalized ranges:
  - get_command mode=line
  - write_file command=line/insert
  - read_file mode=Line
  - search context range handling (clamp negative context_lines)
- add property-style regression test:
  - iq/test/IQLineOffsetUtilsTest.scala
  - verifies bounds and monotonicity across fixed + randomized inputs
  - covers empty files, trailing-newline files, and negative line requests
- enhance iq Makefile test target to compile and run the new test suite

Closes #91.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
