### PR TITLE
Extend Micro Rust sugar (tuples, macros, slices, struct patterns)

### DIFF
--- a/Micro_Rust_Parsing_Frontend/Micro_Rust_Syntax.thy
+++ b/Micro_Rust_Parsing_Frontend/Micro_Rust_Syntax.thy
@@ -242,6 +242,26 @@ syntax
     ("_'.4" [998]998)
   "_urust_tuple_index_5" :: "urust \<Rightarrow> urust"
     ("_'.5" [998]998)
+  "_urust_tuple_index_6" :: "urust \<Rightarrow> urust"
+    ("_'.6" [998]998)
+  "_urust_tuple_index_7" :: "urust \<Rightarrow> urust"
+    ("_'.7" [998]998)
+  "_urust_tuple_index_8" :: "urust \<Rightarrow> urust"
+    ("_'.8" [998]998)
+  "_urust_tuple_index_9" :: "urust \<Rightarrow> urust"
+    ("_'.9" [998]998)
+  "_urust_tuple_index_10" :: "urust \<Rightarrow> urust"
+    ("_'.10" [998]998)
+  "_urust_tuple_index_11" :: "urust \<Rightarrow> urust"
+    ("_'.11" [998]998)
+  "_urust_tuple_index_12" :: "urust \<Rightarrow> urust"
+    ("_'.12" [998]998)
+  "_urust_tuple_index_13" :: "urust \<Rightarrow> urust"
+    ("_'.13" [998]998)
+  "_urust_tuple_index_14" :: "urust \<Rightarrow> urust"
+    ("_'.14" [998]998)
+  "_urust_tuple_index_15" :: "urust \<Rightarrow> urust"
+    ("_'.15" [998]998)
   \<comment>\<open>Array literals: [e0, e1, ...]. Lowered to Cons/Nil lists.\<close>
   "_urust_array_expr_empty" :: \<open>urust\<close>
     ("'[]")
@@ -419,6 +439,10 @@ syntax
     ("_/ {/ _/ }" [1000, 0] 1000)
   "_urust_match_pattern_struct_field" :: \<open>urust_identifier \<Rightarrow> urust_pattern \<Rightarrow> urust_pattern_struct_field\<close>
     ("_ :/ _" [1000, 100] 1000)
+  "_urust_match_pattern_struct_field_short" :: \<open>urust_identifier \<Rightarrow> urust_pattern_struct_field\<close>
+    ("_" [1000]1000)
+  "_urust_match_pattern_struct_rest" :: \<open>urust_pattern_struct_field\<close>
+    ("..")
   "_urust_match_pattern_struct_fields_single" :: \<open>urust_pattern_struct_field \<Rightarrow> urust_pattern_struct_fields\<close>
     ("_")
   "_urust_match_pattern_struct_fields_app" :: \<open>urust_pattern_struct_field \<Rightarrow> urust_pattern_struct_fields \<Rightarrow> urust_pattern_struct_fields\<close>
@@ -564,6 +588,8 @@ translations
   \<comment>\<open>Rust slice literals (&[...]) are currently front-end sugar for list literals.\<close>
   "_urust_borrow (_urust_array_expr_empty)" => "_urust_array_expr_empty"
   "_urust_borrow (_urust_array_expr args)" => "_urust_array_expr args"
+  "_urust_borrow_mut (_urust_array_expr_empty)" => "_urust_array_expr_empty"
+  "_urust_borrow_mut (_urust_array_expr args)" => "_urust_array_expr args"
   "_urust_if_then_else_if c t c' t'" => "_urust_if_then_else c t (_urust_if_then c' t')"
   "_urust_if_then_else_if_else c t c' t' e" => "_urust_if_then_else c t (_urust_if_then_else c' t' e)"
   "_urust_sequence_if_then_else c t e next" => "_urust_sequence (_urust_if_then_else c t e) next"

--- a/Shallow_Micro_Rust/Micro_Rust_Shallow_Embedding.thy
+++ b/Shallow_Micro_Rust/Micro_Rust_Shallow_Embedding.thy
@@ -480,6 +480,26 @@ translations
     \<rightleftharpoons> "CONST tuple_index_4 (_shallow arg)"
   "_shallow (_urust_tuple_index_5 arg)"
     \<rightleftharpoons> "CONST tuple_index_5 (_shallow arg)"
