### PR TITLE
Harden I/Q MCP server defaults and enforce mutation security

### DIFF
--- a/iq/Makefile
+++ b/iq/Makefile
@@ -29,8 +29,8 @@ INSTALL_DIR ?= $(HOME)/.isabelle/Isabelle2025-2/jedit/jars
 
 # Source files
 SCALA_SOURCES := $(wildcard src/*.scala)
-TEST_SOURCES := $(wildcard test/*.scala)
 RESOURCE_FILES := $(wildcard resources/*)
+TEST_SOURCES := $(wildcard test/*.scala) $(wildcard src/test/scala/*.scala)
 
 # Default target
 .PHONY: all
@@ -55,6 +55,10 @@ test: build $(TEST_CLASSES_DIR)/.compiled
 	JAVA_HOME="$(JAVA_HOME)" PATH="$(JAVA_HOME)/bin:$$PATH" $(SCALA) \
 		-classpath "$(CLASSES_DIR):$(TEST_CLASSES_DIR):$(JEDIT_JAR):$(ISABELLE_JAR)" \
 		IQArgumentUtilsTest
+	echo "Running I/Q security tests..."
+	JAVA_HOME="$(JAVA_HOME)" PATH="$(JAVA_HOME)/bin:$$PATH" $(SCALA) \
+		-classpath "$(CLASSES_DIR):$(TEST_CLASSES_DIR):$(JEDIT_JAR):$(ISABELLE_JAR)" \
+		IQSecurityTest
 	echo "I/Q tests passed."
 
 # Documentation checks
@@ -148,6 +152,7 @@ help:
 	echo "  ISABELLE_HOME - Isabelle installation path (default: $(ISABELLE_HOME))"
 	echo "  SCALA_HOME    - Scala installation path (default: $(SCALA_HOME))"
 	echo "  SCALAC        - Scala compiler path (default: $(SCALAC))"
+	echo "  SCALA         - Scala runner path (default: $(SCALA))"
 	echo "  BUILD_DIR     - Build output directory (default: $(BUILD_DIR))"
 	echo ""
 	echo "Examples:"
@@ -163,10 +168,11 @@ debug:
 	echo "  PLUGIN_DIR    = $(PLUGIN_DIR)"
 	echo "  ISABELLE_HOME = $(ISABELLE_HOME)"
 	echo "  JEDIT_JAR     = $(JEDIT_JAR)"
+	echo "  JAVA_HOME     = $(JAVA_HOME)"
 	echo "  SCALA_HOME    = $(SCALA_HOME)"
 	echo "  SCALAC        = $(SCALAC)"
+	echo "  SCALA         = $(SCALA)"
 	echo "  ISABELLE_JAR  = $(ISABELLE_JAR)"
-	echo "  JAVA_HOME     = $(JAVA_HOME)"
 	echo "  JAVA          = $(JAVA)"
 	echo "  JAR           = $(JAR)"
 	echo "  BUILD_DIR     = $(BUILD_DIR)"
@@ -175,3 +181,4 @@ debug:
 	echo "  INSTALL_DIR   = $(INSTALL_DIR)"
 	echo "  SCALA_SOURCES = $(SCALA_SOURCES)"
 	echo "  RESOURCE_FILES = $(RESOURCE_FILES)"
+	echo "  TEST_SOURCES  = $(TEST_SOURCES)"

--- a/iq/README.md
+++ b/iq/README.md
@@ -57,6 +57,24 @@ echo '{"jsonrpc": "2.0", "method": "tools/call", "id": "test", "params": {"name"
 
 should give you a JSON reply with all tracked. theory files.
 
+## Security configuration
+
+I/Q now defaults to a hardened local-only posture:
+
+- Loopback bind by default (`IQ_MCP_BIND_HOST=127.0.0.1`).
+- Remote bind is blocked unless explicitly enabled (`IQ_MCP_ALLOW_REMOTE_BIND=true`).
+- Optional request authentication token (`IQ_MCP_AUTH_TOKEN`).
+- Mutating tools (`open_file` with `create_if_missing=true`, `create_file`, `write_file`, `save_file`) are restricted to allowed mutation roots.
+
+Use these environment variables to configure behavior:
+
+- `IQ_MCP_BIND_HOST`: Host/IP to bind to (default: `127.0.0.1`).
+- `IQ_MCP_ALLOW_REMOTE_BIND`: Set to `true` to allow non-loopback bind hosts (default: `false`).
+- `IQ_MCP_AUTH_TOKEN`: If set, every JSON-RPC request must include top-level `auth_token` matching this value.
+- `IQ_MCP_ALLOWED_ROOTS`: Path-list of allowed mutation roots (separator: `:` on Unix). If unset, defaults to the current working directory.
+
+The bundled `iq_bridge.py` automatically forwards `IQ_MCP_AUTH_TOKEN` as `auth_token` on outgoing requests.
+
 ### Connecting to I/Q via an MCP client
 
 If you connect to I/Q via an MCP-capable AI agent, you should see it learn and use the MCP interface automatically. For example, if you have [Amazon Q](https://aws.amazon.com/q/) installed and the I/Q MCP server registered as above, you should see the following:

--- a/iq/iq_bridge.py
+++ b/iq/iq_bridge.py
@@ -10,12 +10,15 @@ import sys
 import json
 import socket
 import time
+import os
 from typing import Dict, Any, Optional
 
 class MCPBridgeWithReconnect:
     def __init__(self):
         self.isabelle_socket = None
         self.connected = False
+        token = os.environ.get("IQ_MCP_AUTH_TOKEN", "").strip()
+        self.auth_token = token if token else None
 
     def log(self, message: str):
         """Log messages to stderr and file with timestamp."""
@@ -72,6 +75,9 @@ class MCPBridgeWithReconnect:
 
     def forward_to_isabelle(self, request: Dict[str, Any]) -> Optional[Dict[str, Any]]:
         """Forward request to Isabelle server with automatic reconnection."""
+        if self.auth_token and "auth_token" not in request:
+            request["auth_token"] = self.auth_token
+
         method = request.get('method', 'unknown')
 
         # Check if this is a notification (no 'id' field)

--- a/iq/src/IQPlugin.scala
+++ b/iq/src/IQPlugin.scala
@@ -14,7 +14,8 @@ class IQPlugin extends EBPlugin {
 
     // Start MCP server
     try {
-      iqServer = Some(new IQServer(port = 8765))
+      val securityConfig = IQSecurity.fromEnvironment(readEnv = key => Option(Isabelle_System.getenv(key)))
+      iqServer = Some(new IQServer(port = 8765, securityConfig = securityConfig))
       iqServer.foreach(_.start())
       Output.writeln("Isabelle/Q Server started successfully on port 8765")
     } catch {

--- a/iq/src/IQSecurity.scala
+++ b/iq/src/IQSecurity.scala
@@ -1,0 +1,116 @@
+/* Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+   SPDX-License-Identifier: MIT */
+
+import java.io.File
+import java.net.InetAddress
+import java.nio.file.{Files, Path, Paths}
+
+import scala.util.Try
+
+/**
+ * Security configuration and helper utilities for the I/Q MCP server.
+ */
+case class IQServerSecurityConfig(
+  bindHost: String,
+  allowRemoteBind: Boolean,
+  authToken: Option[String],
+  allowedMutationRoots: List[Path]
+)
+
+object IQSecurity {
+  private val BindHostEnv = "IQ_MCP_BIND_HOST"
+  private val AllowRemoteBindEnv = "IQ_MCP_ALLOW_REMOTE_BIND"
+  private val AuthTokenEnv = "IQ_MCP_AUTH_TOKEN"
+  private val AllowedRootsEnv = "IQ_MCP_ALLOWED_ROOTS"
+
+  private val TrueValues = Set("1", "true", "yes", "on")
+  private val DefaultBindHost = "127.0.0.1"
+
+  private def parseBoolean(value: String, defaultValue: Boolean): Boolean = {
+    val normalized = value.trim.toLowerCase
+    if (normalized.isEmpty) defaultValue else TrueValues.contains(normalized)
+  }
+
+  private def canonicalizePath(path: Path): Path = {
+    val absolute = if (path.isAbsolute) path else path.toAbsolutePath
+    val normalized = absolute.normalize()
+
+    if (Files.exists(normalized)) {
+      normalized.toRealPath()
+    } else {
+      var ancestor: Path = normalized
+      while (ancestor != null && !Files.exists(ancestor)) {
+        ancestor = ancestor.getParent
+      }
+
+      if (ancestor == null) normalized
+      else {
+        val canonicalAncestor = ancestor.toRealPath()
+        canonicalAncestor.resolve(ancestor.relativize(normalized)).normalize()
+      }
+    }
+  }
+
+  def fromEnvironment(
+    readEnv: String => Option[String] = key => Option(System.getenv(key)),
+    cwdProvider: () => String = () => new File(".").getAbsolutePath
+  ): IQServerSecurityConfig = {
+    val bindHost = readEnv(BindHostEnv).map(_.trim).filter(_.nonEmpty).getOrElse(DefaultBindHost)
+    val allowRemoteBind = readEnv(AllowRemoteBindEnv).exists(v => parseBoolean(v, defaultValue = false))
+    val authToken = readEnv(AuthTokenEnv).map(_.trim).filter(_.nonEmpty)
+
+    val configuredRoots = readEnv(AllowedRootsEnv)
+      .toList
+      .flatMap(_.split(java.io.File.pathSeparator).toList)
+      .map(_.trim)
+      .filter(_.nonEmpty)
+      .map(path => canonicalizePath(Paths.get(path)))
+
+    val defaultRoot = canonicalizePath(Paths.get(cwdProvider()))
+    val allowedRoots = if (configuredRoots.nonEmpty) configuredRoots.distinct else List(defaultRoot)
+
+    IQServerSecurityConfig(
+      bindHost = bindHost,
+      allowRemoteBind = allowRemoteBind,
+      authToken = authToken,
+      allowedMutationRoots = allowedRoots
+    )
+  }
+
+  def resolveMutationPath(rawPath: String, allowedRoots: List[Path]): Either[String, Path] = {
+    val requested = rawPath.trim
+    if (requested.isEmpty) return Left("path parameter is required")
+
+    val canonicalPathTry = Try {
+      canonicalizePath(Paths.get(requested))
+    }
+
+    canonicalPathTry.toEither.left.map(ex => s"Failed to resolve path '$requested': ${ex.getMessage}").flatMap { canonicalPath =>
+      val isAllowed = allowedRoots.exists(root => canonicalPath.startsWith(root))
+      if (isAllowed) Right(canonicalPath)
+      else {
+        val roots = allowedRoots.map(_.toString).mkString(", ")
+        Left(s"Path '$canonicalPath' is outside allowed mutation roots: $roots")
+      }
+    }
+  }
+
+  def resolveBindAddress(bindHost: String): Either[String, InetAddress] = {
+    Try(InetAddress.getByName(bindHost.trim))
+      .toEither
+      .left
+      .map(ex => s"Failed to resolve bind host '$bindHost': ${ex.getMessage}")
+  }
+
+  def isTokenAuthorized(expectedToken: Option[String], providedToken: Option[String]): Boolean = {
+    expectedToken match {
+      case None => true
+      case Some(expected) => providedToken.exists(_.trim == expected)
+    }
+  }
+
+  def redactAuthToken(jsonLine: String): String = {
+    jsonLine
+      .replaceAll("\"auth_token\"\\s*:\\s*\"[^\"]*\"", "\"auth_token\":\"***\"")
+  }
+}

--- a/iq/src/test/scala/IQSecurityTest.scala
+++ b/iq/src/test/scala/IQSecurityTest.scala
@@ -1,0 +1,58 @@
+/* Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+   SPDX-License-Identifier: MIT */
+
+import java.nio.file.Files
+
+object IQSecurityTest {
+  private def assertThat(condition: Boolean, message: String): Unit = {
+    if (!condition) {
+      throw new RuntimeException(message)
+    }
+  }
+
+  private def testDefaultConfig(): Unit = {
+    val config = IQSecurity.fromEnvironment(
+      readEnv = _ => None,
+      cwdProvider = () => "/tmp/iq-default-root"
+    )
+
+    assertThat(config.bindHost == "127.0.0.1", "default bind host should be loopback")
+    assertThat(!config.allowRemoteBind, "remote bind should be disabled by default")
+    assertThat(config.authToken.isEmpty, "auth token should be disabled by default")
+    assertThat(config.allowedMutationRoots.nonEmpty, "default mutation root should be set")
+  }
+
+  private def testPathAllowlist(): Unit = {
+    val root = Files.createTempDirectory("iq-security-root").toRealPath()
+
+    val insidePath = root.resolve("theories").resolve("Demo.thy").toString
+    val insideResult = IQSecurity.resolveMutationPath(insidePath, List(root))
+    assertThat(insideResult.isRight, s"expected in-root path to be allowed: $insideResult")
+
+    val outsidePath = root.resolve("..").resolve("escape.thy").normalize().toString
+    val outsideResult = IQSecurity.resolveMutationPath(outsidePath, List(root))
+    assertThat(outsideResult.isLeft, s"expected out-of-root path to be rejected: $outsideResult")
+  }
+
+  private def testTokenAuthorization(): Unit = {
+    assertThat(IQSecurity.isTokenAuthorized(None, None), "requests should pass when auth is disabled")
+    assertThat(!IQSecurity.isTokenAuthorized(Some("secret"), None), "missing token should be rejected")
+    assertThat(!IQSecurity.isTokenAuthorized(Some("secret"), Some("wrong")), "wrong token should be rejected")
+    assertThat(IQSecurity.isTokenAuthorized(Some("secret"), Some("secret")), "matching token should pass")
+  }
+
+  private def testTokenRedaction(): Unit = {
+    val input = """{"jsonrpc":"2.0","auth_token":"super-secret","method":"initialize"}"""
+    val redacted = IQSecurity.redactAuthToken(input)
+    assertThat(!redacted.contains("super-secret"), "logs should not contain auth token")
+    assertThat(redacted.contains("\"auth_token\":\"***\""), "auth token should be masked in logs")
+  }
+
+  def main(args: Array[String]): Unit = {
+    testDefaultConfig()
+    testPathAllowlist()
+    testTokenAuthorization()
+    testTokenRedaction()
+    println("IQSecurityTest: all tests passed")
+  }
+}


### PR DESCRIPTION
- bind the MCP server to loopback by default and require explicit opt-in for non-local binds
- add optional request authentication via IQ_MCP_AUTH_TOKEN
- enforce canonical allowlisted mutation roots for open/create/write/save paths
- add security audit logging for auth failures and mutation allow/deny decisions
- redact auth_token values from request/response logging
- update iq_bridge.py to automatically forward IQ_MCP_AUTH_TOKEN
- document the security model and new environment variables in iq/README.md
- add IQSecurity helpers and unit tests covering traversal rejection and unauthorized requests
- add an iq `make test` target and align Java toolchain discovery with isabelle-assistant so plain `make test` works without manual JAVA_HOME setup

Closes #97.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
