### PR TITLE
Make max_tool_iterations optional with unlimited as default

### DIFF
--- a/isabelle-assistant/src/test/scala/AssistantOptionsTest.scala
+++ b/isabelle-assistant/src/test/scala/AssistantOptionsTest.scala
@@ -83,4 +83,27 @@ class AssistantOptionsTest extends AnyFunSuite with Matchers {
     overridden.verifySuggestions shouldBe false
     overridden.useSledgehammer shouldBe true
   }
+
+  test("parseSnapshot should default maxToolIterations to None (unlimited)") {
+    val defaults = parse()
+    defaults.maxToolIterations shouldBe None
+  }
+
+  test("parseSnapshot should parse valid maxToolIterations values") {
+    val withLimit = parse(Map("assistant.max.tool.iterations" -> "25"))
+    withLimit.maxToolIterations shouldBe Some(25)
+  }
+
+  test("parseSnapshot should treat empty/0/none/unlimited as unlimited") {
+    parse(Map("assistant.max.tool.iterations" -> "")).maxToolIterations shouldBe None
+    parse(Map("assistant.max.tool.iterations" -> "0")).maxToolIterations shouldBe None
+    parse(Map("assistant.max.tool.iterations" -> "none")).maxToolIterations shouldBe None
+    parse(Map("assistant.max.tool.iterations" -> "unlimited")).maxToolIterations shouldBe None
+    parse(Map("assistant.max.tool.iterations" -> "UNLIMITED")).maxToolIterations shouldBe None
+  }
+
+  test("parseSnapshot should clamp maxToolIterations to valid range") {
+    parse(Map("assistant.max.tool.iterations" -> "100")).maxToolIterations shouldBe None
+    parse(Map("assistant.max.tool.iterations" -> "-5")).maxToolIterations shouldBe None
+  }
 }


### PR DESCRIPTION
Previously, maxToolIterations was a required Int with a fixed default of 10, limiting the tool-use agentic loop to a maximum of 10 iterations. This prevented models from completing tasks that required more tool uses.

Changes:
- Changed maxToolIterations from Int to Option[Int] in SettingsSnapshot
- Added optIntProp helper to parse optional integer settings
  - Empty string, "0", "none", "unlimited" → None (unlimited)
  - Valid integers (1-50) → Some(n)
  - Out-of-range values → None
- Updated GUI to display empty field for unlimited, allow user to enter 0 or leave blank for unlimited behavior
- Modified BedrockClient.invokeChatWithTools() to handle Option[Int]:
  - None means unlimited iterations
  - Some(n) means cap at n iterations
- Added OptionalIntSetting case class for :set command support
- Updated status messages to show "∞" when limit is None
- Added 5 new tests covering optional behavior

The default is now unlimited (None), allowing models to use as many tool iterations as needed to complete tasks. Users can still set a specific limit via the GUI settings panel or :set command if desired.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