+  "_shallow (_urust_tuple_index_6 arg)"
+    \<rightleftharpoons> "CONST tuple_index_6 (_shallow arg)"
+  "_shallow (_urust_tuple_index_7 arg)"
+    \<rightleftharpoons> "CONST tuple_index_7 (_shallow arg)"
+  "_shallow (_urust_tuple_index_8 arg)"
+    \<rightleftharpoons> "CONST tuple_index_8 (_shallow arg)"
+  "_shallow (_urust_tuple_index_9 arg)"
+    \<rightleftharpoons> "CONST tuple_index_9 (_shallow arg)"
+  "_shallow (_urust_tuple_index_10 arg)"
+    \<rightleftharpoons> "CONST tuple_index_10 (_shallow arg)"
+  "_shallow (_urust_tuple_index_11 arg)"
+    \<rightleftharpoons> "CONST tuple_index_11 (_shallow arg)"
+  "_shallow (_urust_tuple_index_12 arg)"
+    \<rightleftharpoons> "CONST tuple_index_12 (_shallow arg)"
+  "_shallow (_urust_tuple_index_13 arg)"
+    \<rightleftharpoons> "CONST tuple_index_13 (_shallow arg)"
+  "_shallow (_urust_tuple_index_14 arg)"
+    \<rightleftharpoons> "CONST tuple_index_14 (_shallow arg)"
+  "_shallow (_urust_tuple_index_15 arg)"
+    \<rightleftharpoons> "CONST tuple_index_15 (_shallow arg)"
   "_shallow_let_pattern (_urust_let_pattern_tuple args)"
     \<rightleftharpoons> "_shallow_let_pattern_args args"
   "_shallow_let_pattern_args (_urust_let_pattern_tuple_base_pair fst_pat snd_pat)"
@@ -509,6 +529,10 @@ translations
   "_shallow (_urust_borrow (_urust_array_expr_empty))"
     \<rightharpoonup> "_shallow (_urust_array_expr_empty)"
   "_shallow (_urust_borrow (_urust_array_expr args))"
+    \<rightharpoonup> "_shallow (_urust_array_expr args)"
+  "_shallow (_urust_borrow_mut (_urust_array_expr_empty))"
+    \<rightharpoonup> "_shallow (_urust_array_expr_empty)"
+  "_shallow (_urust_borrow_mut (_urust_array_expr args))"
     \<rightharpoonup> "_shallow (_urust_array_expr args)"
   "_shallow (_urust_borrow exp)"
     \<rightharpoonup> "CONST bindlift1 (CONST ro_ref_from_ref) (_shallow exp)"
@@ -555,20 +579,58 @@ translations
   "_shallow_apply_params f (_urust_param_single p)"
     \<rightharpoonup> "f p"
 
-  (* Explicit translations for specific macro forms. More may be added as needed *)
+  (* Explicit translations for specific macro forms. *)
+  "_shallow (_urust_macro_no_args (URUST_CONST panic))"
+    \<rightharpoonup> "CONST panic (CONST String.implode [])"
+  "_shallow (_urust_macro_no_args (URUST_CONST unimplemented))"
+    \<rightharpoonup> "CONST unimplemented (CONST String.implode [])"
+  "_shallow (_urust_macro_no_args (URUST_CONST todo))"
+    \<rightharpoonup> "CONST unimplemented (CONST String.implode [])"
+  "_shallow (_urust_macro_no_args (URUST_CONST fatal))"
+    \<rightharpoonup> "CONST fatal (CONST String.implode [])"
+
   "_shallow (_urust_macro_with_args
       (URUST_CONST assert) (_urust_args_single exp))"
+    \<rightharpoonup> "CONST assert (_shallow exp)"
+  "_shallow (_urust_macro_with_args
+      (URUST_CONST assert) (_urust_args_app exp rest))"
     \<rightharpoonup> "CONST assert (_shallow exp)"
   "_shallow (_urust_macro_with_args
       (URUST_CONST debug_assert) (_urust_args_single exp))"
     \<rightharpoonup> "CONST assert (_shallow exp)"
   "_shallow (_urust_macro_with_args
