### PR TITLE
Remaining pattern language extensions (excluding `ref` binders) from issue 66

### DIFF
--- a/Crush/Examples.thy
+++ b/Crush/Examples.thy
@@ -823,7 +823,7 @@ ML\<open>local
   (* is_points_to should detect points_to predicates from all interpretations,
      and for the unnamed one, we should also be able to use the usual points_to syntax. *)
   val _ = assert     (is_points_to_raw @{term \<open>(r :: ('a2, 'b2) gref) \<mapsto>\<langle>sh\<rangle> g\<close>})
-  val _ = assert_not (is_points_to_raw @{term \<open>(r :: ('a2, 'b2, _) ref) \<mapsto>\<langle>sh\<rangle> g\<down>v\<close>})
+  val _ = assert_not (is_points_to_raw @{term \<open>(r :: ('a2, 'b2, _) Global_Store.ref) \<mapsto>\<langle>sh\<rangle> g\<down>v\<close>})
   val _ = assert     (is_points_to_raw @{term \<open>refA.points_to_raw r sh g\<close>})
   val _ = assert_not (is_points_to_raw @{term \<open>refA.points_to r sh g v\<close>})
   val _ = assert     (is_points_to_raw @{term \<open>refB.points_to_raw r sh g\<close>})
@@ -832,7 +832,7 @@ ML\<open>local
   val _ = assert_not (is_points_to_raw @{term \<open>points_to r sh g v\<close>})
 
   val _ = assert_not (is_points_to @{term \<open>(r :: ('a2, 'b2) gref) \<mapsto>\<langle>sh\<rangle> g\<close>})
-  val _ = assert     (is_points_to @{term \<open>(r :: ('a2, 'b2, _) ref) \<mapsto>\<langle>sh\<rangle> g\<down>v\<close>})
+  val _ = assert     (is_points_to @{term \<open>(r :: ('a2, 'b2, _) Global_Store.ref) \<mapsto>\<langle>sh\<rangle> g\<down>v\<close>})
   val _ = assert_not (is_points_to @{term \<open>refA.points_to_raw r sh g\<close>})
   val _ = assert     (is_points_to @{term \<open>refA.points_to r sh g v\<close>})
   val _ = assert_not (is_points_to @{term \<open>refB.points_to_raw r sh g\<close>})

--- a/Micro_Rust_Examples/Basic_Micro_Rust.thy
+++ b/Micro_Rust_Examples/Basic_Micro_Rust.thy
@@ -333,7 +333,7 @@ of \<^verbatim>\<open>Reference\<close>, we can indeed write functions operating
 context reference
 begin
 
