### PR TITLE
Fix bridge response framing with incremental NDJSON decoding

### DIFF
--- a/iq/.gitignore
+++ b/iq/.gitignore
@@ -1,1 +1,2 @@
 build/
+bridge_log.txt

--- a/iq/Makefile
+++ b/iq/Makefile
@@ -63,8 +63,10 @@ test: build $(TEST_CLASSES_DIR)/.compiled
 	JAVA_HOME="$(JAVA_HOME)" PATH="$(JAVA_HOME)/bin:$$PATH" $(SCALA) \
 		-classpath "$(CLASSES_DIR):$(TEST_CLASSES_DIR):$(JEDIT_JAR):$(ISABELLE_JAR)" \
 		IQUtilsPathResolutionTest
+	echo "Running I/Q bridge framing tests..."
+	python3 -m unittest discover -s test -p 'test_*.py'
 	echo "I/Q tests passed."
-	
+
 # Documentation checks
 .PHONY: check-docs
 check-docs:

--- a/iq/test/test_iq_bridge.py
+++ b/iq/test/test_iq_bridge.py
@@ -1,0 +1,73 @@
+#!/usr/bin/env python3
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: MIT
+
+import os
+import sys
+import unittest
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+from iq_bridge import MCPBridgeWithReconnect
+
+
+class FakeSocket:
+    def __init__(self, recv_chunks):
+        self.recv_chunks = list(recv_chunks)
+        self.sent = []
+        self.closed = False
+
+    def send(self, data):
+        self.sent.append(data)
+        return len(data)
+
+    def recv(self, _size):
+        if self.recv_chunks:
+            return self.recv_chunks.pop(0)
+        return b""
+
+    def close(self):
+        self.closed = True
+
+
+class IQBridgeFramingTest(unittest.TestCase):
+    def make_bridge(self, recv_chunks):
+        bridge = MCPBridgeWithReconnect()
+        bridge.isabelle_socket = FakeSocket(recv_chunks)
+        bridge.connected = True
+        return bridge
+
+    def test_fragmented_response_reads(self):
+        bridge = self.make_bridge(
+            [
+                b'{"jsonrpc":"2.0","id":"1","res',
+                b'ult":{"ok":true}}\n',
+            ]
+        )
+
+        response = bridge.forward_to_isabelle(
+            {"jsonrpc": "2.0", "id": "1", "method": "tools/call", "params": {}}
+        )
+
+        self.assertEqual(response, {"jsonrpc": "2.0", "id": "1", "result": {"ok": True}})
+
+    def test_back_to_back_responses_are_queued(self):
+        bridge = self.make_bridge(
+            [
+                b'{"jsonrpc":"2.0","id":"1","result":1}\n{"jsonrpc":"2.0","id":"2","result":2}\n',
+            ]
+        )
+
+        response1 = bridge.forward_to_isabelle(
+            {"jsonrpc": "2.0", "id": "1", "method": "tools/call", "params": {}}
+        )
+        response2 = bridge.forward_to_isabelle(
+            {"jsonrpc": "2.0", "id": "2", "method": "tools/call", "params": {}}
+        )
+
+        self.assertEqual(response1, {"jsonrpc": "2.0", "id": "1", "result": 1})
+        self.assertEqual(response2, {"jsonrpc": "2.0", "id": "2", "result": 2})
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
- Replace timeout-based whole-buffer JSON parsing in `iq_bridge.py` with incremental newline-delimited framing.
- Add persistent receive buffer + parsed response queue so fragmented reads and back-to-back responses are handled correctly.
- Ensure each request consumes exactly one complete JSON-RPC response while preserving additional complete messages for subsequent requests.
- Add regression tests in `iq/test/test_iq_bridge.py` for:
  - split/fragmented socket frames
  - multiple responses delivered in a single read
- Add `iq/Makefile` `test` target to run Python bridge tests.
- Ignore generated bridge log output via `iq/.gitignore`.

Closes #94.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