+      (URUST_CONST debug_assert) (_urust_args_app exp rest))"
+    \<rightharpoonup> "CONST assert (_shallow exp)"
+
+  "_shallow (_urust_macro_with_args
       (URUST_CONST assert_ne) (_urust_args_app expA (_urust_args_single expB)))"
+    \<rightharpoonup> "CONST assert_ne (_shallow expA) (_shallow expB)"
+  "_shallow (_urust_macro_with_args
+      (URUST_CONST assert_ne) (_urust_args_app expA (_urust_args_app expB rest)))"
     \<rightharpoonup> "CONST assert_ne (_shallow expA) (_shallow expB)"
   "_shallow (_urust_macro_with_args
       (URUST_CONST assert_eq) (_urust_args_app expA (_urust_args_single expB)))"
     \<rightharpoonup> "CONST assert_eq (_shallow expA) (_shallow expB)"
+  "_shallow (_urust_macro_with_args
+      (URUST_CONST assert_eq) (_urust_args_app expA (_urust_args_app expB rest)))"
+    \<rightharpoonup> "CONST assert_eq (_shallow expA) (_shallow expB)"
+  "_shallow (_urust_macro_with_args
+      (URUST_CONST debug_assert_ne) (_urust_args_app expA (_urust_args_single expB)))"
+    \<rightharpoonup> "CONST assert_ne (_shallow expA) (_shallow expB)"
+  "_shallow (_urust_macro_with_args
+      (URUST_CONST debug_assert_ne) (_urust_args_app expA (_urust_args_app expB rest)))"
+    \<rightharpoonup> "CONST assert_ne (_shallow expA) (_shallow expB)"
+  "_shallow (_urust_macro_with_args
+      (URUST_CONST debug_assert_eq) (_urust_args_app expA (_urust_args_single expB)))"
+    \<rightharpoonup> "CONST assert_eq (_shallow expA) (_shallow expB)"
+  "_shallow (_urust_macro_with_args
+      (URUST_CONST debug_assert_eq) (_urust_args_app expA (_urust_args_app expB rest)))"
+    \<rightharpoonup> "CONST assert_eq (_shallow expA) (_shallow expB)"
 
+  "_shallow (_urust_macro_with_args
+       (URUST_CONST panic) (_urust_args_app first rest))"
+    \<rightharpoonup> "_shallow (_urust_macro_with_args
+       (URUST_CONST panic) (_urust_args_single first))"
   "_shallow (_urust_macro_with_args
        (URUST_CONST panic) (_urust_args_single (_urust_identifier a)))"
     \<rightharpoonup> "CONST panic (_shallow_identifier_as_literal a)"
@@ -580,6 +642,10 @@ translations
     \<rightharpoonup> "CONST panic (_string_token_to_hol str)"
 
   "_shallow (_urust_macro_with_args
+       (URUST_CONST unimplemented) (_urust_args_app first rest))"
+    \<rightharpoonup> "_shallow (_urust_macro_with_args
+       (URUST_CONST unimplemented) (_urust_args_single first))"
+  "_shallow (_urust_macro_with_args
        (URUST_CONST unimplemented) (_urust_args_single (_urust_identifier a)))"
     \<rightharpoonup> "CONST unimplemented (_shallow_identifier_as_literal a)"
   "_shallow (_urust_macro_with_args
@@ -590,9 +656,23 @@ translations
     \<rightharpoonup> "CONST unimplemented (_string_token_to_hol str)"
 
   "_shallow (_urust_macro_with_args
+       (URUST_CONST todo) (_urust_args_app first rest))"
+    \<rightharpoonup> "_shallow (_urust_macro_with_args
+       (URUST_CONST todo) (_urust_args_single first))"
+  "_shallow (_urust_macro_with_args
+       (URUST_CONST todo) (_urust_args_single (_urust_identifier a)))"
+    \<rightharpoonup> "CONST unimplemented (_shallow_identifier_as_literal a)"
+  "_shallow (_urust_macro_with_args
+       (URUST_CONST todo) (_urust_args_single (_urust_literal x)))"
+    \<rightharpoonup> "CONST unimplemented (CONST String.implode x)"
+  "_shallow (_urust_macro_with_args
        (URUST_CONST todo) (_urust_args_single (_urust_string_token str)))"
     \<rightharpoonup> "CONST unimplemented (_string_token_to_hol str)"
 
