### PR TITLE
Fix file path resolution collisions and harden I/Q test workflow

### DIFF
--- a/iq/Makefile
+++ b/iq/Makefile
@@ -59,8 +59,12 @@ test: build $(TEST_CLASSES_DIR)/.compiled
 	JAVA_HOME="$(JAVA_HOME)" PATH="$(JAVA_HOME)/bin:$$PATH" $(SCALA) \
 		-classpath "$(CLASSES_DIR):$(TEST_CLASSES_DIR):$(JEDIT_JAR):$(ISABELLE_JAR)" \
 		IQSecurityTest
+	echo "Running I/Q path resolution tests..."
+	JAVA_HOME="$(JAVA_HOME)" PATH="$(JAVA_HOME)/bin:$$PATH" $(SCALA) \
+		-classpath "$(CLASSES_DIR):$(TEST_CLASSES_DIR):$(JEDIT_JAR):$(ISABELLE_JAR)" \
+		IQUtilsPathResolutionTest
 	echo "I/Q tests passed."
-
+	
 # Documentation checks
 .PHONY: check-docs
 check-docs:
@@ -95,6 +99,7 @@ $(TEST_CLASSES_DIR):
 
 $(TEST_CLASSES_DIR)/.compiled: $(TEST_SOURCES) $(CLASSES_DIR)/.compiled | $(TEST_CLASSES_DIR)
 	echo "Compiling I/Q tests..."
+	if [ -z "$(strip $(TEST_SOURCES))" ]; then echo "No test sources found."; touch $@; exit 0; fi
 	JAVA_HOME="$(JAVA_HOME)" PATH="$(JAVA_HOME)/bin:$$PATH" $(SCALAC) \
 		-classpath "$(CLASSES_DIR):$(JEDIT_JAR):$(ISABELLE_JAR)" \
 		-d $(TEST_CLASSES_DIR) \

--- a/iq/src/IQServer.scala
+++ b/iq/src/IQServer.scala
@@ -2665,7 +2665,6 @@ end"""
     createFileWithContentCommon(filePath, content, overwriteIfExists, inView = false)
   }
 
-  // Helper methods
   private def getOpenViews(): List[View] = {
     val viewManager = jEdit.getViewManager()
     if (viewManager == null) List.empty
@@ -2676,6 +2675,7 @@ end"""
     }
   }
 
+  // Helper methods
   private def findViewForFile(filePath: String): Option[View] = {
     val views = getOpenViews()
     views.find { view =>

--- a/iq/test/IQUtilsPathResolutionTest.scala
+++ b/iq/test/IQUtilsPathResolutionTest.scala
@@ -1,0 +1,76 @@
+/* Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+   SPDX-License-Identifier: MIT */
+
+object IQUtilsPathResolutionTest extends App {
+
+  private def assertEqual[A](actual: A, expected: A, context: String): Unit = {
+    if (actual != expected) {
+      throw new RuntimeException(
+        s"$context failed.\nExpected: $expected\nActual:   $actual"
+      )
+    }
+  }
+
+  private def assertLeftContains(actual: Either[String, String], expectedSubstring: String, context: String): Unit = {
+    actual match {
+      case Left(msg) =>
+        if (!msg.contains(expectedSubstring)) {
+          throw new RuntimeException(
+            s"$context failed.\nExpected Left containing: $expectedSubstring\nActual Left:              $msg"
+          )
+        }
+      case Right(value) =>
+        throw new RuntimeException(s"$context failed.\nExpected Left but got Right($value)")
+    }
+  }
+
+  // stripExtension should remove only the final extension segment.
+  assertEqual(
+    IQUtils.stripExtension("/tmp/project/Foo.Bar.thy"),
+    "/tmp/project/Foo.Bar",
+    "stripExtension multi-dot"
+  )
+  assertEqual(
+    IQUtils.stripExtension("/tmp/project/Foo"),
+    "/tmp/project/Foo",
+    "stripExtension no extension"
+  )
+
+  // Multi-dot partial path should resolve correctly when there is one candidate.
+  val uniqueCandidates = List(
+    "/tmp/project/Foo.Bar.thy",
+    "/tmp/project/Other.thy"
+  )
+  assertEqual(
+    IQUtils.autoCompleteFilePathFromCandidates("Foo.Bar.thy", uniqueCandidates),
+    Right("/tmp/project/Foo.Bar.thy"),
+    "unique multi-dot resolution"
+  )
+
+  // Prevent false matches: Foo.Baz should not match only Foo.Bar.
+  assertLeftContains(
+    IQUtils.autoCompleteFilePathFromCandidates("Foo.Baz.thy", List("/tmp/project/Foo.Bar.thy")),
+    "No file found matching 'Foo.Baz.thy'",
+    "false match prevention"
+  )
+
+  // Ambiguities should include all candidates deterministically.
+  val ambiguous = IQUtils.autoCompleteFilePathFromCandidates(
+    "Foo.Bar.thy",
+    List("/tmp/b/Foo.Bar.thy", "/tmp/a/Foo.Bar.thy")
+  )
+  assertEqual(
+    ambiguous,
+    Left("Multiple files found matching 'Foo.Bar.thy': /tmp/a/Foo.Bar.thy, /tmp/b/Foo.Bar.thy"),
+    "deterministic ambiguity reporting"
+  )
+
+  // trackedOnly = false should return the input path if no tracked match exists.
+  assertEqual(
+    IQUtils.autoCompleteFilePathFromCandidates("Untracked/Thing.thy", Nil, trackedOnly = false),
+    Right("Untracked/Thing.thy"),
+    "untracked fallback when trackedOnly=false"
+  )
+
+  println("IQUtilsPathResolutionTest: all tests passed")
+}


### PR DESCRIPTION
- Fix `IQUtils.stripExtension` to remove only the final extension segment (preserves multi-dot basenames like `Foo.Bar.thy` -> `Foo.Bar`).
- Replace lossy path-candidate map logic with list-based matching that preserves all candidates and reports ambiguity deterministically.
- Add pure path-resolution helper (`autoCompleteFilePathFromCandidates`) to make matching behavior testable without GUI state.
- Add regression tests for:
  - multi-dot filename resolution
  - false-match prevention
  - deterministic ambiguous-match reporting
  - trackedOnly=false fallback behavior
- Add `iq/Makefile` test target and test compile wiring.
- Remove deprecated `jEdit.getViews()` usage in `IQServer` by introducing a ViewManager-based `getOpenViews()` helper, eliminating build warnings.

Closes #93.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
