### PR TITLE
Align version/path docs and add doc consistency checks across I/Q and Isabelle Assistant

### DIFF
--- a/iq/Makefile
+++ b/iq/Makefile
@@ -25,7 +25,7 @@ BUILD_DIR ?= $(PLUGIN_DIR)/build
 CLASSES_DIR ?= $(BUILD_DIR)/classes
 TEST_CLASSES_DIR ?= $(BUILD_DIR)/test-classes
 JAR_FILE ?= $(BUILD_DIR)/iq_plugin.jar
-INSTALL_DIR ?= $(HOME)/.isabelle/Isabelle2025/jedit/jars
+INSTALL_DIR ?= $(HOME)/.isabelle/Isabelle2025-2/jedit/jars
 
 # Source files
 SCALA_SOURCES := $(wildcard src/*.scala)
@@ -52,6 +52,11 @@ test: build $(TEST_CLASSES_DIR)/.compiled
 		-classpath "$(CLASSES_DIR):$(TEST_CLASSES_DIR):$(JEDIT_JAR):$(ISABELLE_JAR)" \
 		IQLineOffsetUtilsTest
 	echo "I/Q tests passed."
+
+# Documentation checks
+.PHONY: check-docs
+check-docs:
+	./scripts/check_docs.sh
 
 # Create JAR file
 $(JAR_FILE): $(CLASSES_DIR)/.compiled $(CLASSES_DIR)/.resources
@@ -123,14 +128,15 @@ help:
 	echo "I/Q Plugin Makefile"
 	echo ""
 	echo "Available targets:"
-	echo "  all       - Build the plugin (default)"
-	echo "  build     - Build the plugin JAR file"
-	echo "  test      - Build and run line/offset regression tests"
-	echo "  install   - Build and install the plugin"
-	echo "  clean     - Remove build directory"
-	echo "  uninstall - Remove installed plugin"
-	echo "  help      - Show this help message"
-	echo "  debug     - Show build configuration variables"
+	echo "  all        - Build the plugin (default)"
+	echo "  build      - Build the plugin JAR file"
+	echo "  test       - Build and run line/offset regression tests"
+	echo "  check-docs - Validate docs (tool list + internal links)"
+	echo "  install    - Build and install the plugin"
+	echo "  clean      - Remove build directory"
+	echo "  uninstall  - Remove installed plugin"
+	echo "  help       - Show this help message"
+	echo "  debug      - Show build configuration variables"
 	echo ""
 	echo "Configurable environment variables:"
 	echo "  V             - Show individual commands (default: off)"

--- a/iq/README.md
+++ b/iq/README.md
@@ -14,11 +14,12 @@ The purpose of I/Q is to enable MCP-capable AI agents such as [Amazon Q](https:/
 
 ### Prerequisites
 
-We recommend that you use Isabelle2025. We have not tested I/Q with another version of Isabelle. The build instructions below assume a Unix-like environment (e.g. Linux, MacOS).
+We recommend Isabelle2025-2. We have not tested I/Q with another version of Isabelle.
+The build instructions below assume a Unix-like environment (e.g. Linux, macOS).
 
 ### Building the plugin
 
-You can build the plugin via `make` and `make install`. This compiles the Scala sources and installs the plugin JAR. By default, the JAR is copied to `~/.isabelle/Isabelle2025/jedit/jars/`, but you can inspect and configure various environment variables; see `make help`.
+You can build the plugin via `make` and `make install`. This compiles the Scala sources and installs the plugin JAR. By default, the JAR is copied to `~/.isabelle/Isabelle2025-2/jedit/jars/`, but you can inspect and configure various environment variables; see `make help`.
 
 ### Registering the plugin
 
@@ -102,9 +103,11 @@ You have XXX theory files open in total, ...
 2. **get_command_info**: Get detailed command information including status, errors, and proof states
 3. **get_document_info**: Comprehensive theory file status with error/warning details
 4. **open_file**: Open or create files in Isabelle/jEdit with optional content initialization
-5. **read_file**: Read file content with line range and pattern search support
-6. **explore**: Non-invasive proof exploration (sledgehammer, find_theorems, proof attempts)
+5. **create_file**: Create a new file with content and optionally open it in a view
+6. **read_file**: Read file content with line range and pattern search support
 7. **write_file**: Write or modify content in theory files with multiple edit modes (str_replace, insert, line replacement)
+8. **explore**: Non-invasive proof exploration (sledgehammer, find_theorems, proof attempts)
+9. **save_file**: Save one file or all modified open files
 
 ## Behavioral Guidance
 

--- a/iq/scripts/check_docs.sh
+++ b/iq/scripts/check_docs.sh
@@ -1,0 +1,120 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+
+SERVER_FILE="$REPO_ROOT/iq/src/IQServer.scala"
+IQ_README="$REPO_ROOT/iq/README.md"
+
+tmp_server_tools="$(mktemp)"
+tmp_readme_tools="$(mktemp)"
+cleanup() {
+  rm -f "$tmp_server_tools" "$tmp_readme_tools"
+}
+trap cleanup EXIT
+
+awk '
+  /val tools = List\(/ { in_tools = 1 }
+  in_tools { print }
+  /val result = Map\("tools" -> tools\)/ { in_tools = 0 }
+' "$SERVER_FILE" \
+  | sed -nE 's/.*"name"[[:space:]]*->[[:space:]]*"([^"]+)".*/\1/p' \
+  | sort -u > "$tmp_server_tools"
+
+awk '
+  /^## MCP Tools$/ { in_tools = 1; next }
+  /^## / && in_tools { in_tools = 0 }
+  in_tools { print }
+' "$IQ_README" \
+  | sed -nE 's/^[[:space:]]*[0-9]+\.[[:space:]]+\*\*([^*]+)\*\*:.*/\1/p' \
+  | sort -u > "$tmp_readme_tools"
+
+if ! diff -u "$tmp_server_tools" "$tmp_readme_tools" >/dev/null; then
+  echo "ERROR: iq/README.md MCP tool list does not match iq/src/IQServer.scala registry."
+  echo "Server-only tools:"
+  comm -23 "$tmp_server_tools" "$tmp_readme_tools" | sed 's/^/  - /'
+  echo "README-only tools:"
+  comm -13 "$tmp_server_tools" "$tmp_readme_tools" | sed 's/^/  - /'
+  exit 1
+fi
+
+normalize_anchor() {
+  printf "%s" "$1" \
+    | tr '[:upper:]' '[:lower:]' \
+    | sed -E 's/`//g; s/[^a-z0-9 _-]//g; s/[[:space:]_]+/-/g; s/-+/-/g; s/^-|-$//g'
+}
+
+has_anchor() {
+  local file="$1"
+  local anchor="$2"
+  local heading
+  while IFS= read -r heading; do
+    if [[ "$(normalize_anchor "$heading")" == "$anchor" ]]; then
+      return 0
+    fi
+  done < <(grep -E '^#{1,6}[[:space:]]+' "$file" | sed -E 's/^#{1,6}[[:space:]]+//')
+  return 1
+}
+
+check_links_in_file() {
+  local file="$1"
+  local failed=0
+  local match target link_path link_anchor resolved target_anchor
+
+  while IFS= read -r match; do
+    target="${match#*](}"
+    target="${target%)}"
+    target="${target%% \"*}"
+    target="${target#<}"
+    target="${target%>}"
+
+    [[ -z "$target" ]] && continue
+    [[ "$target" == http://* ]] && continue
+    [[ "$target" == https://* ]] && continue
+    [[ "$target" == mailto:* ]] && continue
+
+    link_path="$target"
+    link_anchor=""
+    if [[ "$target" == *"#"* ]]; then
+      link_path="${target%%#*}"
+      link_anchor="${target#*#}"
+    fi
+
+    if [[ -z "$link_path" ]]; then
+      resolved="$file"
+    elif [[ "$link_path" == /* ]]; then
+      resolved="$link_path"
+    else
+      resolved="$(cd "$(dirname "$file")" && pwd)/$link_path"
+    fi
+
+    if [[ ! -e "$resolved" ]]; then
+      echo "ERROR: Broken link in $file -> $target (missing file: $resolved)"
+      failed=1
+      continue
+    fi
+
+    if [[ -n "$link_anchor" && "$resolved" == *.md ]]; then
+      target_anchor="$(normalize_anchor "$link_anchor")"
+      if ! has_anchor "$resolved" "$target_anchor"; then
+        echo "ERROR: Broken anchor in $file -> $target (missing anchor: #$link_anchor)"
+        failed=1
+      fi
+    fi
+  done < <(grep -oE '\[[^][]+\]\([^)]*\)' "$file")
+
+  return "$failed"
+}
+
+DOC_FILES=(
+  "$REPO_ROOT/iq/README.md"
+  "$REPO_ROOT/isabelle-assistant/README.md"
+  "$REPO_ROOT/isabelle-assistant/CONTRIBUTING.md"
+)
+
+for doc in "${DOC_FILES[@]}"; do
+  check_links_in_file "$doc"
+done
+
+echo "Documentation checks passed."

--- a/isabelle-assistant/README.md
+++ b/isabelle-assistant/README.md
@@ -4,6 +4,17 @@ LLM-powered proof assistant for [Isabelle/jEdit](https://isabelle.in.tum.de/), b
 
 Isabelle Assistant is part of the [AutoCorrode](https://github.com/awslabs/AutoCorrode) project.
 
+## Architecture
+
+Isabelle Assistant combines four main layers:
+
+1. jEdit UI integration (`AssistantPlugin`, `AssistantDockable`, context menus, chat actions)
+2. LLM orchestration (`BedrockClient`, prompts, tool-use loop, retry/caching)
+3. Isabelle context/proof pipelines (`ContextFetcher`, `GoalExtractor`, `SuggestAction`, `ProofLoop`)
+4. Optional I/Q integration for proof-state operations and verification (`IQIntegration`)
+
+For contributor-level component and threading details, see [CONTRIBUTING.md](CONTRIBUTING.md).
+
 ## Highlights
 
 ### Freeform Chat


### PR DESCRIPTION
Fix issue #87 by reconciling documentation with current implementation and adding automated validation to prevent future drift.

- iq/README.md
  - normalize recommended Isabelle version to Isabelle2025-2
  - update default install path to ~/.isabelle/Isabelle2025-2/jedit/jars/
  - sync MCP tool list with IQServer tool registry (add create_file, save_file)
- iq/Makefile
  - align INSTALL_DIR default to Isabelle2025-2
  - add check-docs target
  - use Isabelle-derived JAVA_HOME/JAR toolchain for reliable build/install
- iq/scripts/check_docs.sh
  - validate README MCP tool names against IQServer createToolsListResult registry
  - validate internal markdown links/anchors across iq and assistant docs
- isabelle-assistant/README.md
  - add Architecture section so CONTRIBUTING link target exists

Closes #87.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