+  "_shallow (_urust_macro_with_args
+       (URUST_CONST fatal) (_urust_args_app first rest))"
+    \<rightharpoonup> "_shallow (_urust_macro_with_args
+       (URUST_CONST fatal) (_urust_args_single first))"
   "_shallow (_urust_macro_with_args
        (URUST_CONST fatal) (_urust_args_single (_urust_identifier a)))"
     \<rightharpoonup> "CONST fatal (_shallow_identifier_as_literal a)"
@@ -865,19 +945,43 @@ ML\<open>
       fun mk_args [p] = mk \<^syntax_const>\<open>_urust_match_pattern_args_single\<close> $ p
         | mk_args (p :: ps) = mk \<^syntax_const>\<open>_urust_match_pattern_args_app\<close> $ p $ mk_args ps
         | mk_args [] = error "struct pattern: empty field list"
+      fun mk_pattern_shorthand fld =
+        mk \<^syntax_const>\<open>_urust_match_pattern_constr_no_args\<close> $ fld
 
       fun struct_field_destruct
             (Const (\<^syntax_const>\<open>_urust_match_pattern_struct_field\<close>, _) $ fld $ p) =
-              (canonical_name (dest_ident_name ctxt fld), p)
+              (SOME (canonical_name (dest_ident_name ctxt fld), p), false)
+        | struct_field_destruct
+            (Const (\<^syntax_const>\<open>_urust_match_pattern_struct_field_short\<close>, _) $ fld) =
+              (SOME (canonical_name (dest_ident_name ctxt fld), mk_pattern_shorthand fld), false)
+        | struct_field_destruct
+            (Const (\<^syntax_const>\<open>_urust_match_pattern_struct_rest\<close>, _)) =
+              (NONE, true)
         | struct_field_destruct t =
             error ("struct pattern: invalid field syntax: " ^ Syntax.string_of_term ctxt t)
 
       fun struct_fields_destruct
             (Const (\<^syntax_const>\<open>_urust_match_pattern_struct_fields_single\<close>, _) $ fld) =
-              [struct_field_destruct fld]
+              (case struct_field_destruct fld of
+                (SOME e, has_rest) => ([e], has_rest)
+              | (NONE, has_rest) => ([], has_rest))
         | struct_fields_destruct
             (Const (\<^syntax_const>\<open>_urust_match_pattern_struct_fields_app\<close>, _) $ fld $ rest) =
-              struct_field_destruct fld :: struct_fields_destruct rest
+              let
+                val (entry_opt, has_rest0) = struct_field_destruct fld
+                val (rest_entries, has_rest1) = struct_fields_destruct rest
+                val _ =
+                  if has_rest0 andalso has_rest1 then
+                    error "struct pattern: multiple `..` rest entries"
+                  else
+                    ()
+                val entries =
+                  (case entry_opt of
+                    SOME e => e :: rest_entries
+                  | NONE => rest_entries)
+              in
+                (entries, has_rest0 orelse has_rest1)
+              end
         | struct_fields_destruct t =
             error ("struct pattern: invalid field list syntax: " ^ Syntax.string_of_term ctxt t)
 
@@ -889,7 +993,7 @@ ML\<open>
               SOME n => canonical_name n
             | NONE => dest_ident_name ctxt id)
           val selector_names = map (canonical_name o dest_ident_name ctxt) sels
-          val field_entries = struct_fields_destruct fields
+          val (field_entries, is_open) = struct_fields_destruct fields
           val field_names = map fst field_entries
           fun is_optional_selector s = (s = "more")
           val duplicate_fields = Library.duplicates (op =) field_names
@@ -900,8 +1004,11 @@ ML\<open>
           val extra_fields =
             filter (fn f => not (member (op =) selector_names f)) field_names
           val missing_fields =
