### PR TITLE
Add capability-based permissions system for LLM tool use

### DIFF
--- a/isabelle-assistant/src/AssistantDockable.scala
+++ b/isabelle-assistant/src/AssistantDockable.scala
@@ -569,6 +569,7 @@ class AssistantDockable(view: View, position: String)
   private def clearChat(): Unit = {
     ChatAction.clearHistory()
     AssistantDockable.clearInsertActions()
+    ToolPermissions.clearSession()
     htmlPane.setText("")
     badgeContainer.setVisible(false)
     welcomeShown = false

--- a/isabelle-assistant/src/AssistantPlugin.scala
+++ b/isabelle-assistant/src/AssistantPlugin.scala
@@ -16,6 +16,7 @@ class AssistantPlugin extends EBPlugin {
   override def stop(): Unit = {
     Output.writeln("Isabelle Assistant stopping...")
     AssistantDockable.shutdown()
+    ToolPermissions.clearSession()
     BedrockClient.cleanup()
     ErrorHandler.cleanupAll()
     VerificationCache.clear()

--- a/isabelle-assistant/src/BedrockClient.scala
+++ b/isabelle-assistant/src/BedrockClient.scala
@@ -413,7 +413,7 @@ object BedrockClient {
             GUI_Thread.later {
               ChatAction.addToolMessage(tu.name, tu.input)
             }
-            val result = AssistantTools.executeTool(tu.name, tu.input, view)
+            val result = AssistantTools.executeToolWithPermission(tu.name, tu.input, view)
             (tu.id, result)
           }
 

--- a/isabelle-assistant/src/PayloadBuilder.scala
+++ b/isabelle-assistant/src/PayloadBuilder.scala
@@ -193,7 +193,7 @@ object PayloadBuilder {
       g.writeNumberField("max_tokens", maxTokens)
       g.writeNumberField("temperature", temperature)
       g.writeStringField("system", systemPrompt)
-      AssistantTools.writeToolsJson(g)
+      AssistantTools.writeFilteredToolsJson(g)
       g.writeArrayFieldStart("messages")
       for ((role, content) <- messages) {
         g.writeStartObject()

--- a/isabelle-assistant/src/ToolPermissions.scala
+++ b/isabelle-assistant/src/ToolPermissions.scala
@@ -1,0 +1,313 @@
+/* Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+   SPDX-License-Identifier: MIT */
+
+package isabelle.assistant
+
+import isabelle._
+import org.gjt.sp.jedit.{jEdit, View}
+import java.util.concurrent.{CountDownLatch, TimeUnit}
+
+/**
+ * Capability-based permission system for LLM tool use.
+ * 
+ * Provides four permission levels (Deny, AskAlways, AskAtFirstUse, Allow)
+ * with per-tool defaults, session-scoped memory, and user prompting via
+ * the same UI mechanism as the ask_user tool.
+ */
+object ToolPermissions {
+
+  // --- Permission Levels ---
+
+  sealed trait PermissionLevel {
+    def toConfigString: String = this match {
+      case Deny => "Deny"
+      case AskAlways => "AskAlways"
+      case AskAtFirstUse => "AskAtFirstUse"
+      case Allow => "Allow"
+    }
+    
+    def toDisplayString: String = this match {
+      case Deny => "Deny"
+      case AskAlways => "Ask Always"
+      case AskAtFirstUse => "Ask at First Use"
+      case Allow => "Allow"
+    }
+  }
+  case object Deny extends PermissionLevel
+  case object AskAlways extends PermissionLevel
+  case object AskAtFirstUse extends PermissionLevel
+  case object Allow extends PermissionLevel
+
+  object PermissionLevel {
+    def fromString(s: String): Option[PermissionLevel] = s match {
+      case "Deny" => Some(Deny)
+      case "AskAlways" => Some(AskAlways)
+      case "AskAtFirstUse" => Some(AskAtFirstUse)
+      case "Allow" => Some(Allow)
+      case _ => None
+    }
+    
+    def fromDisplayString(s: String): Option[PermissionLevel] = s match {
+      case "Deny" => Some(Deny)
+      case "Ask Always" => Some(AskAlways)
+      case "Ask at First Use" => Some(AskAtFirstUse)
+      case "Allow" => Some(Allow)
+      case _ => None
+    }
+    
+    val displayOptions: Array[String] = Array("Deny", "Ask Always", "Ask at First Use", "Allow")
+  }
+
+  // --- Permission Decision ---
+
+  sealed trait PermissionDecision
+  case object Allowed extends PermissionDecision
+  case object Denied extends PermissionDecision
+  case class NeedPrompt(toolName: String, resource: Option[String]) extends PermissionDecision
+
+  // --- Session State ---
+
+  private val sessionLock = new Object()
+  @volatile private var sessionAllowedTools: Set[String] = Set.empty
+  @volatile private var sessionDeniedTools: Set[String] = Set.empty
+
+  /** Clear session-scoped permission decisions. Called on chat clear and plugin stop. */
+  def clearSession(): Unit = sessionLock.synchronized {
+    sessionAllowedTools = Set.empty
+    sessionDeniedTools = Set.empty
+  }
+
+  private def isSessionAllowed(toolName: String): Boolean =
+    sessionAllowedTools.contains(toolName)
+
+  private def isSessionDenied(toolName: String): Boolean =
+    sessionDeniedTools.contains(toolName)
+
+  private def setSessionAllowed(toolName: String): Unit = sessionLock.synchronized {
+    sessionAllowedTools += toolName
+    sessionDeniedTools -= toolName
+  }
+
+  private def setSessionDenied(toolName: String): Unit = sessionLock.synchronized {
+    sessionDeniedTools += toolName
+    sessionAllowedTools -= toolName
+  }
+
+  // --- Default Permission Levels ---
+
+  /** Default permission level for each tool. Consulted if no user override exists. */
+  private val defaultPermissions: Map[String, PermissionLevel] = Map(
+    // Safe read-only operations → Allow
+    "read_theory" -> Allow,
+    "list_theories" -> Allow,
+    "search_in_theory" -> Allow,
+    "search_all_theories" -> Allow,
+    "get_goal_state" -> Allow,
+    "get_proof_context" -> Allow,
+    "get_command_text" -> Allow,
+    "get_type" -> Allow,
+    "get_errors" -> Allow,
+    "get_warnings" -> Allow,
+    "get_context_info" -> Allow,
+    "get_proof_block" -> Allow,
+    "get_dependencies" -> Allow,
+    "get_entities" -> Allow,
+    "set_cursor_position" -> Allow,
+    
+    // I/Q-dependent verification (computational but non-destructive) → AskAtFirstUse
+    "verify_proof" -> AskAtFirstUse,
+    "execute_step" -> AskAtFirstUse,
+    "try_methods" -> AskAtFirstUse,
+    "find_theorems" -> AskAtFirstUse,
+    "get_definitions" -> AskAtFirstUse,
+    "run_sledgehammer" -> AskAtFirstUse,
+    "run_nitpick" -> AskAtFirstUse,
+    "run_quickcheck" -> AskAtFirstUse,
+    "trace_simplifier" -> AskAtFirstUse,
+    
+    // Side effects (file creation, modification, network) → AskAlways
+    "edit_theory" -> AskAlways,
+    "create_theory" -> AskAlways,
+    "open_theory" -> AskAlways,
+    "web_search" -> AskAlways,
+    
+    // Meta-tool for user interaction → Always Allow (exempt from permission checks)
+    "ask_user" -> Allow
+  )
+
+  /** Human-readable description of what each tool does (for permission prompts). */
+  private[assistant] val toolDescriptions: Map[String, String] = Map(
+    "read_theory" -> "read the content of theory files",
+    "list_theories" -> "list all open theory files",
+    "search_in_theory" -> "search for text patterns in theory files",
+    "search_all_theories" -> "search for text patterns across all theory files",
+    "get_goal_state" -> "check the current proof goal state",
+    "get_proof_context" -> "view local facts and assumptions",
+    "get_command_text" -> "read Isabelle command text",
+    "get_type" -> "get type information",
+    "get_errors" -> "read error messages",
+    "get_warnings" -> "read warning messages",
+    "get_context_info" -> "analyze proof context",
+    "get_proof_block" -> "read complete proof blocks",
+    "get_dependencies" -> "read theory dependencies",
+    "get_entities" -> "list definitions and lemmas",
+    "set_cursor_position" -> "move the cursor position",
+    "verify_proof" -> "verify proof methods using Isabelle",
+    "execute_step" -> "execute proof steps",
+    "try_methods" -> "try multiple proof methods",
+    "find_theorems" -> "search for theorems",
+    "get_definitions" -> "look up definitions",
+    "run_sledgehammer" -> "run automated theorem provers",
+    "run_nitpick" -> "search for counterexamples",
+    "run_quickcheck" -> "test with random examples",
+    "trace_simplifier" -> "trace simplifier operations",
+    "edit_theory" -> "modify theory file content",
+    "create_theory" -> "create new theory files",
+    "open_theory" -> "open existing theory files",
+    "web_search" -> "search the web",
+    "ask_user" -> "ask you questions"
+  )
+
+  // --- Resource Extraction ---
+
+  /** Extract a displayable resource identifier from tool arguments (e.g., theory name, URL). */
+  private def extractResource(toolName: String, args: Map[String, Any]): Option[String] = {
+    toolName match {
+      case "read_theory" | "search_in_theory" | "edit_theory" | 
+           "get_entities" | "get_dependencies" =>
+        args.get("theory").map(_.toString)
+      case "create_theory" =>
+        args.get("name").map(n => s"$n.thy")
+      case "open_theory" =>
+        args.get("path").map(_.toString)
+      case "web_search" =>
+        args.get("query").map(q => s"query: ${q.toString.take(50)}")
+      case _ => None
+    }
+  }
+
+  // --- Configuration Persistence ---
+
+  /** Get the configured permission level for a tool from jEdit properties. */
+  def getConfiguredLevel(toolName: String): PermissionLevel = {
+    // ask_user is always Allow and cannot be changed (would create recursion)
+    if (toolName == "ask_user") return Allow
+    
+    val key = s"assistant.permissions.tool.$toolName"
+    val value = jEdit.getProperty(key, "")
+    PermissionLevel.fromString(value).getOrElse(
+      defaultPermissions.getOrElse(toolName, AskAtFirstUse)
+    )
+  }
+
+  /** Set the permission level for a tool in jEdit properties. */
+  def setConfiguredLevel(toolName: String, level: PermissionLevel): Unit = {
+    if (toolName == "ask_user") return // ask_user is locked to Allow
+    val key = s"assistant.permissions.tool.$toolName"
+    jEdit.setProperty(key, level.toConfigString)
+  }
+
+  /** Reset all tool permissions to defaults. */
+  def resetToDefaults(): Unit = {
+    for ((toolName, level) <- defaultPermissions if toolName != "ask_user") {
+      setConfiguredLevel(toolName, level)
+    }
+  }
+
+  /** Get all tool names with their configured or default permission levels. */
+  def getAllToolPermissions: List[(String, PermissionLevel)] = {
+    AssistantTools.tools.map { tool =>
+      (tool.name, getConfiguredLevel(tool.name))
+    }
+  }
+
+  // --- Permission Check ---
+
+  /**
+   * Check if a tool is permitted to execute.
+   * 
+   * @param toolName The name of the tool
+   * @param args The tool arguments (for resource extraction)
+   * @return PermissionDecision
+   */
+  def checkPermission(toolName: String, args: Map[String, Any]): PermissionDecision = {
+    // 1. Check session-scoped denials/allowances
+    if (isSessionDenied(toolName)) return Denied
+    if (isSessionAllowed(toolName)) return Allowed
+    
+    // 2. Get configured level
+    val level = getConfiguredLevel(toolName)
+    
+    // 3. Apply policy
+    level match {
+      case Deny => Denied
+      case Allow => Allowed
+      case AskAtFirstUse =>
+        // If already allowed in session, allow; otherwise prompt
+        if (isSessionAllowed(toolName)) Allowed
+        else NeedPrompt(toolName, extractResource(toolName, args))
+      case AskAlways =>
+        // Always prompt (don't check session)
+        NeedPrompt(toolName, extractResource(toolName, args))
+    }
+  }
+
+  /**
+   * Prompt the user for permission using the same UI as ask_user.
+   * Blocks until user responds or times out.
+   * 
+   * @param toolName The tool requesting permission
+   * @param resource Optional resource identifier (e.g., theory name)
+   * @param view The current jEdit view
+   * @return PermissionDecision (Allowed or Denied)
+   */
+  def promptUser(toolName: String, resource: Option[String], view: View): PermissionDecision = {
+    val resourceText = resource.map(r => s" on '$r'").getOrElse("")
+    val action = toolDescriptions.getOrElse(toolName, "perform this action")
+    val question = s"Tool '$toolName' wants to $action$resourceText. Allow?"
+    
+    val toolDef = AssistantTools.tools.find(_.name == toolName)
+    val context = toolDef.map(_.description).getOrElse("")
+    
+    val options = List(
+      "Allow (for this session)",
+      "Allow Once",
+      "Deny (for this session)"
+    )
+    
+    // Reuse the exact same prompt mechanism as execAskUser
+    AssistantTools.promptUserWithChoices(question, options, context, view) match {
+      case Some(choice) =>
+        choice match {
+          case "Allow (for this session)" =>
+            setSessionAllowed(toolName)
+            Output.writeln(s"[Permissions] User allowed '$toolName' for session")
+            Allowed
+          case "Allow Once" =>
+            Output.writeln(s"[Permissions] User allowed '$toolName' once")
+            Allowed
+          case "Deny (for this session)" =>
+            setSessionDenied(toolName)
+            Output.writeln(s"[Permissions] User denied '$toolName' for session")
+            Denied
+          case _ =>
+            Output.writeln(s"[Permissions] Unexpected choice for '$toolName': $choice")
+            Denied
+        }
+      case None =>
+        // Timeout or cancellation
+        Output.writeln(s"[Permissions] User did not respond, denying '$toolName'")
+        Denied
+    }
+  }
+
+  // --- Filtered Tool List for LLM ---
+
+  /**
+   * Get the list of tools that should be sent to the LLM.
+   * Excludes tools with Deny permission level.
+   */
+  def getVisibleTools: List[AssistantTools.ToolDef] = {
+    AssistantTools.tools.filter(tool => getConfiguredLevel(tool.name) != Deny)
+  }
+}

--- a/isabelle-assistant/src/test/scala/ToolPermissionsTest.scala
+++ b/isabelle-assistant/src/test/scala/ToolPermissionsTest.scala
@@ -1,0 +1,147 @@
+/* Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+   SPDX-License-Identifier: MIT */
+
+package isabelle.assistant
+
+import org.scalatest.funsuite.AnyFunSuite
+import org.scalatest.matchers.should.Matchers
+
+/**
+ * Tests for ToolPermissions permission checking and configuration.
+ * Tests the permission model without requiring jEdit runtime.
+ */
+class ToolPermissionsTest extends AnyFunSuite with Matchers {
+
+  test("PermissionLevel should have correct config strings") {
+    ToolPermissions.Deny.toConfigString shouldBe "Deny"
+    ToolPermissions.AskAlways.toConfigString shouldBe "AskAlways"
+    ToolPermissions.AskAtFirstUse.toConfigString shouldBe "AskAtFirstUse"
+    ToolPermissions.Allow.toConfigString shouldBe "Allow"
+  }
+
+  test("PermissionLevel.fromString should parse valid levels") {
+    ToolPermissions.PermissionLevel.fromString("Deny") shouldBe Some(ToolPermissions.Deny)
+    ToolPermissions.PermissionLevel.fromString("AskAlways") shouldBe Some(ToolPermissions.AskAlways)
+    ToolPermissions.PermissionLevel.fromString("AskAtFirstUse") shouldBe Some(ToolPermissions.AskAtFirstUse)
+    ToolPermissions.PermissionLevel.fromString("Allow") shouldBe Some(ToolPermissions.Allow)
+  }
+
+  test("PermissionLevel.fromString should return None for invalid strings") {
+    ToolPermissions.PermissionLevel.fromString("Invalid") shouldBe None
+    ToolPermissions.PermissionLevel.fromString("allow") shouldBe None // case-sensitive
+    ToolPermissions.PermissionLevel.fromString("") shouldBe None
+  }
+
+  test("all tools should have default permissions defined") {
+    val toolNames = AssistantTools.tools.map(_.name).toSet
+    val defaults = ToolPermissions.getAllToolPermissions.map(_._1).toSet
+    toolNames shouldBe defaults
+  }
+
+  test("read-only tools should default to Allow") {
+    val readOnlyTools = List("read_theory", "list_theories", "search_in_theory",
+      "get_goal_state", "get_proof_context", "get_errors", "get_warnings")
+    for (toolName <- readOnlyTools) {
+      val level = ToolPermissions.getConfiguredLevel(toolName)
+      level shouldBe ToolPermissions.Allow
+    }
+  }
+
+  test("I/Q verification tools should default to AskAtFirstUse") {
+    val verifyTools = List("verify_proof", "execute_step", "try_methods",
+      "find_theorems", "get_definitions", "run_sledgehammer")
+    for (toolName <- verifyTools) {
+      val level = ToolPermissions.getConfiguredLevel(toolName)
+      level shouldBe ToolPermissions.AskAtFirstUse
+    }
+  }
+
+  test("side-effect tools should default to AskAlways") {
+    val sideEffectTools = List("edit_theory", "create_theory", "open_theory", "web_search")
+    for (toolName <- sideEffectTools) {
+      val level = ToolPermissions.getConfiguredLevel(toolName)
+      level shouldBe ToolPermissions.AskAlways
+    }
+  }
+
+  test("ask_user tool should always be Allow and locked") {
+    val level = ToolPermissions.getConfiguredLevel("ask_user")
+    level shouldBe ToolPermissions.Allow
+  }
+
+  test("checkPermission should return Allowed for Allow-level tools") {
+    val args = Map.empty[String, Any]
+    ToolPermissions.clearSession()
+    val decision = ToolPermissions.checkPermission("read_theory", args)
+    decision shouldBe ToolPermissions.Allowed
+  }
+
+  test("clearSession should reset session state") {
+    ToolPermissions.clearSession()
+    // Session state is internal, but we can test indirectly via checkPermission behavior
+    // After clear, checkPermission should follow configured defaults
+    val decision = ToolPermissions.checkPermission("read_theory", Map.empty)
+    decision shouldBe ToolPermissions.Allowed
+  }
+
+  test("getVisibleTools should exclude Deny-level tools") {
+    // This test assumes default configuration (no tools are Deny by default)
+    val visible = ToolPermissions.getVisibleTools
+    visible.length shouldBe AssistantTools.tools.length
+  }
+
+  test("all tools should have descriptions for permission prompts") {
+    val permissions = ToolPermissions.getAllToolPermissions
+    permissions should not be empty
+    permissions.length shouldBe 29 // All 29 tools
+  }
+
+  test("session-level decisions should be isolated") {
+    ToolPermissions.clearSession()
+    // checkPermission behavior depends on session state which is internal
+    // This test verifies clearSession doesn't throw
+    ToolPermissions.clearSession()
+    succeed
+  }
+
+  test("getConfiguredLevel should handle unknown tools gracefully") {
+    val level = ToolPermissions.getConfiguredLevel("nonexistent_tool")
+    // Should return AskAtFirstUse as default fallback
+    level shouldBe ToolPermissions.AskAtFirstUse
+  }
+
+  test("ask_user cannot have its permission level changed") {
+    // ask_user should always return Allow, regardless of configuration attempts
+    val level = ToolPermissions.getConfiguredLevel("ask_user")
+    level shouldBe ToolPermissions.Allow
+    
+    // Attempting to set should be no-op (doesn't throw)
+    ToolPermissions.setConfiguredLevel("ask_user", ToolPermissions.Deny)
+    val stillAllow = ToolPermissions.getConfiguredLevel("ask_user")
+    stillAllow shouldBe ToolPermissions.Allow
+  }
+
+  test("resetToDefaults should restore default permissions") {
+    ToolPermissions.resetToDefaults()
+    // Verify a few representative tools
+    ToolPermissions.getConfiguredLevel("read_theory") shouldBe ToolPermissions.Allow
+    ToolPermissions.getConfiguredLevel("verify_proof") shouldBe ToolPermissions.AskAtFirstUse
+    ToolPermissions.getConfiguredLevel("edit_theory") shouldBe ToolPermissions.AskAlways
+  }
+
+  test("getAllToolPermissions should return all 29 tools") {
+    val all = ToolPermissions.getAllToolPermissions
+    all.length shouldBe 29
+    all.map(_._1).toSet shouldBe AssistantTools.tools.map(_.name).toSet
+  }
+
+  test("permission levels should have stable config string representation") {
+    // Verify round-trip: level -> string -> level
+    for (level <- List(ToolPermissions.Deny, ToolPermissions.AskAlways, 
+                       ToolPermissions.AskAtFirstUse, ToolPermissions.Allow)) {
+      val configStr = level.toConfigString
+      val parsed = ToolPermissions.PermissionLevel.fromString(configStr)
+      parsed shouldBe Some(level)
+    }
+  }
+}


### PR DESCRIPTION
Implements a four-level permission model (Deny, Ask Always, Ask at First Use, Allow) to give users control over which tools the AI assistant can access. This addresses security concerns about autonomous LLM actions by requiring user approval for potentially impactful operations.

Key features:
- Permission levels: Deny (blocked), Ask Always (prompt every time), Ask at First Use (prompt once per session), Allow (no prompting)
- Sensible defaults: read-only tools auto-allowed, verification tools ask at first use, side-effect tools (edit_theory, create_theory, web_search) always ask
- Session-scoped memory: decisions persist until chat clear or plugin restart
- Seamless UI: permission prompts use the same interface as ask_user tool
- Security: denied tools are filtered before being sent to LLM
- Special handling: ask_user tool locked to "Allow" to prevent recursive prompting

Configuration stored in jEdit properties: assistant.permissions.tool.<tool_name>
UI accessible via: Plugins → Plugin Options → Isabelle Assistant → Tool Permissions

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