-definition add_one_to_ref :: \<open>(_, _, 64 word) ref \<Rightarrow> ('s, unit, _, _, _) function_body\<close> where
+definition add_one_to_ref :: \<open>(_, _, 64 word) Global_Store.ref \<Rightarrow> ('s, unit, _, _, _) function_body\<close> where
   \<open>add_one_to_ref ptr \<equiv> FunctionBody \<lbrakk>
      let val = *ptr; \<comment>\<open>Reading requires explicit dereferencing\<close>
      let new_val = val + 1;

--- a/Micro_Rust_Examples/Crush_Examples.thy
+++ b/Micro_Rust_Examples/Crush_Examples.thy
@@ -897,7 +897,7 @@ begin
 adhoc_overloading store_update_const \<rightleftharpoons>
   update_fun
 
-definition swap_ref :: \<open>('a, 'b, 'v) ref \<Rightarrow> ('a, 'b, 'v) ref \<Rightarrow> ('s, unit, unit, 'abort, 'i prompt, 'o prompt_output) expression\<close> where
+definition swap_ref :: \<open>('a, 'b, 'v) Global_Store.ref \<Rightarrow> ('a, 'b, 'v) Global_Store.ref \<Rightarrow> ('s, unit, unit, 'abort, 'i prompt, 'o prompt_output) expression\<close> where
   \<open>swap_ref rA rB \<equiv> \<lbrakk>
      let oldA = *rA;
      let oldB = *rB;
@@ -911,7 +911,7 @@ lemma swap_ref_correct:
   fixes \<Gamma> :: \<open>('s, 'abort, 'i, 'o) striple_context\<close>
     and gA gB :: 'b
     and vA vB :: 'v
-    and rA rB :: \<open>('a, 'b, 'v) ref\<close>
+    and rA rB :: \<open>('a, 'b, 'v) Global_Store.ref\<close>
   shows \<open>\<Gamma> ;   \<comment>\<open>Initial reference contents\<close>
               rA \<mapsto> \<langle>\<top>\<rangle> gA\<down>vA \<star> rB \<mapsto>\<langle>\<top>\<rangle> gB\<down>vB
             \<turnstile> swap_ref rA rB
@@ -933,7 +933,7 @@ lemma
   fixes \<Gamma> :: \<open>('s, 'abort, 'i, 'o) striple_context\<close>
     and gA gB :: 'b
     and vA vB :: 'v
-    and rA rB :: \<open>('a, 'b, 'v) ref\<close>
+    and rA rB :: \<open>('a, 'b, 'v) Global_Store.ref\<close>
   shows \<open>\<Gamma> ;   \<comment>\<open>Initial reference contents\<close>
               rA \<mapsto> \<langle>\<top>\<rangle> gA\<down>vA \<star> rB \<mapsto>\<langle>\<top>\<rangle> gB\<down>vB
             \<turnstile> swap_ref rA rB
@@ -1032,7 +1032,7 @@ text\<open>Normally, we would not reason about individual \<mu>Rust expressions,
 specifications and contracts to do so. We illustrate this in the example of the above
 reference-swapping code wrapped into a function:\<close>
 
-definition swap_ref_fun :: \<open>('a, 'b, 'v) ref \<Rightarrow> ('a, 'b, 'v) ref \<Rightarrow> ('s, unit, 'abort, 'i prompt, 'o prompt_output) function_body\<close> where
+definition swap_ref_fun :: \<open>('a, 'b, 'v) Global_Store.ref \<Rightarrow> ('a, 'b, 'v) Global_Store.ref \<Rightarrow> ('s, unit, 'abort, 'i prompt, 'o prompt_output) function_body\<close> where
   \<open>swap_ref_fun rA rB \<equiv> FunctionBody \<lbrakk>
      let oldA = *rA;
      let oldB = *rB;
@@ -1044,7 +1044,7 @@ text\<open>The contract for a uRust function is usually captured in a separate d
 \<^verbatim>\<open>function_contract\<close>. In this case:\<close>
 
 definition swap_ref_fun_contract ::
-   \<open>('a, 'b, 'v) ref \<Rightarrow> ('a, 'b, 'v) ref \<Rightarrow> 'b \<Rightarrow> 'v \<Rightarrow> 'b \<Rightarrow> 'v \<Rightarrow> ('s, unit, 'abort) function_contract\<close>
+   \<open>('a, 'b, 'v) Global_Store.ref \<Rightarrow> ('a, 'b, 'v) Global_Store.ref \<Rightarrow> 'b \<Rightarrow> 'v \<Rightarrow> 'b \<Rightarrow> 'v \<Rightarrow> ('s, unit, 'abort) function_contract\<close>
   where \<open>swap_ref_fun_contract rA rB gA vA gB vB \<equiv>
      let pre = rA \<mapsto> \<langle>\<top>\<rangle> gA\<down>vA \<star> rB \<mapsto>\<langle>\<top>\<rangle> gB\<down>vB in
      let post = \<lambda>_. (\<Squnion>gA' gB'. rA \<mapsto> \<langle>\<top>\<rangle> gA'\<down>vB \<star> rB \<mapsto>\<langle>\<top>\<rangle> gB'\<down>vA) in
@@ -1071,7 +1071,7 @@ lemma swap_ref_fun_spec:
 
 text\<open>Next, imagine we write a higher-level function which relies on \<^verbatim>\<open>swap_ref_fun\<close>.\<close>
 
-definition rotate_ref3 :: \<open>('a, 'b, 'v) ref \<Rightarrow> ('a, 'b, 'v) ref \<Rightarrow> ('a, 'b, 'v) ref \<Rightarrow> ('s, unit, 'abort, 'i prompt, 'o prompt_output) function_body\<close> where
+definition rotate_ref3 :: \<open>('a, 'b, 'v) Global_Store.ref \<Rightarrow> ('a, 'b, 'v) Global_Store.ref \<Rightarrow> ('a, 'b, 'v) Global_Store.ref \<Rightarrow> ('s, unit, 'abort, 'i prompt, 'o prompt_output) function_body\<close> where
   \<open>rotate_ref3 rA rB rC \<equiv> FunctionBody \<lbrakk>
      swap_ref_fun (rA, rB);
      swap_ref_fun (rB, rC);
@@ -1080,7 +1080,7 @@ definition rotate_ref3 :: \<open>('a, 'b, 'v) ref \<Rightarrow> ('a, 'b, 'v) ref
 text\<open>Next, we write the contract for \<^verbatim>\<open>rotate_ref3\<close>:\<close>
 
 definition rotate_ref3_contract ::
-   \<open>('a, 'b, 'v) ref \<Rightarrow> ('a, 'b, 'v) ref \<Rightarrow> ('a, 'b, 'v) ref \<Rightarrow> 'b \<Rightarrow> 'v \<Rightarrow> 'b \<Rightarrow> 'v \<Rightarrow> 'b \<Rightarrow> 'v \<Rightarrow> ('s, unit, 'abort) function_contract\<close>
+   \<open>('a, 'b, 'v) Global_Store.ref \<Rightarrow> ('a, 'b, 'v) Global_Store.ref \<Rightarrow> ('a, 'b, 'v) Global_Store.ref \<Rightarrow> 'b \<Rightarrow> 'v \<Rightarrow> 'b \<Rightarrow> 'v \<Rightarrow> 'b \<Rightarrow> 'v \<Rightarrow> ('s, unit, 'abort) function_contract\<close>
   where \<open>rotate_ref3_contract rA rB rC gA vA gB vB gC vC \<equiv>
      let pre = rA \<mapsto> \<langle>\<top>\<rangle> gA\<down>vA \<star> rB \<mapsto>\<langle>\<top>\<rangle> gB\<down>vB \<star> rC \<mapsto>\<langle>\<top>\<rangle> gC\<down>vC in
      let post = \<lambda>_. (\<Squnion>gA' gB' gC'. rA \<mapsto> \<langle>\<top>\<rangle> gA'\<down>vB \<star> rB \<mapsto>\<langle>\<top>\<rangle> gB'\<down>vC \<star> rC \<mapsto>\<langle>\<top>\<rangle> gC'\<down>vA) in
@@ -1191,14 +1191,14 @@ adhoc_overloading store_update_const \<rightleftharpoons>
 
 text\<open>Overwrite one structure field, return the other:\<close>
 
-definition write_foo_read_bar :: \<open>('a, 'b, test_record) ref \<Rightarrow> ('s, int, 'abort, 'i prompt, 'o prompt_output) function_body\<close> where
+definition write_foo_read_bar :: \<open>('a, 'b, test_record) Global_Store.ref \<Rightarrow> ('s, int, 'abort, 'i prompt, 'o prompt_output) function_body\<close> where
   \<open>write_foo_read_bar ptr \<equiv> FunctionBody \<lbrakk>
      ptr.foo = 42;
      *(ptr.bar)
   \<rbrakk>\<close>
 
 definition write_foo_read_bar_contract ::
-   \<open>('a, 'b, test_record) ref \<Rightarrow> 'b \<Rightarrow> test_record \<Rightarrow> ('s, int, 'abort) function_contract\<close>
+   \<open>('a, 'b, test_record) Global_Store.ref \<Rightarrow> 'b \<Rightarrow> test_record \<Rightarrow> ('s, int, 'abort) function_contract\<close>
   where \<open>write_foo_read_bar_contract r g v \<equiv>
      let pre = r \<mapsto> \<langle>\<top>\<rangle> g\<down>v in
      let post = \<lambda>t. \<langle>t = test_record.bar v\<rangle> \<star> (\<Squnion>g'. r \<mapsto> \<langle>\<top>\<rangle> g'\<down>(test_record.update_foo (\<lambda>_. 42) v)) in
@@ -1270,7 +1270,7 @@ lemma write_foo_read_bar_spec':
 
 text\<open>Clear many structure fields, return another:\<close>
 
-definition test_record2_zeroize :: \<open>('a, 'b, test_record2) ref \<Rightarrow> ('s, int, 'abort, 'i prompt, 'o prompt_output) function_body\<close> where
+definition test_record2_zeroize :: \<open>('a, 'b, test_record2) Global_Store.ref \<Rightarrow> ('s, int, 'abort, 'i prompt, 'o prompt_output) function_body\<close> where
   \<open>test_record2_zeroize ptr \<equiv> FunctionBody \<lbrakk>(
      ptr.f0 = 3;
      ptr.f1 = 3;
@@ -1356,7 +1356,7 @@ definition test_record2_zeroize :: \<open>('a, 'b, test_record2) ref \<Rightarro
   )\<rbrakk>\<close>
 
 definition test_record2_zeroize_contract ::
-   \<open>('a, 'b, test_record2) ref \<Rightarrow> 'b \<Rightarrow> test_record2 \<Rightarrow> ('s, int, 'abort) function_contract\<close>
+   \<open>('a, 'b, test_record2) Global_Store.ref \<Rightarrow> 'b \<Rightarrow> test_record2 \<Rightarrow> ('s, int, 'abort) function_contract\<close>
   where \<open>test_record2_zeroize_contract r g v \<equiv>
      let pre = r \<mapsto> \<langle>\<top>\<rangle> g\<down>v in
      let post = \<lambda>t. \<langle>t = test_record2.f20 v\<rangle> \<star> (\<Squnion>g'. r \<mapsto> \<langle>\<top>\<rangle> g'\<down>(
@@ -1396,13 +1396,13 @@ lemma test_record2_zeroize_contract_spec:
 
 text\<open>Another similar stress test, but this time using array accesses behind a function wrapper.\<close>
 
-definition test_record3_zero_field :: \<open>('a, 'b, test_record3) ref \<Rightarrow> 64 word \<Rightarrow> ('s, unit, 'abort, 'i prompt, 'o prompt_output) function_body\<close> where
+definition test_record3_zero_field :: \<open>('a, 'b, test_record3) Global_Store.ref \<Rightarrow> 64 word \<Rightarrow> ('s, unit, 'abort, 'i prompt, 'o prompt_output) function_body\<close> where
   \<open>test_record3_zero_field r i \<equiv> FunctionBody \<lbrakk>
      r.data[i] = 0
   \<rbrakk>\<close>
 
 definition test_record3_zero_field_contract ::
-   \<open>('a, 'b, test_record3) ref \<Rightarrow> 64 word \<Rightarrow> 'b \<Rightarrow> test_record3 \<Rightarrow> ('s, unit, 'abort) function_contract\<close>
+   \<open>('a, 'b, test_record3) Global_Store.ref \<Rightarrow> 64 word \<Rightarrow> 'b \<Rightarrow> test_record3 \<Rightarrow> ('s, unit, 'abort) function_contract\<close>
   where [crush_contracts]: \<open>test_record3_zero_field_contract r i g v \<equiv>
      let pre = r \<mapsto> \<langle>\<top>\<rangle> g\<down>v \<star> \<langle>i < 20\<rangle> in
      let zero_ith_pure :: test_record3 \<Rightarrow> test_record3 = (\<lambda>t. t \<lparr> data := array_update (data t) (unat i) 0 \<rparr> ) in
@@ -1423,7 +1423,7 @@ proof (crush_boot f: test_record3_zero_field_def contract: test_record3_zero_fie
     by crush_base
 qed
 
-definition test_record3_zeroize :: \<open>('a, 'b, test_record3) ref \<Rightarrow> ('s, int, 'abort, 'i prompt, 'o prompt_output) function_body\<close> where
+definition test_record3_zeroize :: \<open>('a, 'b, test_record3) Global_Store.ref \<Rightarrow> ('s, int, 'abort, 'i prompt, 'o prompt_output) function_body\<close> where
   \<open>test_record3_zeroize ptr \<equiv> FunctionBody \<lbrakk>(
      ptr.test_record3_zero_field(0);
      ptr.test_record3_zero_field(1);
@@ -1489,7 +1489,7 @@ definition test_record3_zeroize :: \<open>('a, 'b, test_record3) ref \<Rightarro
   )\<rbrakk>\<close>
 
 definition test_record3_zeroize_contract ::
-   \<open>('a, 'b, test_record3) ref \<Rightarrow> 'b \<Rightarrow> test_record3 \<Rightarrow> ('s, int, 'abort) function_contract\<close>
+   \<open>('a, 'b, test_record3) Global_Store.ref \<Rightarrow> 'b \<Rightarrow> test_record3 \<Rightarrow> ('s, int, 'abort) function_contract\<close>
   where \<open>test_record3_zeroize_contract r g v \<equiv>
      let pre = r \<mapsto> \<langle>\<top>\<rangle> g\<down>v in
      let zero_data_pure :: test_record3 \<Rightarrow> test_record3 = (\<lambda>t. t \<lparr> data := array_constant 0 \<rparr> ) in

--- a/Micro_Rust_Examples/Linked_List.thy
+++ b/Micro_Rust_Examples/Linked_List.thy
@@ -44,15 +44,15 @@ definition gref_map :: \<open>('a \<Rightarrow> 'b) \<Rightarrow> ('a, 'v) gref 
   where \<open>gref_map f r \<equiv> make_gref (f (gref_address r))\<close>
 
 abbreviation ll_ptr_as_ref' ::
-  \<open>('caddr, 'gv) gref \<Rightarrow> ('addr, 'gv, ('caddr, 'gv, 't) ll_node_raw) ref\<close> where
+  \<open>('caddr, 'gv) gref \<Rightarrow> ('addr, 'gv, ('caddr, 'gv, 't) ll_node_raw) Global_Store.ref\<close> where
   \<open>ll_ptr_as_ref' r \<equiv> make_focused (gref_map (prism_embed caddr_prism) r) ll_focus\<close>
 
 abbreviation \<open>ll_ptr_as_ref \<equiv> Option.map_option ll_ptr_as_ref'\<close>
 
 \<comment>\<open>Bounded reversal of linked lists of uRust references\<close>
 definition reverse_unlink :: \<open>64 word \<Rightarrow> ('caddr, 'gv) gref option \<Rightarrow>
-      ('addr, 'gv, ('caddr, 'gv) gref option) ref \<Rightarrow>
-      ('addr, 'gv, ('caddr, 'gv) gref option) ref \<Rightarrow>
+      ('addr, 'gv, ('caddr, 'gv) gref option) Global_Store.ref \<Rightarrow>
+      ('addr, 'gv, ('caddr, 'gv) gref option) Global_Store.ref \<Rightarrow>
       ('s, ('caddr, 'gv) gref option \<times> ('caddr, 'gv) gref option \<times> tnil, 'abort, 'i prompt, 'o prompt_output) function_body\<close> where
   \<open>reverse_unlink n orig cur_raw last_raw \<equiv> FunctionBody \<lbrakk>
       last_raw = None;
@@ -98,8 +98,8 @@ by (induction ds; cases ll; auto intro: ucincl_intros)
 definition reverse_unlink_contract ::
    \<open>64 word
    \<Rightarrow> ('caddr, 'gv) gref option
-   \<Rightarrow> ('addr, 'gv, ('caddr, 'gv) gref option) ref
-   \<Rightarrow> ('addr, 'gv, ('caddr, 'gv) gref option) ref
+   \<Rightarrow> ('addr, 'gv, ('caddr, 'gv) gref option) Global_Store.ref
+   \<Rightarrow> ('addr, 'gv, ('caddr, 'gv) gref option) Global_Store.ref
    \<Rightarrow> 't list
    \<Rightarrow> ('caddr, 'gv) gref option
    \<Rightarrow> ('s, ('caddr, 'gv) gref option \<times> ('caddr, 'gv) gref option \<times> tnil, 'abort) function_contract\<close> where

--- a/Micro_Rust_Examples/Linked_List_Executable_Hybrid.thy
+++ b/Micro_Rust_Examples/Linked_List_Executable_Hybrid.thy
@@ -297,8 +297,8 @@ definition ll_head :: \<open>(NonNullRaw, gv) gref option\<close> where
 
 \<comment>\<open>\<^verbatim>\<open>
 definition reverse_unlink :: \<open>64 word \<Rightarrow> ('caddr, 'gv) gref option
-  \<Rightarrow> ('addr, 'gv, ('caddr, 'gv) gref option) ref
-  \<Rightarrow> ('addr, 'gv, ('caddr, 'gv) gref option) ref
+  \<Rightarrow> ('addr, 'gv, ('caddr, 'gv) gref option) Global_Store.ref
+  \<Rightarrow> ('addr, 'gv, ('caddr, 'gv) gref option) Global_Store.ref
   \<Rightarrow> ('s, ('caddr, 'gv) gref option \<times> ('caddr, 'gv) gref option) function_body\<close> where
   \<open>reverse_unlink n orig cur_raw last_raw \<equiv> FunctionBody \<lbrakk>
       last_raw = None;

--- a/Micro_Rust_Examples/Linked_List_Executable_Physical_Memory.thy
+++ b/Micro_Rust_Examples/Linked_List_Executable_Physical_Memory.thy
@@ -172,15 +172,15 @@ text\<open>Pointer to head of linked list\<close>
 definition ll_head :: \<open>(NonNullRaw, byte list) gref option\<close> where
   \<open>ll_head \<equiv> Some (make_gref test_page_ptr)\<close>
 text\<open>Pointer to scratch memory needed by linked list reversal\<close>
-private definition tmp0_ref :: \<open>(raw_pmem_region, byte list, (NonNullRaw, byte list) gref option) ref\<close> where
+private definition tmp0_ref :: \<open>(raw_pmem_region, byte list, (NonNullRaw, byte list) gref option) Global_Store.ref\<close> where
   \<open>tmp0_ref \<equiv> make_focused (make_gref (make_raw_pmem_region (test_page + 0x38) 8)) ref_gref_opt_focus\<close>
-private definition tmp1_ref :: \<open>(raw_pmem_region, byte list, (NonNullRaw, byte list) gref option) ref\<close> where
+private definition tmp1_ref :: \<open>(raw_pmem_region, byte list, (NonNullRaw, byte list) gref option) Global_Store.ref\<close> where
   \<open>tmp1_ref \<equiv> make_focused (make_gref (make_raw_pmem_region (test_page + 0x40) 8)) ref_gref_opt_focus\<close>
 
 \<comment>\<open>\<^verbatim>\<open>
 definition reverse_unlink :: \<open>64 word \<Rightarrow> ('caddr, 'gv) gref option
-  \<Rightarrow> ('addr, 'gv, ('caddr, 'gv) gref option) ref
-  \<Rightarrow> ('addr, 'gv, ('caddr, 'gv) gref option) ref
+  \<Rightarrow> ('addr, 'gv, ('caddr, 'gv) gref option) Global_Store.ref
+  \<Rightarrow> ('addr, 'gv, ('caddr, 'gv) gref option) Global_Store.ref
   \<Rightarrow> ('s, ('caddr, 'gv) gref option \<times> ('caddr, 'gv) gref option) function_body\<close> where
   \<open>reverse_unlink n orig cur_raw last_raw \<equiv> FunctionBody \<lbrakk>
       last_raw = None;

--- a/Micro_Rust_Examples/Reference_Examples.thy
+++ b/Micro_Rust_Examples/Reference_Examples.thy
@@ -68,7 +68,7 @@ and typing would consist of encoding/decoding byte strings as as concrete types.
 
 text\<open>Before going into further details, here is the example of the \<^verbatim>\<open>swap\<close> function:\<close>
 
-definition swap_ref :: \<open>('addr, 'gv, 'v) ref \<Rightarrow> ('addr, 'gv, 'v) ref \<Rightarrow> ('s, unit, 'abort, 'i prompt, 'o prompt_output) function_body\<close> where
+definition swap_ref :: \<open>('addr, 'gv, 'v) Global_Store.ref \<Rightarrow> ('addr, 'gv, 'v) Global_Store.ref \<Rightarrow> ('s, unit, 'abort, 'i prompt, 'o prompt_output) function_body\<close> where
   \<open>swap_ref rA rB \<equiv> FunctionBody \<lbrakk>
      let oldA = *rA;
      let oldB = *rB;
@@ -137,15 +137,15 @@ First, the empty heap:\<close>
 definition h\<^sub>0 :: heap_ex_ty where \<open>h\<^sub>0 \<equiv> mem_from_alist []\<close>
 value[code] h\<^sub>0
 
-text\<open>Next, we need two typed references in \<^typ>\<open>(nat, heap_ex_gv, 'a) ref\<close>, which is
+text\<open>Next, we need two typed references in \<^typ>\<open>(nat, heap_ex_gv, 'a) Global_Store.ref\<close>, which is
 essentially a combination of a raw reference in \<^typ>\<open>(nat, heap_ex_gv) gref\<close>, and a 'focus'. In general,
 a focus is a means to go from the fixed global value type to varying 'local' value types, but in our
 case, we just use the global value type directly, and hence resort to the identity focus.\<close>
 
-definition ref0 :: \<open>(nat, heap_ex_gv, heap_ex_gv) ref\<close> where
+definition ref0 :: \<open>(nat, heap_ex_gv, heap_ex_gv) Global_Store.ref\<close> where
   \<open>ref0 \<equiv> make_focused (make_gref 0) focus_id\<close>
 
-definition ref1 :: \<open>(nat, heap_ex_gv, heap_ex_gv) ref\<close> where
+definition ref1 :: \<open>(nat, heap_ex_gv, heap_ex_gv) Global_Store.ref\<close> where
   \<open>ref1 \<equiv> make_focused (make_gref 1) focus_id\<close>
 
 text\<open>Let's try to run the function. This functions are essentially uRust \<^verbatim>\<open>expression\<close>s, we
@@ -233,11 +233,11 @@ relating the global and local value type. While in the abstract-heap example, th
 here we use a focus representing little/big endian decoder/encoders of \<^verbatim>\<open>32 word\<close> as \<^verbatim>\<open>byte list\<close>.
 The theory \<^file>\<open>../Byte_Level_Encoding/Byte_Encoding_Word_Nat.thy\<close> provides foci for standard little/big-endian encoding
 of words and nats.\<close>
-definition pref_le :: \<open>(raw_pmem_region, 8 word list, 32 word) ref\<close>
+definition pref_le :: \<open>(raw_pmem_region, 8 word list, 32 word) Global_Store.ref\<close>
     where \<open>pref_le \<equiv> make_focused (make_gref (make_raw_pmem_region 0x0000000FF1C8 4))
                                               word32_byte_list_focus_le\<close>
 
-definition pref_be :: \<open>(raw_pmem_region, 8 word list, 32 word) ref\<close>
+definition pref_be :: \<open>(raw_pmem_region, 8 word list, 32 word) Global_Store.ref\<close>
    where \<open>pref_be \<equiv> make_focused (make_gref (make_raw_pmem_region 0xDEADBEEF0 4))
                                               word32_byte_list_focus_be\<close>
 
@@ -291,7 +291,7 @@ adhoc_overloading store_dereference_const \<rightleftharpoons> raw_pmem_trie_der
 
 text\<open>With this, we can make sense of the \<^verbatim>\<open>swap_ref\<close> function outside of any locale:\<close>
 
-definition swap_ref :: \<open>(raw_pmem_region, byte list, 'v) ref \<Rightarrow> (raw_pmem_region, byte list, 'v) ref
+definition swap_ref :: \<open>(raw_pmem_region, byte list, 'v) Global_Store.ref \<Rightarrow> (raw_pmem_region, byte list, 'v) Global_Store.ref
    \<Rightarrow> (unit tagged_physical_memory, unit, 'abort, 'i prompt, 'o prompt_output) function_body\<close> where
   \<open>swap_ref rA rB \<equiv> FunctionBody \<lbrakk>
      let oldA = *rA;

--- a/Micro_Rust_Examples/Showcase.thy
+++ b/Micro_Rust_Examples/Showcase.thy
@@ -76,7 +76,7 @@ into a symbolic execution goal \<^verbatim>\<open>\<Delta> \<turnstile> WP e _\<
   done
 
 text\<open>Let's make this a bit more interesting, and verify the classic \<^verbatim>\<open>swap\<close> function\<close>
-definition swap_ref :: \<open>('addr, 'gv, 'v) ref \<Rightarrow> ('addr, 'gv, 'v) ref \<Rightarrow> ('s, unit, 'abort, 'i prompt, 'o prompt_output) function_body\<close> where
+definition swap_ref :: \<open>('addr, 'gv, 'v) Global_Store.ref \<Rightarrow> ('addr, 'gv, 'v) Global_Store.ref \<Rightarrow> ('s, unit, 'abort, 'i prompt, 'o prompt_output) function_body\<close> where
   \<open>swap_ref rA rB \<equiv> FunctionBody \<lbrakk>
      let oldA = *rA;
      let oldB = *rB;
@@ -86,7 +86,7 @@ definition swap_ref :: \<open>('addr, 'gv, 'v) ref \<Rightarrow> ('addr, 'gv, 'v
 
 text\<open>The contract of \<^term>\<open>swap_ref\<close> might differ slightly from what you'd expect, specifically
 in the arguments of the points-to connective \<^verbatim>\<open>\<mapsto>\<close>. \<^term>\<open>l \<mapsto>\<langle>s\<rangle> g\<down>v\<close> describes the resource where we
-partially own (indicated by share \<^term>\<open>s :: share\<close>) a location \<^term>\<open>l :: ('addr, 'gv, 'v) ref\<close> that
+partially own (indicated by share \<^term>\<open>s :: share\<close>) a location \<^term>\<open>l :: ('addr, 'gv, 'v) Global_Store.ref\<close> that
 points to a 'global' value \<^term>\<open>g :: 'gv\<close>, which we currently read/interpret as a value
 \<^term>\<open>v :: 'v\<close>. You can think of \<^term>\<open>g :: 'gv\<close> being a bitwise representation of an actual
 value \<^term>\<open>v :: 'v\<close>, where \<^term>\<open>g :: 'gv\<close> might comprise bitfields for other values. Writing
@@ -94,7 +94,7 @@ to this location will only change the bits related to \<^term>\<open>v :: 'v\<cl
 This effect is captured with the \<^term>\<open>l \<mapsto>\<langle>s\<rangle> (\<lambda>_. w) \<sqdot> (g\<down>v)\<close> resource, which describes that
 we (partially) own a location \<^term>\<open>l\<close> that points to a 'global' value \<^term>\<open>g\<close>, but field \<^term>\<open>v\<close>
 of that global value has been overwritten with new content \<^term>\<open>w\<close>.\<close>
-definition swap_ref_contract :: \<open>('addr, 'gv, 'v) ref \<Rightarrow> ('addr, 'gv, 'v) ref \<Rightarrow> 'gv \<Rightarrow> 'gv \<Rightarrow> 'v \<Rightarrow> 'v \<Rightarrow> ('s, 'a, 'b) function_contract\<close> where
+definition swap_ref_contract :: \<open>('addr, 'gv, 'v) Global_Store.ref \<Rightarrow> ('addr, 'gv, 'v) Global_Store.ref \<Rightarrow> 'gv \<Rightarrow> 'gv \<Rightarrow> 'v \<Rightarrow> 'v \<Rightarrow> ('s, 'a, 'b) function_contract\<close> where
   \<open>swap_ref_contract lref rref lg rg lval rval \<equiv>
     let pre  = lref \<mapsto>\<langle>\<top>\<rangle> lg\<down>lval \<star> rref \<mapsto>\<langle>\<top>\<rangle> rg\<down>rval in
     let post = \<lambda> _.

--- a/Micro_Rust_Interfaces_Core/References.thy
+++ b/Micro_Rust_Interfaces_Core/References.thy
@@ -61,7 +61,7 @@ text\<open>Lifting the raw reference operations to typed ones using foci:\<close
 definition reference_fun ::
   \<open>('b, 'v) prism \<Rightarrow>
    'v \<Rightarrow>
-   ('s, ('a, 'b, 'v) ref, 'abort, 'i, 'o) function_body\<close> where
+   ('s, ('a, 'b, 'v) Global_Store.ref, 'abort, 'i, 'o) function_body\<close> where
   [all_reference_defs']: \<open>reference_fun p e \<equiv> FunctionBody \<lbrakk>
        let r = reference_raw_fun (\<llangle>prism_embed p e\<rrangle>);
        \<llangle>make_ref_typed_from_untyped\<rrangle>\<^sub>2(r, \<llangle>prism_to_focus p\<rrangle>)
@@ -79,17 +79,17 @@ definition modify_raw_fun :: \<open>('a, 'b) gref \<Rightarrow> ('b \<Rightarrow
      update_raw_fun(r, \<llangle>f\<rrangle>\<^sub>1(g))
   \<rbrakk>\<close>
 
-definition modify_fun :: \<open>('a, 'b, 'v) ref \<Rightarrow> ('v \<Rightarrow> 'v) \<Rightarrow> ('s, unit, 'abort, 'i, 'o) function_body\<close> where
+definition modify_fun :: \<open>('a, 'b, 'v) Global_Store.ref \<Rightarrow> ('v \<Rightarrow> 'v) \<Rightarrow> ('s, unit, 'abort, 'i, 'o) function_body\<close> where
   [all_reference_defs']: \<open>modify_fun ref f \<equiv> FunctionBody \<lbrakk>
      modify_raw_fun (\<llangle>untype_ref\<rrangle>\<^sub>1(ref), \<llangle>focus_modify (get_focus ref) f\<rrangle>)
   \<rbrakk>\<close>
 
-definition update_fun :: \<open>('a, 'b, 'v) ref \<Rightarrow> 'v \<Rightarrow> ('s, unit, 'abort, 'i, 'o) function_body\<close> where
+definition update_fun :: \<open>('a, 'b, 'v) Global_Store.ref \<Rightarrow> 'v \<Rightarrow> ('s, unit, 'abort, 'i, 'o) function_body\<close> where
   [all_reference_defs']: \<open>update_fun ref v \<equiv> FunctionBody \<lbrakk>
      modify_fun(ref, \<llangle>\<lambda>_. v\<rrangle>)
    \<rbrakk>\<close>
 
-definition dereference_fun :: \<open>('a, 'b, 'v) ref \<Rightarrow> ('s, 'v, 'abort, 'i, 'o) function_body\<close> where
+definition dereference_fun :: \<open>('a, 'b, 'v) Global_Store.ref \<Rightarrow> ('s, 'v, 'abort, 'i, 'o) function_body\<close> where
   [all_reference_defs']: \<open>dereference_fun ref \<equiv> FunctionBody \<lbrakk>
       let b = dereference_raw_fun(\<llangle>untype_ref\<rrangle>\<^sub>1(ref));
       match (\<llangle>focus_view (\<integral> ref) b\<rrangle>) {
@@ -102,7 +102,7 @@ definition ro_dereference_fun ::
       \<open>('a, 'b, 'v) ro_ref \<Rightarrow> ('s, 'v, 'abort, 'i, 'o) function_body\<close> where
   [all_reference_defs']: \<open>ro_dereference_fun r \<equiv> FunctionBody \<lbrakk> dereference_fun(\<llangle>unsafe_ref_from_ro_ref\<rrangle>\<^sub>1(r)) \<rbrakk>\<close>
 
-definition is_valid_ref_for :: \<open>('a, 'b, 'v) ref \<Rightarrow> 'b set \<Rightarrow> bool\<close>
+definition is_valid_ref_for :: \<open>('a, 'b, 'v) Global_Store.ref \<Rightarrow> 'b set \<Rightarrow> bool\<close>
   where \<open>is_valid_ref_for r P \<equiv> focus_dom (get_focus r) \<subseteq> P\<close>
 
 lemma is_valid_ref_for_compose[focus_intros]:
@@ -110,16 +110,16 @@ lemma is_valid_ref_for_compose[focus_intros]:
   shows \<open>is_valid_ref_for (focus_reference f r) P\<close> 
   using assms by (simp add: is_valid_ref_for_def focus_factors_trans focus_focused_get_focus)
 
-abbreviation points_to_localizes :: \<open>('a, 'b, 'v) ref \<Rightarrow> 'b \<Rightarrow> 'v \<Rightarrow> bool\<close> where
+abbreviation points_to_localizes :: \<open>('a, 'b, 'v) Global_Store.ref \<Rightarrow> 'b \<Rightarrow> 'v \<Rightarrow> bool\<close> where
   \<open>points_to_localizes r b v \<equiv> is_valid_ref_for r (gref_can_store (unwrap_focused r)) 
                                 \<and> focus_view (get_focus r) b = Some v\<close>
 
-definition points_to :: \<open>('a, 'b, 'v) ref \<Rightarrow> share \<Rightarrow> 'b \<Rightarrow> 'v \<Rightarrow> 's assert\<close> where
+definition points_to :: \<open>('a, 'b, 'v) Global_Store.ref \<Rightarrow> share \<Rightarrow> 'b \<Rightarrow> 'v \<Rightarrow> 's assert\<close> where
   [all_reference_defs']: \<open>points_to r sh b v \<equiv> points_to_raw (unwrap_focused r) sh b \<star> \<langle>points_to_localizes r b v\<rangle>\<close>
 
 notation points_to ("(_) \<mapsto> \<langle>_\<rangle>/_/ \<down>/ _" [69,0,69,69]70)
 
-abbreviation points_to_modified :: \<open>('a, 'b, 'v) ref \<Rightarrow> share \<Rightarrow> ('v \<Rightarrow> 'v) \<Rightarrow> 'b \<Rightarrow> 'v \<Rightarrow> 's assert\<close> where
+abbreviation points_to_modified :: \<open>('a, 'b, 'v) Global_Store.ref \<Rightarrow> share \<Rightarrow> ('v \<Rightarrow> 'v) \<Rightarrow> 'b \<Rightarrow> 'v \<Rightarrow> 's assert\<close> where
   \<open>points_to_modified r sh op b v \<equiv> points_to r sh (focus_modify (get_focus r) op b) (op v) \<star>
    \<langle>points_to_localizes r b v\<rangle>\<close>
 
@@ -131,20 +131,20 @@ definition modify_raw_contract :: \<open>('a, 'b) gref \<Rightarrow> 'b \<Righta
      let post = \<lambda>_. (points_to_raw r \<top> (f g)) in
      make_function_contract pre post\<close>
 
-definition update_contract :: \<open>('a, 'b, 'v) ref \<Rightarrow> 'b \<Rightarrow> 'v \<Rightarrow> 'v \<Rightarrow> ('s, unit, 'abort) function_contract\<close> where 
+definition update_contract :: \<open>('a, 'b, 'v) Global_Store.ref \<Rightarrow> 'b \<Rightarrow> 'v \<Rightarrow> 'v \<Rightarrow> ('s, unit, 'abort) function_contract\<close> where 
   [all_reference_defs']: \<open>update_contract r g0 v0 v \<equiv>
      let pre = points_to r \<top> g0 v0 in
      let post = \<lambda>_. points_to_modified r \<top> (\<lambda>_. v) g0 v0 in
      make_function_contract pre post\<close>
 
-definition modify_contract :: \<open>('a, 'b, 'v) ref \<Rightarrow> 'b \<Rightarrow> 'v \<Rightarrow> ('v \<Rightarrow> 'v) \<Rightarrow> ('s, unit, 'abort) function_contract\<close> 
+definition modify_contract :: \<open>('a, 'b, 'v) Global_Store.ref \<Rightarrow> 'b \<Rightarrow> 'v \<Rightarrow> ('v \<Rightarrow> 'v) \<Rightarrow> ('s, unit, 'abort) function_contract\<close> 
   where [all_reference_defs']: \<open>modify_contract r g0 v0 f \<equiv>
      let pre = points_to r \<top> g0 v0 in
      let post = \<lambda>_. (points_to_modified r \<top> f g0 v0) in
      make_function_contract pre post\<close>
 
 definition dereference_contract 
-  :: \<open>('a, 'b, 'v) ref \<Rightarrow> share \<Rightarrow> 'b \<Rightarrow> 'v \<Rightarrow> ('s, 'v, 'abort) function_contract\<close> where 
+  :: \<open>('a, 'b, 'v) Global_Store.ref \<Rightarrow> share \<Rightarrow> 'b \<Rightarrow> 'v \<Rightarrow> ('s, 'v, 'abort) function_contract\<close> where 
   [all_reference_defs']: \<open>dereference_contract r sh g v \<equiv>
      let pre = points_to r sh g v in
      let post = \<lambda>v'. (points_to r sh g v \<star> \<langle>v=v'\<rangle>) in
@@ -157,7 +157,7 @@ definition ro_dereference_contract
      let post = \<lambda>v'. points_to (unsafe_ref_from_ro_ref r) sh g v \<star> \<langle>v=v'\<rangle> in
      make_function_contract pre post\<close>
 
-definition reference_contract :: \<open>('b, 'v) prism \<Rightarrow> 'v \<Rightarrow> ('s, ('a, 'b, 'v) ref, 'abort) function_contract\<close> where 
+definition reference_contract :: \<open>('b, 'v) prism \<Rightarrow> 'v \<Rightarrow> ('s, ('a, 'b, 'v) Global_Store.ref, 'abort) function_contract\<close> where 
   [all_reference_defs']: \<open>reference_contract p v \<equiv>
      let pre = can_alloc_reference in
      let post = \<lambda>r. points_to r \<top> (prism_embed p v) v \<star> \<langle>\<integral>r = prism_to_focus p\<rangle> \<star> can_alloc_reference in

--- a/Micro_Rust_Std_Lib/StdLib_Iterators.thy
+++ b/Micro_Rust_Std_Lib/StdLib_Iterators.thy
@@ -49,7 +49,7 @@ context reference
 begin
 
 definition iter_mut ::
-  \<open>('a, 'b, 'v list) ref \<Rightarrow> ('s, ('s, ('a, 'b, 'v) ref, 'abort, 'i prompt, 'o prompt_output) iterator, 'abort, 'i prompt, 'o prompt_output) function_body\<close>
+  \<open>('a, 'b, 'v list) Global_Store.ref \<Rightarrow> ('s, ('s, ('a, 'b, 'v) Global_Store.ref, 'abort, 'i prompt, 'o prompt_output) iterator, 'abort, 'i prompt, 'o prompt_output) function_body\<close>
   where
   \<open>iter_mut ref \<equiv> FunctionBody \<lbrakk>
     let xs = *ref;

--- a/Micro_Rust_Std_Lib/StdLib_Option.thy
+++ b/Micro_Rust_Std_Lib/StdLib_Option.thy
@@ -128,7 +128,7 @@ begin
 adhoc_overloading store_update_const \<rightleftharpoons> update_fun
 
 definition option_as_mut ::
-  \<open>('a, 'b, 'v option) ref \<Rightarrow> ('s, ('a, 'b, 'v) ref option, 'abort, 'i prompt, 'o prompt_output) function_body\<close> where
+  \<open>('a, 'b, 'v option) Global_Store.ref \<Rightarrow> ('s, ('a, 'b, 'v) Global_Store.ref option, 'abort, 'i prompt, 'o prompt_output) function_body\<close> where
   \<open>option_as_mut self \<equiv> FunctionBody \<lbrakk>
     if (*self).is_some() {
       Some (\<llangle>focus_option self\<rrangle>)
@@ -136,8 +136,8 @@ definition option_as_mut ::
       None
     }\<rbrakk>\<close>
 
-definition option_as_mut_contract :: \<open>'b \<Rightarrow> ('a, 'b, 'v option) ref \<Rightarrow> 'v option \<Rightarrow>
-    ('s::{sepalg}, ('a, 'b, 'v) ref option, 'abort) function_contract\<close> where
+definition option_as_mut_contract :: \<open>'b \<Rightarrow> ('a, 'b, 'v option) Global_Store.ref \<Rightarrow> 'v option \<Rightarrow>
+    ('s::{sepalg}, ('a, 'b, 'v) Global_Store.ref option, 'abort) function_contract\<close> where
   [crush_contracts]: \<open>option_as_mut_contract g ref opt \<equiv>
     let pre  = ref \<mapsto>\<langle>\<top>\<rangle> g\<down>opt;
         post = \<lambda>res. ref \<mapsto>\<langle>\<top>\<rangle> g\<down>opt \<star> \<langle>res = 
@@ -151,7 +151,7 @@ lemma option_as_mut_spec [crush_specs]:
   apply (crush_base simp add: option_focus_def split: option.splits)
   done
 
-definition take_mut_ref_option :: \<open>('a, 'b, 'v option) ref \<Rightarrow>
+definition take_mut_ref_option :: \<open>('a, 'b, 'v option) Global_Store.ref \<Rightarrow>
       ('s, 'v option, 'abort, 'i prompt, 'o prompt_output) function_body\<close> where
   \<open>take_mut_ref_option ptr \<equiv> FunctionBody \<lbrakk>
     let val = *ptr;
@@ -161,7 +161,7 @@ definition take_mut_ref_option :: \<open>('a, 'b, 'v option) ref \<Rightarrow>
 adhoc_overloading take_const \<rightleftharpoons>
   take_mut_ref_option
 
-definition take_mut_ref_option_contract :: \<open>('a, 'b, 'v option) ref \<Rightarrow> 'b \<Rightarrow> 'v option \<Rightarrow>
+definition take_mut_ref_option_contract :: \<open>('a, 'b, 'v option) Global_Store.ref \<Rightarrow> 'b \<Rightarrow> 'v option \<Rightarrow>
     ('s::{sepalg}, 'v option, 'abort) function_contract\<close> where
   [crush_contracts]: \<open>take_mut_ref_option_contract ptr g v \<equiv>
     let pre = ptr \<mapsto>\<langle>\<top>\<rangle> g\<down>v;

--- a/Micro_Rust_Std_Lib/StdLib_References.thy
+++ b/Micro_Rust_Std_Lib/StdLib_References.thy
@@ -255,10 +255,10 @@ abbreviation project :: \<open>'b \<Rightarrow> 'v option\<close> where
 abbreviation embed :: \<open>'v \<Rightarrow> 'b\<close> where
   \<open>embed b \<equiv> prism_embed prism b\<close>
 
-definition cast :: \<open>('a, 'b) gref \<Rightarrow> ('a, 'b, 'v) ref\<close>
+definition cast :: \<open>('a, 'b) gref \<Rightarrow> ('a, 'b, 'v) Global_Store.ref\<close>
   where \<open>cast gref \<equiv> make_ref_typed_from_untyped gref (prism_to_focus prism)\<close>
 
-definition new :: \<open>'v \<Rightarrow> ('s, ('a, 'b, 'v) ref, 'abort, 'i prompt, 'o prompt_output) function_body\<close>
+definition new :: \<open>'v \<Rightarrow> ('s, ('a, 'b, 'v) Global_Store.ref, 'abort, 'i prompt, 'o prompt_output) function_body\<close>
   where \<open>new x \<equiv> reference_fun prism x\<close>
 
 definition \<open>focus = prism_to_focus prism\<close>

--- a/Micro_Rust_Std_Lib/StdLib_Result.thy
+++ b/Micro_Rust_Std_Lib/StdLib_Result.thy
@@ -166,8 +166,8 @@ context reference
 begin       
 adhoc_overloading store_update_const \<rightleftharpoons> update_fun
 
-definition result_as_mut :: \<open>('a, 'b, ('v, 'e) result) ref \<Rightarrow>
-    ('s, (('a, 'b, 'v) ref, ('a, 'b, 'e) ref) result, 'abort, 'i prompt, 'o prompt_output) function_body\<close> where
+definition result_as_mut :: \<open>('a, 'b, ('v, 'e) result) Global_Store.ref \<Rightarrow>
+    ('s, (('a, 'b, 'v) Global_Store.ref, ('a, 'b, 'e) Global_Store.ref) result, 'abort, 'i prompt, 'o prompt_output) function_body\<close> where
   \<open>result_as_mut self \<equiv> FunctionBody \<lbrakk>
      match *self {
        Ok(_)  \<Rightarrow> Ok (\<llangle>focus_result_ok self\<rrangle>),
@@ -175,8 +175,8 @@ definition result_as_mut :: \<open>('a, 'b, ('v, 'e) result) ref \<Rightarrow>
      }
   \<rbrakk>\<close>
 
-definition result_as_mut_contract :: \<open>'b \<Rightarrow> ('a, 'b, ('v, 'e) result) ref
-     \<Rightarrow> ('v, 'e) result \<Rightarrow> ('s::{sepalg}, (('a, 'b, 'v) ref, ('a, 'b, 'e) ref) result, 'abort) function_contract\<close> where
+definition result_as_mut_contract :: \<open>'b \<Rightarrow> ('a, 'b, ('v, 'e) result) Global_Store.ref
+     \<Rightarrow> ('v, 'e) result \<Rightarrow> ('s::{sepalg}, (('a, 'b, 'v) Global_Store.ref, ('a, 'b, 'e) Global_Store.ref) result, 'abort) function_contract\<close> where
   [crush_contracts]: \<open>result_as_mut_contract g ref opt \<equiv>
     let pre  = ref \<mapsto>\<langle>\<top>\<rangle> g\<down>opt;
         post = \<lambda>res. ref \<mapsto>\<langle>\<top>\<rangle> g\<down>opt \<star> 

--- a/Micro_Rust_Std_Lib/StdLib_Slice.thy
+++ b/Micro_Rust_Std_Lib/StdLib_Slice.thy
@@ -46,8 +46,8 @@ lemma array_index_spec [crush_specs]:
 
 context reference begin
 
-definition slice_index :: \<open>('a, 'b, 'v list) ref \<Rightarrow> 'w::{len} word \<Rightarrow>
-        ('s, ('a, 'b, 'v) ref, 'abort, 'i prompt, 'o prompt_output) function_body\<close> where
+definition slice_index :: \<open>('a, 'b, 'v list) Global_Store.ref \<Rightarrow> 'w::{len} word \<Rightarrow>
+        ('s, ('a, 'b, 'v) Global_Store.ref, 'abort, 'i prompt, 'o prompt_output) function_body\<close> where
   \<open>slice_index r i \<equiv> FunctionBody \<lbrakk>
      let ls = *r;
      if \<llangle>unat i\<rrangle> < \<llangle>length\<rrangle>\<^sub>1(ls) {
@@ -72,7 +72,7 @@ lemma slice_index_spec [crush_specs]:
   done
 
 definition slice_index_array ::
-  \<open>('a, 'b, ('v, 'l::{len}) array) ref \<Rightarrow> 'w::{len} word \<Rightarrow> ('s, ('a, 'b, 'v) ref, 'abort, 'i prompt, 'o prompt_output) function_body\<close>
+  \<open>('a, 'b, ('v, 'l::{len}) array) Global_Store.ref \<Rightarrow> 'w::{len} word \<Rightarrow> ('s, ('a, 'b, 'v) Global_Store.ref, 'abort, 'i prompt, 'o prompt_output) function_body\<close>
   where \<open>slice_index_array r idx \<equiv> FunctionBody (
      if unat idx < LENGTH('l) then
          literal (focus_nth_array (unat idx) r)
@@ -94,8 +94,8 @@ lemma slice_index_array_spec [crush_specs]:
   apply crush_base
   done
 
-definition slice_index_vector :: \<open>('a, 'b, ('v, 'l::{len}) vector) ref \<Rightarrow> 'w::{len} word \<Rightarrow>
-      ('s, ('a, 'b, 'v) ref, 'abort, 'i prompt, 'o prompt_output) function_body\<close> where
+definition slice_index_vector :: \<open>('a, 'b, ('v, 'l::{len}) vector) Global_Store.ref \<Rightarrow> 'w::{len} word \<Rightarrow>
+      ('s, ('a, 'b, 'v) Global_Store.ref, 'abort, 'i prompt, 'o prompt_output) function_body\<close> where
   \<open>slice_index_vector r idx \<equiv> FunctionBody \<lbrakk>
      let v = *r;
      if \<llangle>unat idx\<rrangle> < \<llangle>vector_len v\<rrangle> {
@@ -123,8 +123,8 @@ lemma slice_index_vector_spec [crush_specs]:
 the following does not work anymore. Once we actually use subrange slices, this needs to be
 revisited.\<close>
 (*
-definition slice_index_range :: \<open>('a, 'b, 'v list) ref \<Rightarrow> 'w::{len} word range \<Rightarrow>
-    ('s, ('a, 'b, 'v list) ref, 'abort, 'i, 'o) function_body\<close> where
+definition slice_index_range :: \<open>('a, 'b, 'v list) Global_Store.ref \<Rightarrow> 'w::{len} word range \<Rightarrow>
+    ('s, ('a, 'b, 'v list) Global_Store.ref, 'abort, 'i, 'o) function_body\<close> where
   \<open>slice_index_range r rng \<equiv> FunctionBody (
     bind (call (dereference_fun r)) (\<lambda>xs.
     case rng of

--- a/Shallow_Micro_Rust/Micro_Rust_Shallow_Embedding_Tests.thy
+++ b/Shallow_Micro_Rust/Micro_Rust_Shallow_Embedding_Tests.thy
@@ -282,10 +282,10 @@ subsection\<open>Assignment Operators\<close>
 subsubsection\<open>Simple Assignment\<close>
 
 context
-  fixes r :: \<open>('s, 'b, integer) ref\<close>
+  fixes r :: \<open>('s, 'b, integer) Global_Store.ref\<close>
 begin
 
-private definition dummy_dereference_assign :: \<open>('s, 'b, 'v) ref \<Rightarrow> ('s, 'v, unit, unit, unit) function_body\<close> where
+private definition dummy_dereference_assign :: \<open>('s, 'b, 'v) Global_Store.ref \<Rightarrow> ('s, 'v, unit, unit, unit) function_body\<close> where
   \<open>dummy_dereference_assign \<equiv> undefined\<close>
 
 adhoc_overloading store_dereference_const \<rightleftharpoons> dummy_dereference_assign
@@ -766,6 +766,80 @@ term\<open>\<lbrakk>
   } else {
     assert!(False);
     ()
+  }
+\<rbrakk>\<close>
+
+subsubsection\<open>Extended Rust-Style Pattern Forms\<close>
+
+term\<open>\<lbrakk>
+  let y = match \<llangle>True\<rrangle> {
+    true \<Rightarrow> \<llangle>1 :: 32 word\<rrangle>,
+    false \<Rightarrow> \<llangle>0 :: 32 word\<rrangle>
+  };
+  assert!(y == \<llangle>1 :: 32 word\<rrangle>)
+\<rbrakk>\<close>
+
+term\<open>\<lbrakk>
+  let y = match \<llangle>String.implode ''ok''\<rrangle> {
+    "ok" \<Rightarrow> \<llangle>1 :: 32 word\<rrangle>,
+    _ \<Rightarrow> \<llangle>0 :: 32 word\<rrangle>
+  };
+  assert!(y == \<llangle>1 :: 32 word\<rrangle>)
+\<rbrakk>\<close>
+
+term\<open>\<lbrakk>
+  let y = match \<llangle>CHR ''a''\<rrangle> {
+    \<llangle>CHR ''a''\<rrangle> \<Rightarrow> \<llangle>1 :: 32 word\<rrangle>,
+    _ \<Rightarrow> \<llangle>0 :: 32 word\<rrangle>
+  };
+  assert!(y == \<llangle>1 :: 32 word\<rrangle>)
+\<rbrakk>\<close>
+
+term\<open>\<lbrakk>
+  let y = match Some(\<llangle>7 :: 32 word\<rrangle>) {
+    whole @ Some(v) \<Rightarrow> v,
+    _ \<Rightarrow> \<llangle>0 :: 32 word\<rrangle>
+  };
+  assert!(y == \<llangle>7 :: 32 word\<rrangle>)
+\<rbrakk>\<close>
+
+text\<open>Note: Rust-style pattern binders @{text "ref p"} and @{text "ref mut p"} are currently
+not supported in this frontend, because they conflict with existing syntax around references
+and function parameters in this Isabelle embedding.\<close>
+
+term\<open>\<lbrakk>
+  let y = match Some(\<llangle>7 :: 32 word\<rrangle>) {
+    Some(&v) \<Rightarrow> v,
+    _ \<Rightarrow> \<llangle>0 :: 32 word\<rrangle>
+  };
+  assert!(y == \<llangle>7 :: 32 word\<rrangle>)
+\<rbrakk>\<close>
+
+term\<open>\<lbrakk>
+  let y = match Some(\<llangle>7 :: 32 word\<rrangle>) {
+    Some(& mut v) \<Rightarrow> v,
+    _ \<Rightarrow> \<llangle>0 :: 32 word\<rrangle>
+  };
+  assert!(y == \<llangle>7 :: 32 word\<rrangle>)
+\<rbrakk>\<close>
+
+text\<open>Range patterns are lowered in the shallow embedding, but concrete parser-level
+coverage for the Rust-style syntax is exercised separately in frontend-focused tests.\<close>
+
+term\<open>\<lbrakk>
+  let y = match \<llangle>[7 :: 32 word, 8, 9]\<rrangle> {
+    [head, ..] \<Rightarrow> head,
+    _ \<Rightarrow> \<llangle>0 :: 32 word\<rrangle>
+  };
+  assert!(y == \<llangle>7 :: 32 word\<rrangle>)
+\<rbrakk>\<close>
+
+text\<open>Current slice-rest lowering is partial: patterns with a suffix after @{text ".."}
+elaborate, but only the prefix before @{text ".."} is currently enforced.\<close>
+term\<open>\<lbrakk>
+  match \<llangle>[1 :: 32 word, 2, 3, 4]\<rrangle> {
+    [a, b, .., z] \<Rightarrow> \<llangle>1 :: 32 word\<rrangle>,
+    _ \<Rightarrow> \<llangle>0 :: 32 word\<rrangle>
   }
 \<rbrakk>\<close>
 
@@ -1336,7 +1410,7 @@ term\<open>\<lbrakk>
 subsubsection\<open>Borrow Syntax\<close>
 
 context
-  fixes r :: \<open>('s, 'b, integer) ref\<close>
+  fixes r :: \<open>('s, 'b, integer) Global_Store.ref\<close>
   fixes x y :: \<open>32 word\<close>
 begin
 term \<open>\<lbrakk> &r \<rbrakk>\<close>
@@ -1354,10 +1428,10 @@ term\<open>\<lbrakk>
 subsubsection\<open>Dereference\<close>
 
 context
-  fixes r :: \<open>('s, 'b, integer) ref\<close>
+  fixes r :: \<open>('s, 'b, integer) Global_Store.ref\<close>
 begin
 
-private definition dummy_dereference_ref :: \<open>('s, 'b, 'v) ref \<Rightarrow> ('s, 'v, unit, unit, unit) function_body\<close> where
+private definition dummy_dereference_ref :: \<open>('s, 'b, 'v) Global_Store.ref \<Rightarrow> ('s, 'v, unit, unit, unit) function_body\<close> where
   \<open>dummy_dereference_ref \<equiv> undefined\<close>
 
 adhoc_overloading store_dereference_const \<rightleftharpoons> dummy_dereference_ref
@@ -1370,10 +1444,10 @@ end
 subsubsection\<open>Double Dereference\<close>
 
 context
-  fixes rr :: \<open>('s, 'b, ('s, 'b, integer) ref) ref\<close>
+  fixes rr :: \<open>('s, 'b, ('s, 'b, integer) Global_Store.ref) Global_Store.ref\<close>
 begin
 
-private definition dummy_dereference_ref2 :: \<open>('s, 'b, 'v) ref \<Rightarrow> ('s, 'v, unit, unit, unit) function_body\<close> where
+private definition dummy_dereference_ref2 :: \<open>('s, 'b, 'v) Global_Store.ref \<Rightarrow> ('s, 'v, unit, unit, unit) function_body\<close> where
   \<open>dummy_dereference_ref2 \<equiv> undefined\<close>
 
 adhoc_overloading store_dereference_const \<rightleftharpoons> dummy_dereference_ref2
@@ -1427,12 +1501,12 @@ end
 subsubsection\<open>Field Assignment Through Lenses\<close>
 
 context
-  fixes r :: \<open>('s, 'b, integer) ref\<close>
-  fixes s :: \<open>('s, 'b, testrec2) ref\<close>
-  fixes f :: \<open>('s, 'b, integer) ref \<Rightarrow> integer \<Rightarrow> ('s, unit, unit, unit, unit) function_body\<close>
+  fixes r :: \<open>('s, 'b, integer) Global_Store.ref\<close>
+  fixes s :: \<open>('s, 'b, testrec2) Global_Store.ref\<close>
+  fixes f :: \<open>('s, 'b, integer) Global_Store.ref \<Rightarrow> integer \<Rightarrow> ('s, unit, unit, unit, unit) function_body\<close>
 begin
 
-private definition dummy_dereference_field :: \<open>('s, 'b, 'v) ref \<Rightarrow> ('s, 'v, unit, unit, unit) function_body\<close> where
+private definition dummy_dereference_field :: \<open>('s, 'b, 'v) Global_Store.ref \<Rightarrow> ('s, 'v, unit, unit, unit) function_body\<close> where
   \<open>dummy_dereference_field \<equiv> undefined\<close>
 
 adhoc_overloading store_dereference_const \<rightleftharpoons> dummy_dereference_field


### PR DESCRIPTION
- Extend pattern syntax/lowering with:
  - boolean, string, and generic literal patterns
  - alias patterns (`id @ pat`)
  - borrow patterns (`&pat`, `& mut pat`)
  - range patterns (`..`, `..=`)
  - slice/rest patterns and nested/disjunctive pattern handling
- Wire shallow embedding normalization/guard lowering for extended patterns.
- Add/update Micro Rust shallow embedding tests for the new pattern forms.
- Intentionally remove/omit `ref pat` and `ref mut pat` support due to parser/syntax conflicts with existing `ref` usage in this Isabelle setup.
- Restore explicit boolean expression parsing (`true`/`false`) in expression position to keep `if` branches and related terms parsing cleanly.

Closes #66 (with `ref`/`ref mut` pattern binders documented as unsupported).

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