-            filter (fn s =>
-              not (member (op =) field_names s) andalso not (is_optional_selector s)) selector_names
+            if is_open then
+              []
+            else
+              filter (fn s =>
+                not (member (op =) field_names s) andalso not (is_optional_selector s)) selector_names
           val _ =
             if null extra_fields then ()
             else error ("struct pattern for " ^ quote ctor_name ^ " has unknown field(s): " ^
@@ -915,7 +1022,8 @@ ML\<open>
               (case AList.lookup (op =) field_entries s of
                 SOME p => p
               | NONE =>
-                  if is_optional_selector s then Syntax.const \<^syntax_const>\<open>_urust_match_pattern_other\<close>
+                  if is_optional_selector s orelse is_open then
+                    Syntax.const \<^syntax_const>\<open>_urust_match_pattern_other\<close>
                   else error ("internal error: struct field lookup failed for " ^ quote s))) selector_names
         in
           mk \<^syntax_const>\<open>_urust_match_pattern_constr_with_args\<close> $ ctor $ mk_args ordered_pats

--- a/Shallow_Micro_Rust/Micro_Rust_Shallow_Embedding_Tests.thy
+++ b/Shallow_Micro_Rust/Micro_Rust_Shallow_Embedding_Tests.thy
@@ -1025,6 +1025,22 @@ term\<open>\<lbrakk>
   assert!(res == \<llangle>21 :: 32 word\<rrangle>)
 \<rbrakk>\<close>
 
+term\<open>\<lbrakk>
+  let res = match \<llangle>Foo (12 :: 32 word) 34\<rrangle> {
+    Foo { foo, goo } \<Rightarrow> foo + goo,
+    _ \<Rightarrow> \<llangle>0 :: 32 word\<rrangle>
+  };
+  assert!(res == \<llangle>46 :: 32 word\<rrangle>)
+\<rbrakk>\<close>
+
+term\<open>\<lbrakk>
+  let res = match \<llangle>Foo (12 :: 32 word) 34\<rrangle> {
+    Foo { foo, .. } \<Rightarrow> foo,
+    _ \<Rightarrow> \<llangle>0 :: 32 word\<rrangle>
+  };
+  assert!(res == \<llangle>12 :: 32 word\<rrangle>)
+\<rbrakk>\<close>
+
 subsubsection\<open>Struct Expressions\<close>
 
 term\<open>\<lbrakk>
@@ -1272,6 +1288,16 @@ value[simp]\<open>\<lbrakk>
   assert!(tup.3 == 3);
   assert!(tup.4 == 4);
   assert!(tup.5 == 5);
+\<rbrakk>\<close>
+
+value[simp]\<open>\<lbrakk>
+  let tup = (\<llangle>0 :: 32 word\<rrangle>, \<llangle>1 :: 32 word\<rrangle>, \<llangle>2 :: 32 word\<rrangle>, \<llangle>3 :: 32 word\<rrangle>,
+             \<llangle>4 :: 32 word\<rrangle>, \<llangle>5 :: 32 word\<rrangle>, \<llangle>6 :: 32 word\<rrangle>, \<llangle>7 :: 32 word\<rrangle>,
+             \<llangle>8 :: 32 word\<rrangle>, \<llangle>9 :: 32 word\<rrangle>, \<llangle>10 :: 32 word\<rrangle>, \<llangle>11 :: 32 word\<rrangle>,
+             \<llangle>12 :: 32 word\<rrangle>, \<llangle>13 :: 32 word\<rrangle>, \<llangle>14 :: 32 word\<rrangle>, \<llangle>15 :: 32 word\<rrangle>);
+  assert!(tup.6 == \<llangle>6 :: 32 word\<rrangle>);
+  assert!(tup.10 == \<llangle>10 :: 32 word\<rrangle>);
+  assert!(tup.15 == \<llangle>15 :: 32 word\<rrangle>)
 \<rbrakk>\<close>
 
 value[simp]\<open>\<lbrakk>
@@ -1631,6 +1657,12 @@ term\<open>\<lbrakk> assert!(b); a_value as u16\<rbrakk>\<close>
 term\<open>\<lbrakk> assert!(a_value as usize == a_value as usize); a_value as u16\<rbrakk>\<close>
 term \<open>\<lbrakk> assert_eq!(x, y) \<rbrakk>\<close>
 term \<open>\<lbrakk> assert_ne!(x, y) \<rbrakk>\<close>
