### PR TITLE
Preserve JSON numeric values and enforce typed param validation in I/Q

### DIFF
--- a/iq/Makefile
+++ b/iq/Makefile
@@ -51,6 +51,10 @@ test: build $(TEST_CLASSES_DIR)/.compiled
 	JAVA_HOME="$(JAVA_HOME)" PATH="$(JAVA_HOME)/bin:$$PATH" $(SCALA) \
 		-classpath "$(CLASSES_DIR):$(TEST_CLASSES_DIR):$(JEDIT_JAR):$(ISABELLE_JAR)" \
 		IQLineOffsetUtilsTest
+	echo "Running I/Q argument tests..."
+	JAVA_HOME="$(JAVA_HOME)" PATH="$(JAVA_HOME)/bin:$$PATH" $(SCALA) \
+		-classpath "$(CLASSES_DIR):$(TEST_CLASSES_DIR):$(JEDIT_JAR):$(ISABELLE_JAR)" \
+		IQArgumentUtilsTest
 	echo "I/Q tests passed."
 
 # Documentation checks
@@ -130,7 +134,7 @@ help:
 	echo "Available targets:"
 	echo "  all        - Build the plugin (default)"
 	echo "  build      - Build the plugin JAR file"
-	echo "  test       - Build and run line/offset regression tests"
+	echo "  test       - Build and run I/Q regression tests"
 	echo "  check-docs - Validate docs (tool list + internal links)"
 	echo "  install    - Build and install the plugin"
 	echo "  clean      - Remove build directory"

--- a/iq/test/IQArgumentUtilsTest.scala
+++ b/iq/test/IQArgumentUtilsTest.scala
@@ -1,0 +1,53 @@
+/* Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+   SPDX-License-Identifier: MIT */
+
+import isabelle._
+
+object IQArgumentUtilsTest {
+  private def requireThat(condition: Boolean, message: String): Unit = {
+    if (!condition) throw new RuntimeException(message)
+  }
+
+  def main(args: Array[String]): Unit = {
+    val input: Map[String, JSON.T] = Map(
+      "small_int" -> 42.0,
+      "large_int" -> 1234567890123.0,
+      "decimal" -> 12.75,
+      "flag" -> true,
+      "name" -> "alpha",
+      "nested" -> Map("x" -> 7.0, "y" -> "z"),
+      "list" -> List(1.0, 2.5, "v")
+    )
+
+    val argsMap = IQArgumentUtils.extractArguments(input)
+
+    requireThat(argsMap("small_int").isInstanceOf[Double], "small_int should remain numeric Double")
+    requireThat(argsMap("large_int").isInstanceOf[Double], "large_int should remain numeric Double")
+    requireThat(argsMap("decimal").isInstanceOf[Double], "decimal should remain numeric Double")
+    requireThat(argsMap("large_int").asInstanceOf[Double] == 1234567890123.0, "large_int value changed")
+    requireThat(argsMap("decimal").asInstanceOf[Double] == 12.75, "decimal value changed")
+
+    requireThat(argsMap("nested").isInstanceOf[Map[_, _]], "nested object should remain map")
+    requireThat(argsMap("list").isInstanceOf[List[_]], "list should remain list")
+
+    val intOk = IQArgumentUtils.optionalIntParam(argsMap, "small_int")
+    requireThat(intOk == Right(Some(42)), s"expected small_int parse success, got $intOk")
+
+    val longOk = IQArgumentUtils.optionalLongParam(argsMap, "large_int")
+    requireThat(longOk == Right(Some(1234567890123L)), s"expected large_int parse success, got $longOk")
+
+    val decimalErr = IQArgumentUtils.optionalIntParam(argsMap, "decimal")
+    requireThat(decimalErr.isLeft, s"decimal integer parse should fail, got $decimalErr")
+    requireThat(decimalErr.left.get.contains("decimal"), s"decimal error should reference parameter, got $decimalErr")
+
+    val outOfRangeInt = IQArgumentUtils.optionalIntParam(Map("x" -> 3000000000.0), "x")
+    requireThat(outOfRangeInt.isLeft, s"out-of-range int should fail, got $outOfRangeInt")
+    requireThat(outOfRangeInt.left.get.contains("Int range"), s"out-of-range error should mention Int range, got $outOfRangeInt")
+
+    val missingRequired = IQArgumentUtils.requiredIntParam(Map.empty, "start_line")
+    requireThat(missingRequired.isLeft, "missing required int should fail")
+    requireThat(missingRequired.left.get.contains("start_line"), "missing required message should reference parameter")
+
+    println("IQArgumentUtilsTest passed")
+  }
+}


### PR DESCRIPTION
Fix issue #92 by removing lossy Number->Int coercion at tools/call argument extraction and adding explicit numeric type/range validation at tool boundaries.

- add IQArgumentUtils in IQServer.scala:
  - preserve JSON value kinds recursively (object/list/number/string/bool/null)
  - parse/validate Int and Long parameters with clear errors
  - reject decimal values for integer-only params
  - reject out-of-range integer values with explicit range messages
- update extractArguments to delegate to IQArgumentUtils (no silent truncation)
- switch tools/call dispatch to typed error codes:
  - INVALID_PARAMS for argument/type errors
  - METHOD_NOT_FOUND for unknown tools
  - INTERNAL_ERROR for execution failures
- replace ad-hoc numeric parsing in handlers (get_command_info, get_document_info, read_file, write_file, explore) with typed parsers
- add regression tests:
  - iq/test/IQArgumentUtilsTest.scala for numeric preservation and validation
- update iq/Makefile:
  - add runnable test target that compiles/runs IQArgumentUtilsTest
  - use Isabelle-derived JAVA_HOME for stable scalac/jar execution

Closes #92.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
