### PR TITLE
Guarantee exactly-once I/Q operation deactivation across all async paths

### DIFF
--- a/isabelle-assistant/src/IQOperationLifecycle.scala
+++ b/isabelle-assistant/src/IQOperationLifecycle.scala
@@ -1,0 +1,67 @@
+/* Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+   SPDX-License-Identifier: MIT */
+
+package isabelle.assistant
+
+import isabelle.{GUI_Thread, Isabelle_Thread}
+
+/**
+ * Shared lifecycle guard for asynchronous I/Q operations.
+ * Ensures completion/deactivation happens exactly once across success/failure/timeout races.
+ */
+final class IQOperationLifecycle[A](
+  onComplete: A => Unit,
+  deactivate: () => Unit
+) {
+  private val lock = new Object()
+  @volatile private var completed = false
+  @volatile private var timeoutThread: Thread = null
+
+  def isCompleted: Boolean = completed
+
+  def setTimeoutThread(thread: Thread): Unit = {
+    timeoutThread = thread
+  }
+
+  /** Complete from non-timeout path and interrupt timeout watcher. */
+  def complete(result: A): Unit = {
+    finish(result, interruptTimeout = true)
+  }
+
+  /** Complete from timeout path without self-interrupting timeout thread. */
+  def completeFromTimeout(result: A): Unit = {
+    finish(result, interruptTimeout = false)
+  }
+
+  /** Spawn timeout watcher that completes with the given timeout result. */
+  def forkTimeout(name: String, timeoutMs: Long)(timeoutResult: => A): Thread = {
+    val thread = Isabelle_Thread.fork(name = name) {
+      try {
+        Thread.sleep(timeoutMs)
+        completeFromTimeout(timeoutResult)
+      } catch {
+        case _: InterruptedException => ()
+      }
+    }
+    setTimeoutThread(thread)
+    thread
+  }
+
+  private def finish(result: A, interruptTimeout: Boolean): Unit = {
+    var shouldRun = false
+    lock.synchronized {
+      if (!completed) {
+        completed = true
+        shouldRun = true
+      }
+    }
+    if (shouldRun) {
+      if (interruptTimeout) Option(timeoutThread).foreach(_.interrupt())
+      try {
+        onComplete(result)
+      } finally {
+        GUI_Thread.later { deactivate() }
+      }
+    }
+  }
+}

--- a/isabelle-assistant/src/test/scala/IQOperationLifecycleTest.scala
+++ b/isabelle-assistant/src/test/scala/IQOperationLifecycleTest.scala
@@ -1,0 +1,97 @@
+/* Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+   SPDX-License-Identifier: MIT */
+
+package isabelle.assistant
+
+import org.scalatest.funsuite.AnyFunSuite
+import org.scalatest.matchers.should.Matchers
+import java.util.concurrent.{CountDownLatch, TimeUnit}
+import java.util.concurrent.atomic.AtomicInteger
+
+class IQOperationLifecycleTest extends AnyFunSuite with Matchers {
+
+  test("complete should invoke callback and deactivate exactly once") {
+    val completionLatch = new CountDownLatch(1)
+    val deactivateLatch = new CountDownLatch(1)
+    val deactivateCount = new AtomicInteger(0)
+    val values = scala.collection.mutable.ListBuffer[String]()
+
+    val lifecycle = new IQOperationLifecycle[String](
+      onComplete = value => {
+        values.synchronized { values += value }
+        completionLatch.countDown()
+      },
+      deactivate = () => {
+        deactivateCount.incrementAndGet()
+        deactivateLatch.countDown()
+      }
+    )
+
+    lifecycle.complete("first")
+    lifecycle.complete("second")
+
+    completionLatch.await(1, TimeUnit.SECONDS) shouldBe true
+    deactivateLatch.await(1, TimeUnit.SECONDS) shouldBe true
+    Thread.sleep(50)
+
+    values.synchronized { values.toList } shouldBe List("first")
+    deactivateCount.get shouldBe 1
+  }
+
+  test("non-timeout completion should win over timeout watcher") {
+    val completionLatch = new CountDownLatch(1)
+    val deactivateLatch = new CountDownLatch(1)
+    val deactivateCount = new AtomicInteger(0)
+    val values = scala.collection.mutable.ListBuffer[String]()
+
+    val lifecycle = new IQOperationLifecycle[String](
+      onComplete = value => {
+        values.synchronized { values += value }
+        completionLatch.countDown()
+      },
+      deactivate = () => {
+        deactivateCount.incrementAndGet()
+        deactivateLatch.countDown()
+      }
+    )
+
+    lifecycle.forkTimeout(name = "iq-lifecycle-timeout-1", timeoutMs = 200)("timeout")
+    lifecycle.complete("success")
+
+    completionLatch.await(1, TimeUnit.SECONDS) shouldBe true
+    deactivateLatch.await(1, TimeUnit.SECONDS) shouldBe true
+    Thread.sleep(300)
+
+    values.synchronized { values.toList } shouldBe List("success")
+    deactivateCount.get shouldBe 1
+  }
+
+  test("timeout completion should deactivate exactly once and ignore late completions") {
+    val completionLatch = new CountDownLatch(1)
+    val deactivateLatch = new CountDownLatch(1)
+    val deactivateCount = new AtomicInteger(0)
+    val values = scala.collection.mutable.ListBuffer[String]()
+
+    val lifecycle = new IQOperationLifecycle[String](
+      onComplete = value => {
+        values.synchronized { values += value }
+        completionLatch.countDown()
+      },
+      deactivate = () => {
+        deactivateCount.incrementAndGet()
+        deactivateLatch.countDown()
+      }
+    )
+
+    lifecycle.forkTimeout(name = "iq-lifecycle-timeout-2", timeoutMs = 50)("timeout")
+
+    completionLatch.await(1, TimeUnit.SECONDS) shouldBe true
+    deactivateLatch.await(1, TimeUnit.SECONDS) shouldBe true
+
+    lifecycle.complete("late")
+    Thread.sleep(50)
+
+    values.synchronized { values.toList } shouldBe List("timeout")
+    deactivateCount.get shouldBe 1
+  }
+}


### PR DESCRIPTION
- Add `IQOperationLifecycle` guard to centralize completion/timeout cleanup and enforce exactly-once `deactivate()` semantics.
- Refactor all assistant-side `Extended_Query_Operation` flows to use the guard:
  - `verifyProofAsync`
  - `executeStepAsync`
  - `runFindTheoremsAsync`
  - `runQueryAsync`
  - `runSledgehammerAsync`
  - `ContextFetcher.fetchDefinitions`
- Ensure cleanup now runs on every terminal path: success, failed status, timeout, and setup exceptions.
- Preserve race safety by interrupting timeout watchers on non-timeout completion.
- Add lifecycle race regression tests in `IQOperationLifecycleTest` verifying:
  - callback/deactivation happen exactly once
  - non-timeout completion beats timeout
  - timeout completion ignores late completions

Closes #96.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