+term \<open>\<lbrakk> assert!(b, "ignored assertion message") \<rbrakk>\<close>
+term \<open>\<lbrakk> debug_assert!(b, "ignored debug assertion message", x) \<rbrakk>\<close>
+term \<open>\<lbrakk> assert_eq!(x, y, "ignored assert_eq message", x) \<rbrakk>\<close>
+term \<open>\<lbrakk> assert_ne!(x, y, "ignored assert_ne message", y) \<rbrakk>\<close>
+term \<open>\<lbrakk> debug_assert_eq!(x, y, "ignored debug_assert_eq message") \<rbrakk>\<close>
+term \<open>\<lbrakk> debug_assert_ne!(x, y, "ignored debug_assert_ne message") \<rbrakk>\<close>
 end
 
 subsubsection\<open>Error Macros\<close>
@@ -1645,6 +1677,14 @@ term \<open>\<lbrakk> unimplemented!(nm) \<rbrakk>\<close>
 term \<open>\<lbrakk> todo!("oh no!") \<rbrakk>\<close>
 term \<open>\<lbrakk> fatal!("yikes!") \<rbrakk>\<close>
 term \<open>\<lbrakk> fatal!( \<llangle>''yikes!''\<rrangle> ) \<rbrakk>\<close>
+term \<open>\<lbrakk> panic!() \<rbrakk>\<close>
+term \<open>\<lbrakk> unimplemented!() \<rbrakk>\<close>
+term \<open>\<lbrakk> todo!() \<rbrakk>\<close>
+term \<open>\<lbrakk> fatal!() \<rbrakk>\<close>
+term \<open>\<lbrakk> panic!("first", msg) \<rbrakk>\<close>
+term \<open>\<lbrakk> unimplemented!("first", msg) \<rbrakk>\<close>
+term \<open>\<lbrakk> todo!("first", msg) \<rbrakk>\<close>
+term \<open>\<lbrakk> fatal!("first", msg) \<rbrakk>\<close>
 end
 
 subsubsection\<open>Logging\<close>
@@ -1671,6 +1711,8 @@ subsubsection\<open>Array and Slice Expression Literals\<close>
 
 term \<open>\<lbrakk> [\<llangle>1 :: 32 word\<rrangle>, \<llangle>2 :: 32 word\<rrangle>, \<llangle>3 :: 32 word\<rrangle>] \<rbrakk>\<close>
 term \<open>\<lbrakk> &[\<llangle>1 :: 32 word\<rrangle>, \<llangle>2 :: 32 word\<rrangle>] \<rbrakk>\<close>
+term \<open>\<lbrakk> & mut [\<llangle>1 :: 32 word\<rrangle>, \<llangle>2 :: 32 word\<rrangle>] \<rbrakk>\<close>
+term \<open>\<lbrakk> & mut [] \<rbrakk>\<close>
 term \<open>\<lbrakk> [\<llangle>1 :: 32 word\<rrangle> + \<llangle>2 :: 32 word\<rrangle>, \<llangle>3 :: 32 word\<rrangle>] \<rbrakk>\<close>
 
 value[simp]\<open>\<lbrakk>

