### PR TITLE
Type tool args/roles and enforce stricter Scala compilation

### DIFF
--- a/isabelle-assistant/Makefile
+++ b/isabelle-assistant/Makefile
@@ -11,6 +11,7 @@ JEDIT_DIR := $(shell ls -d $(ISABELLE_HOME)/contrib/jedit-* 2>/dev/null | head -
 JEDIT_JAR ?= $(JEDIT_DIR)/jedit5.7.0-patched/jedit.jar
 SCALA_HOME ?= $(ISABELLE_HOME)/contrib/scala-3.3.4
 SCALAC ?= $(SCALA_HOME)/bin/scalac
+SCALAC_FLAGS ?= -deprecation -feature -unchecked -Werror
 ISABELLE_JAR ?= $(ISABELLE_HOME)/lib/classes/isabelle.jar
 JAVA_HOME ?= $(shell $(ISABELLE) getenv -b JAVA_HOME 2>/dev/null)
 JAVA ?= $(if $(JAVA_HOME),$(JAVA_HOME)/bin/java,java)
@@ -84,6 +85,7 @@ $(CLASSES_DIR)/.libs: $(LIB_JARS) | $(CLASSES_DIR)
 $(CLASSES_DIR)/.compiled: $(SCALA_SOURCES) | $(CLASSES_DIR)
 	echo "Compiling..."
 	$(JAVA_ENV) $(SCALAC) \
+		$(SCALAC_FLAGS) \
 		-classpath "$(JEDIT_JAR):$(ISABELLE_JAR):$(SCALA_SWING_JAR):$(LIB_CLASSPATH):$(IQ_CLASSPATH)" \
 		-d $(CLASSES_DIR) \
 		$(SCALA_SOURCES)
@@ -117,6 +119,7 @@ test: build fetch-test-deps check-test-sanity verify-test-coverage
 	echo "Compiling tests..."
 	mkdir -p $(TEST_CLASSES_DIR)
 	$(JAVA_ENV) $(SCALAC) \
+		$(SCALAC_FLAGS) \
 		-classpath "$(JEDIT_JAR):$(ISABELLE_JAR):$(SCALA_SWING_JAR):$(LIB_CLASSPATH):$(IQ_CLASSPATH):$(CLASSES_DIR):$(TEST_CLASSPATH)" \
 		-d $(TEST_CLASSES_DIR) \
 		$(TEST_SOURCES)
@@ -196,6 +199,7 @@ debug:
 	echo "JEDIT_JAR     = $(JEDIT_JAR)"
 	echo "ISABELLE_JAR  = $(ISABELLE_JAR)"
 	echo "SCALA_HOME    = $(SCALA_HOME)"
+	echo "SCALAC_FLAGS  = $(SCALAC_FLAGS)"
 	echo "JAVA_HOME     = $(JAVA_HOME)"
 	echo "JAVA          = $(JAVA)"
 	echo "JAR           = $(JAR)"

--- a/isabelle-assistant/src/test/scala/ChatActionTest.scala
+++ b/isabelle-assistant/src/test/scala/ChatActionTest.scala
@@ -31,8 +31,8 @@ class ChatActionTest extends AnyFunSuite with Matchers {
 
   test("transient messages should be filterable") {
     ChatAction.clearHistory()
-    ChatAction.addMessage(ChatAction.Message("user", "regular", java.time.LocalDateTime.now()))
-    ChatAction.addMessage(ChatAction.Message("assistant", "transient", java.time.LocalDateTime.now(), transient = true))
+    ChatAction.addMessage(ChatAction.Message(ChatAction.User, "regular", java.time.LocalDateTime.now()))
+    ChatAction.addMessage(ChatAction.Message(ChatAction.Assistant, "transient", java.time.LocalDateTime.now(), transient = true))
     
     val all = ChatAction.getHistorySnapshot
     all.length shouldBe 2

--- a/isabelle-assistant/src/test/scala/ResponseParserTest.scala
+++ b/isabelle-assistant/src/test/scala/ResponseParserTest.scala
@@ -97,7 +97,8 @@ class ResponseParserTest extends AnyFunSuite with Matchers {
     val toolUse = blocks(1).asInstanceOf[ResponseParser.ToolUseBlock]
     toolUse.id shouldBe "toolu_123"
     toolUse.name shouldBe "read_theory"
-    toolUse.input("theory") shouldBe "Foo.thy"
+    toolUse.input("theory") shouldBe ResponseParser.StringValue("Foo.thy")
+    toolUse.input("start_line") shouldBe ResponseParser.IntValue(1)
     stopReason shouldBe "tool_use"
   }
 
@@ -118,7 +119,7 @@ class ResponseParserTest extends AnyFunSuite with Matchers {
     val (blocks, _) = ResponseParser.parseAnthropicContentBlocks(json)
     blocks should have length 1
     val tu = blocks.head.asInstanceOf[ResponseParser.ToolUseBlock]
-    tu.input("proof") shouldBe "by simp"
+    tu.input("proof") shouldBe ResponseParser.StringValue("by simp")
   }
 
   test("parseAnthropicContentBlocks should handle tool_use with numeric input") {
@@ -130,9 +131,9 @@ class ResponseParserTest extends AnyFunSuite with Matchers {
     }"""
     val (blocks, _) = ResponseParser.parseAnthropicContentBlocks(json)
     val tu = blocks.head.asInstanceOf[ResponseParser.ToolUseBlock]
-    tu.input("theory") shouldBe "Foo"
-    tu.input("start_line") shouldBe 10
-    tu.input("end_line") shouldBe 20
+    tu.input("theory") shouldBe ResponseParser.StringValue("Foo")
+    tu.input("start_line") shouldBe ResponseParser.IntValue(10)
+    tu.input("end_line") shouldBe ResponseParser.IntValue(20)
   }
 
   test("parseAnthropicContentBlocks should handle tool_use with boolean input") {
@@ -144,7 +145,7 @@ class ResponseParserTest extends AnyFunSuite with Matchers {
     }"""
     val (blocks, _) = ResponseParser.parseAnthropicContentBlocks(json)
     val tu = blocks.head.asInstanceOf[ResponseParser.ToolUseBlock]
-    tu.input("exact") shouldBe true
+    tu.input("exact") shouldBe ResponseParser.BooleanValue(true)
   }
 
   test("parseAnthropicContentBlocks should handle multiple tool_use blocks") {
@@ -171,8 +172,8 @@ class ResponseParserTest extends AnyFunSuite with Matchers {
     val (blocks, _) = ResponseParser.parseAnthropicContentBlocks(json)
     val tu = blocks.head.asInstanceOf[ResponseParser.ToolUseBlock]
     // Nested objects are serialized as JSON strings
-    tu.input("config").toString should include("key")
-    tu.input("config").toString should include("value")
+    ResponseParser.toolValueToDisplay(tu.input("config")) should include("key")
+    ResponseParser.toolValueToDisplay(tu.input("config")) should include("value")
   }
 
   test("parseAnthropicContentBlocks should handle nested array in tool input") {
@@ -184,7 +185,7 @@ class ResponseParserTest extends AnyFunSuite with Matchers {
     }"""
     val (blocks, _) = ResponseParser.parseAnthropicContentBlocks(json)
     val tu = blocks.head.asInstanceOf[ResponseParser.ToolUseBlock]
-    tu.input("items").toString should include("1")
+    ResponseParser.toolValueToDisplay(tu.input("items")) should include("1")
   }
 
   test("parseAnthropicContentBlocks should handle missing stop_reason") {
@@ -200,8 +201,8 @@ class ResponseParserTest extends AnyFunSuite with Matchers {
     blocks.length shouldBe 1
     blocks.head match {
       case ResponseParser.ToolUseBlock(_, _, input) =>
-        input("line") shouldBe 188  // Int not Double
-        input("valid") shouldBe 25  // Int not Double
+        input("line") shouldBe ResponseParser.IntValue(188)  // Int not Double
+        input("valid") shouldBe ResponseParser.IntValue(25)  // Int not Double
       case _ => fail("Expected ToolUseBlock")
     }
   }
@@ -212,8 +213,8 @@ class ResponseParserTest extends AnyFunSuite with Matchers {
     blocks.length shouldBe 1
     blocks.head match {
       case ResponseParser.ToolUseBlock(_, _, input) =>
-        input("temp") shouldBe 0.5  // Double preserved
-        input("ratio") shouldBe 3.14  // Double preserved
+        input("temp") shouldBe ResponseParser.DecimalValue(0.5)  // Double preserved
+        input("ratio") shouldBe ResponseParser.DecimalValue(3.14)  // Double preserved
       case _ => fail("Expected ToolUseBlock")
     }
   }


### PR DESCRIPTION
- Replace dynamic tool argument plumbing (`Map[String, Any]`) with typed `ToolValue`/`ToolArgs` in `ResponseParser`, and wire it through tool parsing, execution, and serialization
- Refactor Anthropic content parsing to produce typed tool inputs
- Introduce `ChatRole` enum for chat message roles and migrate internal message handling away from stringly-typed roles
- Replace ad-hoc tool parameter JSON parsing in `AssistantDockable` with shared typed parser logic
- Update `AssistantTools` argument extraction/coercion to handle typed tool values explicitly
- Tighten Scala build flags in `Makefile` with `-deprecation -feature -unchecked -Werror` for both main and test compilation
- Update tests to assert typed tool values and enum-backed chat roles

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