--- a/Shallow_Micro_Rust/Tuple.thy
+++ b/Shallow_Micro_Rust/Tuple.thy
@@ -44,6 +44,46 @@ abbreviation(input) tuple_index_5 :: \<open>('s, 'arg0 \<times> 'arg1 \<times> '
                                       ('s, 'arg5, 'c, 'abort, 'i, 'o) expression\<close> where
   \<open>tuple_index_5 \<equiv> bindlift1 (fst \<circ> snd \<circ> snd \<circ> snd \<circ> snd \<circ> snd)\<close>
 
+abbreviation(input) tuple_index_6 :: \<open>('s, 'arg0 \<times> 'arg1 \<times> 'arg2 \<times> 'arg3 \<times> 'arg4 \<times> 'arg5 \<times> 'arg6 \<times> 'arg7, 'c, 'abort, 'i, 'o) expression \<Rightarrow>
+                                      ('s, 'arg6, 'c, 'abort, 'i, 'o) expression\<close> where
+  \<open>tuple_index_6 \<equiv> bindlift1 (fst \<circ> snd \<circ> snd \<circ> snd \<circ> snd \<circ> snd \<circ> snd)\<close>
+
+abbreviation(input) tuple_index_7 :: \<open>('s, 'arg0 \<times> 'arg1 \<times> 'arg2 \<times> 'arg3 \<times> 'arg4 \<times> 'arg5 \<times> 'arg6 \<times> 'arg7 \<times> 'arg8, 'c, 'abort, 'i, 'o) expression \<Rightarrow>
+                                      ('s, 'arg7, 'c, 'abort, 'i, 'o) expression\<close> where
+  \<open>tuple_index_7 \<equiv> bindlift1 (fst \<circ> snd \<circ> snd \<circ> snd \<circ> snd \<circ> snd \<circ> snd \<circ> snd)\<close>
+
+abbreviation(input) tuple_index_8 :: \<open>('s, 'arg0 \<times> 'arg1 \<times> 'arg2 \<times> 'arg3 \<times> 'arg4 \<times> 'arg5 \<times> 'arg6 \<times> 'arg7 \<times> 'arg8 \<times> 'arg9, 'c, 'abort, 'i, 'o) expression \<Rightarrow>
+                                      ('s, 'arg8, 'c, 'abort, 'i, 'o) expression\<close> where
+  \<open>tuple_index_8 \<equiv> bindlift1 (fst \<circ> snd \<circ> snd \<circ> snd \<circ> snd \<circ> snd \<circ> snd \<circ> snd \<circ> snd)\<close>
+
+abbreviation(input) tuple_index_9 :: \<open>('s, 'arg0 \<times> 'arg1 \<times> 'arg2 \<times> 'arg3 \<times> 'arg4 \<times> 'arg5 \<times> 'arg6 \<times> 'arg7 \<times> 'arg8 \<times> 'arg9 \<times> 'arg10, 'c, 'abort, 'i, 'o) expression \<Rightarrow>
+                                      ('s, 'arg9, 'c, 'abort, 'i, 'o) expression\<close> where
+  \<open>tuple_index_9 \<equiv> bindlift1 (fst \<circ> snd \<circ> snd \<circ> snd \<circ> snd \<circ> snd \<circ> snd \<circ> snd \<circ> snd \<circ> snd)\<close>
+
+abbreviation(input) tuple_index_10 :: \<open>('s, 'arg0 \<times> 'arg1 \<times> 'arg2 \<times> 'arg3 \<times> 'arg4 \<times> 'arg5 \<times> 'arg6 \<times> 'arg7 \<times> 'arg8 \<times> 'arg9 \<times> 'arg10 \<times> 'arg11, 'c, 'abort, 'i, 'o) expression \<Rightarrow>
+                                       ('s, 'arg10, 'c, 'abort, 'i, 'o) expression\<close> where
+  \<open>tuple_index_10 \<equiv> bindlift1 (fst \<circ> snd \<circ> snd \<circ> snd \<circ> snd \<circ> snd \<circ> snd \<circ> snd \<circ> snd \<circ> snd \<circ> snd)\<close>
+
+abbreviation(input) tuple_index_11 :: \<open>('s, 'arg0 \<times> 'arg1 \<times> 'arg2 \<times> 'arg3 \<times> 'arg4 \<times> 'arg5 \<times> 'arg6 \<times> 'arg7 \<times> 'arg8 \<times> 'arg9 \<times> 'arg10 \<times> 'arg11 \<times> 'arg12, 'c, 'abort, 'i, 'o) expression \<Rightarrow>
+                                       ('s, 'arg11, 'c, 'abort, 'i, 'o) expression\<close> where
+  \<open>tuple_index_11 \<equiv> bindlift1 (fst \<circ> snd \<circ> snd \<circ> snd \<circ> snd \<circ> snd \<circ> snd \<circ> snd \<circ> snd \<circ> snd \<circ> snd \<circ> snd)\<close>
+
+abbreviation(input) tuple_index_12 :: \<open>('s, 'arg0 \<times> 'arg1 \<times> 'arg2 \<times> 'arg3 \<times> 'arg4 \<times> 'arg5 \<times> 'arg6 \<times> 'arg7 \<times> 'arg8 \<times> 'arg9 \<times> 'arg10 \<times> 'arg11 \<times> 'arg12 \<times> 'arg13, 'c, 'abort, 'i, 'o) expression \<Rightarrow>
+                                       ('s, 'arg12, 'c, 'abort, 'i, 'o) expression\<close> where
+  \<open>tuple_index_12 \<equiv> bindlift1 (fst \<circ> snd \<circ> snd \<circ> snd \<circ> snd \<circ> snd \<circ> snd \<circ> snd \<circ> snd \<circ> snd \<circ> snd \<circ> snd \<circ> snd)\<close>
+
+abbreviation(input) tuple_index_13 :: \<open>('s, 'arg0 \<times> 'arg1 \<times> 'arg2 \<times> 'arg3 \<times> 'arg4 \<times> 'arg5 \<times> 'arg6 \<times> 'arg7 \<times> 'arg8 \<times> 'arg9 \<times> 'arg10 \<times> 'arg11 \<times> 'arg12 \<times> 'arg13 \<times> 'arg14, 'c, 'abort, 'i, 'o) expression \<Rightarrow>
+                                       ('s, 'arg13, 'c, 'abort, 'i, 'o) expression\<close> where
+  \<open>tuple_index_13 \<equiv> bindlift1 (fst \<circ> snd \<circ> snd \<circ> snd \<circ> snd \<circ> snd \<circ> snd \<circ> snd \<circ> snd \<circ> snd \<circ> snd \<circ> snd \<circ> snd \<circ> snd)\<close>
+
+abbreviation(input) tuple_index_14 :: \<open>('s, 'arg0 \<times> 'arg1 \<times> 'arg2 \<times> 'arg3 \<times> 'arg4 \<times> 'arg5 \<times> 'arg6 \<times> 'arg7 \<times> 'arg8 \<times> 'arg9 \<times> 'arg10 \<times> 'arg11 \<times> 'arg12 \<times> 'arg13 \<times> 'arg14 \<times> 'arg15, 'c, 'abort, 'i, 'o) expression \<Rightarrow>
+                                       ('s, 'arg14, 'c, 'abort, 'i, 'o) expression\<close> where
+  \<open>tuple_index_14 \<equiv> bindlift1 (fst \<circ> snd \<circ> snd \<circ> snd \<circ> snd \<circ> snd \<circ> snd \<circ> snd \<circ> snd \<circ> snd \<circ> snd \<circ> snd \<circ> snd \<circ> snd \<circ> snd)\<close>
+
+abbreviation(input) tuple_index_15 :: \<open>('s, 'arg0 \<times> 'arg1 \<times> 'arg2 \<times> 'arg3 \<times> 'arg4 \<times> 'arg5 \<times> 'arg6 \<times> 'arg7 \<times> 'arg8 \<times> 'arg9 \<times> 'arg10 \<times> 'arg11 \<times> 'arg12 \<times> 'arg13 \<times> 'arg14 \<times> 'arg15 \<times> 'arg16, 'c, 'abort, 'i, 'o) expression \<Rightarrow>
+                                       ('s, 'arg15, 'c, 'abort, 'i, 'o) expression\<close> where
+  \<open>tuple_index_15 \<equiv> bindlift1 (fst \<circ> snd \<circ> snd \<circ> snd \<circ> snd \<circ> snd \<circ> snd \<circ> snd \<circ> snd \<circ> snd \<circ> snd \<circ> snd \<circ> snd \<circ> snd \<circ> snd \<circ> snd)\<close>
+
 (*<*)
 end
 (*>*)


### PR DESCRIPTION
Add tuple projection grammar and lowering for .6 through .15
- frontend syntax in Micro_Rust_Syntax.thy
- shallow tuple combinators tuple_index_6 .. tuple_index_15 in Tuple.thy
- shallow translations in Micro_Rust_Shallow_Embedding.thy Extend macro lowering coverage
- no-arg forms: panic!, unimplemented!, todo!, fatal!
- tolerate extra args/messages for assert! / debug_assert!
- tolerate extra args/messages for assert_eq! / assert_ne! and debug variants
- normalize variadic panic/todo/unimplemented/fatal to first-arg lowering Add mutable slice literal sugar
- lower & mut [..] and & mut [] like existing &[..] list sugar Add struct pattern sugar
- shorthand fields (e.g. Foo { foo, goo })
- rest patterns (e.g. Foo { foo, .. }) Add dedicated syntax/lowering tests in Micro_Rust_Shallow_Embedding_Tests.thy
- tuple projection tests for higher indices
- macro no-arg/variadic tests
- struct pattern shorthand/rest tests
- mutable slice literal tests

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
