### PR TITLE
Add Isabelle/REPL (I/R) for interactive theory exploration 

### DIFF
--- a/.github/workflows/ir.yml
+++ b/.github/workflows/ir.yml
@@ -1,0 +1,113 @@
+name: I/R
+
+permissions:
+  contents: read
+
+on:
+  push:
+    branches: [ main, develop ]
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  basic:
+    name: Basic test (HOL)
+    runs-on: ubuntu-latest
+    container:
+      image: makarius/isabelle:Isabelle2025-2
+      options: --user root
+
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: Setup Isabelle
+      uses: ./.github/actions/setup-isabelle-action
+
+    - name: Install dependencies
+      run: |
+        apt-get update -qq && apt-get install -y -qq python3 python3-pip python3-venv > /dev/null
+        pip3 install --break-system-packages prompt_toolkit
+
+    - name: Set Isabelle environment
+      run: |
+        ISABELLE_BIN=/home/isabelle/Isabelle/bin/isabelle
+        echo "ISABELLE=$ISABELLE_BIN" >> $GITHUB_ENV
+
+    - name: Build HOL heap
+      run: $ISABELLE build -b HOL
+
+    - name: Test explore.ML via console
+      run: python3 ir/test_console.py --isabelle $ISABELLE --session HOL
+
+    - name: Test repl.py TCP server
+      run: python3 ir/test_repl.py --isabelle $ISABELLE --session HOL
+
+  segment_storage:
+    name: Build heap with intermediate states
+    runs-on: ubuntu-latest
+    container:
+      image: makarius/isabelle:Isabelle2025-2
+      options: --user root
+
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: Install dependencies
+      run: |
+        apt-get update -qq && apt-get install -y -qq python3 python3-pip python3-venv > /dev/null
+        pip3 install --break-system-packages prompt_toolkit
+
+    - name: Set Isabelle environment
+      run: |
+        ISABELLE=/home/isabelle/Isabelle/bin/isabelle
+        ISABELLE_HOME=$($ISABELLE getenv -b ISABELLE_HOME)
+        ISABELLE_HOME_USER=$($ISABELLE getenv -b ISABELLE_HOME_USER)
+        echo "ISABELLE=$ISABELLE" >> $GITHUB_ENV
+        echo "ISABELLE_HOME=$ISABELLE_HOME" >> $GITHUB_ENV
+        echo "ISABELLE_HOME_USER=$ISABELLE_HOME_USER" >> $GITHUB_ENV
+
+    - name: Create dummy session
+      run: |
+        mkdir -p /tmp/seg_test
+        cp segment_storage.ML /tmp/seg_test/
+        cat > /tmp/seg_test/ROOT <<'EOF'
+        session Seg_Test = HOL +
+          theories Test_Seg
+        EOF
+        sed -i 's/^        //' /tmp/seg_test/ROOT
+        cat > /tmp/seg_test/Test_Seg.thy <<'EOF'
+        theory Test_Seg imports Main begin
+        declare [[ML_write_global = true]]
+        ML_file "segment_storage.ML"
+        declare [[ML_write_global = false]]
+        end
+        EOF
+        sed -i 's/^        //' /tmp/seg_test/Test_Seg.thy
+
+    - name: "A: Build without option — expect no source"
+      run: |
+        $ISABELLE build -d /tmp/seg_test -b Seg_Test
+        output=$(printf 'use "%s";' "$PWD/ir/explore.ML" \
+          | $ISABELLE console -d /tmp/seg_test -l Seg_Test -n 2>&1)
+        echo "$output"
+        echo "$output" | grep -q "source commands not available"
+
+    - name: "B: Register option as false — expect no source"
+      run: |
+        mkdir -p "$ISABELLE_HOME_USER/etc"
+        echo 'option store_segments : bool = false for build' \
+          >> "$ISABELLE_HOME_USER/etc/options"
+        $ISABELLE build -d /tmp/seg_test -c -b Seg_Test
+        output=$(printf 'use "%s";' "$PWD/ir/explore.ML" \
+          | $ISABELLE console -d /tmp/seg_test -l Seg_Test -n 2>&1)
+        echo "$output"
+        echo "$output" | grep -q "source commands not available"
+
+    - name: "C: Build with store_segments=true — expect source"
+      run: |
+        $ISABELLE build -d /tmp/seg_test -c -b -o store_segments=true Seg_Test
+        output=$(printf 'use "%s";' "$PWD/ir/explore.ML" \
+          | $ISABELLE console -d /tmp/seg_test -l Seg_Test -n 2>&1)
+        echo "$output"
+        echo "$output" | grep -q "source commands available"
+        echo "$output" | grep -qv "not available"

--- a/AutoCorrode.thy
+++ b/AutoCorrode.thy
@@ -22,5 +22,9 @@ theory AutoCorrode
     "Shallow_Separation_Logic.Shallow_Separation_Logic"
 begin
 
+declare [[ML_write_global = true]]
+ML_file \<open>segment_storage.ML\<close>
+declare [[ML_write_global = false]]
+
 end
 (*>*)

--- a/README.md
+++ b/README.md
@@ -21,6 +21,10 @@ or collaboratively conduct interactive theorem proving using Isabelle. See [iq](
 
 [I/P](ip) -- short for Isabelle/Proxy -- runs the Isabelle ML prover on a remote machine while keeping Isabelle/jEdit local. It requires no Isabelle source changes and includes a jEdit plugin for remote status monitoring. See [ip](ip) for more information.
 
+## I/R
+
+[I/R](ir) -- short for Isabelle/REPL -- provides interactive theory exploration outside of jEdit, from the command line or programmatically via TCP and MCP. See [ir](ir) for more information.
+
 ## Isabelle Assistant
 
 [Isabelle Assistant](isabelle-assistant) is an LLM-powered proof assistant for Isabelle/jEdit, built on [AWS Bedrock](https://aws.amazon.com/bedrock/). It provides autonomous proof search, interactive chat with LaTeX rendering, proof suggestions, code explanation, refactoring, and more — all integrated into the Isabelle/jEdit IDE. When combined with [I/Q](iq), generated proofs are automatically verified against Isabelle before display. See [isabelle-assistant](isabelle-assistant) for more information.

--- a/ir/README.md
+++ b/ir/README.md
@@ -1,0 +1,63 @@
+# I/R — Isabelle/REPL
+
+I/R provides interactive Isabelle theory exploration outside of jEdit,
+from the command line or programmatically via TCP and MCP.
+
+## Overview
+
+I/R consists of three components:
+
+- **`explore.ML`** — Isabelle/ML library providing named, forkable REPL
+  sessions rooted at arbitrary theory positions. Supports stepping through
+  Isar text, editing and replaying steps, viewing proof state, inspecting
+  theory source, and invoking sledgehammer.
+- **`repl.py`** — TCP server wrapping a Poly/ML console. Starts an Isabelle
+  console process, loads `explore.ML`, and multiplexes client connections
+  over a single serialized ML session. Includes an interactive management
+  console with tab completion and Unicode-to-Isabelle symbol translation.
+- **`explore_mcp.py`** — MCP server exposing each Explore function as an
+  MCP tool, allowing LLM agents to drive proof exploration over a
+  structured tool interface. Connects to `repl.py` over TCP.
+
+## Quick Start
+
+```bash
+# Install Python dependencies
+pip install -r ir/requirements.txt
+
+# Start the REPL server (loads HOL + AutoCorrode session)
+python3 ir/repl.py --session AutoCorrode --dir .
+
+# In another terminal, connect via netcat or the MCP server
+nc localhost 9147
+Explore.init "test" "MyTheory";
+Explore.step "lemma foo: True";
+Explore.step "by simp";
+Explore.state ~1;
+```
+
+## MCP Integration
+
+```bash
+# Start the MCP server (connects to a running repl.py)
+python3 ir/explore_mcp.py
+```
+
+The MCP server exposes tools for `init`, `fork`, `focus`, `step`, `show`,
+`state`, `edit`, `replay`, `sledgehammer`, and more.
+
+## Dependencies
+
+- **Isabelle2025-2** with a built session heap (e.g. HOL or AutoCorrode)
+- **Python 3.10+**
+- **prompt_toolkit** — interactive console with tab completion and history (`repl.py`)
+- **mcp** — Model Context Protocol server framework (`explore_mcp.py`)
+
+Install via `pip install -r requirements.txt`, or in a virtual environment:
+
+```bash
+cd ir
+python3 -m venv venv
+source venv/bin/activate
+pip install -r requirements.txt
+```

--- a/ir/explore.ML
+++ b/ir/explore.ML
@@ -1,0 +1,622 @@
+(* Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+   SPDX-License-Identifier: MIT *)
+
+(* REPL for exploring Isabelle theories via Isar text.
+   Designed for use from the Poly/ML console after loading a heap. *)
+
+signature EXPLORE =
+sig
+  type config = {color: bool, show_ignored: bool, full_spans: bool,
+                 show_theory_in_source: bool, auto_replay: bool}
+  val config : (config -> config) -> unit
+  val get_cfg : unit -> config
+
+  val init : string -> string -> unit
+  val fork : string -> int -> unit
+  val focus : string -> unit
+  val step : string -> unit
+  val step_file : string -> unit
+  val show : unit -> unit
+  val state : int -> unit
+  val text : unit -> unit
+  val edit : int -> string -> unit
+  val replay : unit -> unit
+  val truncate : int -> unit
+  val merge : unit -> unit
+
+  val remove : string -> unit
+  val repls : unit -> unit
+  val theories : unit -> unit
+  val source : string -> int -> int -> unit
+  val sledgehammer : int -> unit
+  val timeout : int -> unit
+  val help : unit -> unit
+end;
+
+(* Shared refs for sledgehammer compiler bridge — must be in global namespace *)
+val sh_state_ref = Unsynchronized.ref (Toplevel.make_state NONE);
+val sh_timeout_ref = Unsynchronized.ref 30;
+val sh_result_ref = Unsynchronized.ref "";
+
+(* Probe for stored_segments — may or may not exist in the loaded heap *)
+val stored_segments_probe =
+  Unsynchronized.ref (NONE : (string * Document_Output.segment list) list Synchronized.var option);
+val _ = Exn.capture (fn () =>
+  ML_Compiler.eval ML_Compiler.flags Position.none
+    (ML_Lex.tokenize "stored_segments_probe := SOME stored_segments")) ();
+
+structure Explore : EXPLORE =
+struct
+
+(** Configuration **)
+
+type config = {color: bool, show_ignored: bool, full_spans: bool,
+               show_theory_in_source: bool, auto_replay: bool};
+val cfg : config Synchronized.var =
+  Synchronized.var "Explore.cfg" {color = true, show_ignored = false, full_spans = false,
+                                   show_theory_in_source = false, auto_replay = true};
+fun config f = Synchronized.change cfg f;
+fun get_cfg () = Synchronized.value cfg;
+
+(** Step timeout (seconds, 0 = no limit) **)
+
+val step_timeout : int Synchronized.var = Synchronized.var "Explore.timeout" 5;
+fun timeout secs =
+  (Synchronized.change step_timeout (K secs);
+   TextIO.print ("Timeout set to " ^ (if secs = 0 then "unlimited" else string_of_int secs ^ "s") ^ "\n"));
+
+(** Symbol translation **)
+
+local
+  fun parse_code s =
+    StringCvt.scanString (Int.scan StringCvt.HEX)
+      (if String.isPrefix "0x" s then String.extract (s, 2, NONE) else s);
+
+  fun utf8_of_codepoint cp =
+    if cp < 0x80 then chr cp
+    else if cp < 0x800 then
+      implode [chr (0xC0 + cp div 64), chr (0x80 + cp mod 64)]
+    else if cp < 0x10000 then
+      implode [chr (0xE0 + cp div 4096),
+               chr (0x80 + (cp div 64) mod 64),
+               chr (0x80 + cp mod 64)]
+    else
+      implode [chr (0xF0 + cp div 262144),
+               chr (0x80 + (cp div 4096) mod 64),
+               chr (0x80 + (cp div 64) mod 64),
+               chr (0x80 + cp mod 64)];
+
+  val symbol_table : string Symtab.table =
+    let val path = Path.explode "$ISABELLE_HOME/etc/symbols"
+        val lines = split_lines (File.read path)
+        fun parse_line line =
+          case String.tokens Char.isSpace line of
+            (sym :: "code:" :: hex :: _) =>
+              (case parse_code hex of
+                SOME cp => SOME (sym, utf8_of_codepoint cp)
+              | NONE => NONE)
+          | _ => NONE
+    in Symtab.make (map_filter parse_line lines) end;
+
+  val unicode_to_symbol : string Symtab.table =
+    Symtab.fold (fn (sym, utf) => Symtab.update (utf, sym)) symbol_table Symtab.empty;
+in
+  fun unicode_of_symbol sym =
+    case Symtab.lookup symbol_table sym of SOME u => u | NONE => sym;
+
+  fun to_unicode text =
+    Symbol.explode text |> map unicode_of_symbol |> implode;
+
+  fun from_unicode text =
+    let fun convert [] = []
+          | convert (c :: cs) =
+              if Char.ord (String.sub (c, 0)) < 128 then c :: convert cs
+              else
+                let fun try_match n =
+                      if n > 4 orelse n > length cs + 1 then NONE
+                      else let val candidate = implode (List.take (c :: cs, n))
+                           in case Symtab.lookup unicode_to_symbol candidate of
+                                SOME sym => SOME (sym, List.drop (cs, n - 1))
+                              | NONE => try_match (n + 1)
+                           end
+                in case try_match 1 of
+                     SOME (sym, rest) => sym :: convert rest
+                   | NONE => c :: convert cs
+                end
+    in implode (convert (map str (String.explode text))) end;
+end;
+
+
+(** ANSI highlighting **)
+
+(** ANSI highlighting **)
+
+local
+  val reset = "\027[0m" val bold = "\027[1m"
+  val red = "\027[31m" val green = "\027[32m"
+  val yellow = "\027[33m" val blue = "\027[34m" val gray = "\027[90m"
+
+  fun ansi_of tok =
+    if Token.is_command tok then bold ^ blue
+    else if Token.is_kind Token.Keyword tok then blue
+    else if Token.is_kind Token.String tok then green
+    else if Token.is_kind Token.Alt_String tok then green
+    else if Token.is_kind Token.Cartouche tok then green
+    else if Token.is_kind Token.Var tok then yellow
+    else if Token.is_kind Token.Type_Var tok then yellow
+    else if Token.is_kind Token.Type_Ident tok then yellow
+    else if Token.is_comment tok then gray
+    else if Token.is_error tok then red
+    else ""
+
+  fun colorize_token tok =
+    let val text = Token.unparse tok
+        val code = ansi_of tok
+    in if code = "" then text else code ^ text ^ reset end
+
+  fun flatten s = String.translate (fn #"\n" => " " | c => str c) s
+in
+  fun span_text_color (Command_Span.Span (_, toks)) =
+    flatten (implode (map colorize_token toks));
+
+  fun span_text_full (Command_Span.Span (_, toks)) =
+    flatten (implode (map Token.unparse toks));
+
+  fun fmt_span full (Command_Span.Span (_, toks)) =
+    if full then
+      let val use_color = #color (get_cfg ())
+          val render = if use_color then colorize_token else Token.unparse
+      in flatten (implode (map render toks)) end
+    else
+      let val use_color = #color (get_cfg ())
+          val render = if use_color then colorize_token else Token.unparse
+          fun go _ [] = ("", false)
+            | go remaining (tok :: rest) =
+                let val w = size (flatten (Token.unparse tok))
+                in if w > remaining then ("", true)
+                   else let val (s, trunc) = go (remaining - w) rest
+                        in (flatten (render tok) ^ s, trunc) end
+                end
+          val (text, truncated) = go 80 toks
+      in if truncated then text ^ reset ^ "..." else text end;
+end;
+
+fun is_ignored (Command_Span.Span (Command_Span.Ignored_Span, _)) = true
+  | is_ignored _ = false;
+
+fun out s = TextIO.print (to_unicode s ^ "\n");
+
+(* Format a raw text string using the same config as spans *)
+fun fmt_text text =
+  let val thy = Theory.get_pure ()
+      val kws = Thy_Header.get_keywords thy
+      val toks = Token.tokenize kws {strict = false} (Symbol_Pos.explode (text, Position.none))
+      val span = Command_Span.Span (Command_Span.Malformed_Span, toks)
+  in fmt_span (#full_spans (get_cfg ())) span end;
+
+
+(** Segments **)
+
+fun find_source thy_name =
+  case ! stored_segments_probe of
+    NONE => error ("No stored segments available in this heap. " ^
+                   "The 'source' command requires a heap built with segment storage.")
+  | SOME sv =>
+      (case List.find (fn (n, _) => n = thy_name) (Synchronized.value sv) of
+         SOME (_, segs) => segs
+       | NONE => error ("No stored segments for " ^ quote thy_name ^
+                        ". Available: " ^ commas (map #1 (Synchronized.value sv))));
+
+fun source thy_name start stop =
+  let val segs = find_source thy_name
+      val len = length segs
+      val start' = if start < 0 then Int.max (0, len + start) else start
+      val stop' = if stop < 0 then len + stop else stop
+      val {show_ignored = incl, full_spans, show_theory_in_source, ...} = get_cfg ()
+      val prefix = if show_theory_in_source then thy_name ^ ":" else ""
+      fun pr _ [] = ()
+        | pr i (({span, prev_state, ...} : Document_Output.segment) :: rest) =
+            let val indent = StringCvt.padLeft #" " (2 * Toplevel.level prev_state) ""
+            in (if i >= start' andalso i <= stop' then
+               if is_ignored span then
+                 (if incl then out (prefix ^ StringCvt.padLeft #" " 4 (string_of_int i) ^
+                                    "  " ^ indent ^ "\027[90m" ^ span_text_full span ^ "\027[0m") else ())
+               else out (prefix ^ StringCvt.padLeft #" " 4 (string_of_int i) ^
+                         "  " ^ indent ^ fmt_span full_spans span)
+             else ();
+             pr (i + 1) rest)
+            end
+  in pr 0 segs end;
+
+
+(** REPL core **)
+
+datatype origin =
+  From_Theory of string
+| From_Segment of string * int
+| From_REPL of string * int;
+
+type repl_step = {
+  text: string,
+  pre_state: Toplevel.state,
+  post_state: Toplevel.state,
+  stale: bool
+};
+
+type repl = {
+  origin: origin,
+  base_state: Toplevel.state,
+  steps: repl_step list
+};
+
+val repl_tab : repl Symtab.table Synchronized.var
+  = Synchronized.var "Explore.repls" Symtab.empty;
+
+val current_repl : string Synchronized.var
+  = Synchronized.var "Explore.current_repl" "";
+
+fun the_repl id =
+  case Symtab.lookup (Synchronized.value repl_tab) id of
+    SOME r => r
+  | NONE => error ("No REPL " ^ quote id);
+
+fun the_current () =
+  let val id = Synchronized.value current_repl
+  in if id = "" then error "No current REPL" else (id, the_repl id) end;
+
+fun update_repl id r =
+  Synchronized.change repl_tab (Symtab.update (id, r));
+
+(* Execute Isar text against a state *)
+fun exec_text text st =
+  let val text = from_unicode text
+      val thy = Toplevel.theory_of st
+      val transitions = Outer_Syntax.parse_text thy (fn () => thy) Position.none text
+      fun run (tr, s) =
+        let val old = !Multithreading.parallel_proofs
+            val _ = Multithreading.parallel_proofs := Int.min (2, old)
+            val s' = Toplevel.command_exception false tr s
+            val _ = Multithreading.parallel_proofs := old
+        in s' end
+      val secs = Synchronized.value step_timeout
+      fun go () = List.foldl (fn (tr, s) => run (tr, s)) st transitions
+  in if secs > 0
+     then Timeout.apply (Time.fromSeconds (Int.toLarge secs)) go ()
+       handle Timeout.TIMEOUT _ =>
+         error ("Step timed out after " ^ string_of_int secs ^ "s")
+     else go ()
+  end;
+
+fun last_state ({steps, base_state, ...} : repl) =
+  case rev steps of [] => base_state | ({post_state, ...} :: _) => post_state;
+
+fun pretty_state st =
+  Pretty.string_of (Pretty.chunks (Toplevel.pretty_state st));
+
+
+(** Commands **)
+
+(* Parse "TheoryName:IDX" or "TheoryName" *)
+fun parse_spec spec =
+  case String.fields (fn c => c = #":") spec of
+    [thy, idx_str] =>
+      (case Int.fromString idx_str of
+        SOME idx => (thy, SOME idx)
+      | NONE => error ("Bad index in " ^ quote spec))
+  | [thy] => (thy, NONE)
+  | _ => error ("Bad spec: " ^ quote spec);
+
+fun init id spec =
+  let val _ = if Symtab.defined (Synchronized.value repl_tab) id
+              then error ("REPL " ^ quote id ^ " already exists")
+              else ()
+      val (thy_name, opt_idx) = parse_spec spec
+      val (origin, st) =
+        case opt_idx of
+          NONE =>
+            (From_Theory thy_name,
+             Toplevel.make_state (SOME (Thy_Info.get_theory thy_name
+               |> Config.put_global Goal.quick_and_dirty true)))
+        | SOME idx =>
+            let val segs = find_source thy_name
+                val seg = nth segs idx
+                  handle General.Subscript =>
+                    error ("Index " ^ string_of_int idx ^ " out of range")
+            in (From_Segment (thy_name, idx), #state (seg : Document_Output.segment)) end
+      val r : repl = {origin = origin, base_state = st, steps = []}
+  in update_repl id r;
+     Synchronized.change current_repl (K id);
+     out ("Created REPL " ^ quote id ^ ", set as current")
+  end;
+
+fun fork id state_idx =
+  let val _ = if Symtab.defined (Synchronized.value repl_tab) id
+              then error ("REPL " ^ quote id ^ " already exists")
+              else ()
+      val (pid, parent) = the_current ()
+      val steps = #steps parent
+      val n = length steps
+      (* Use same indexing as state: 0=base, 1=after step 0, ... *)
+      val i = if state_idx < 0 then n + 1 + state_idx else state_idx
+      val st = if i = 0 then #base_state parent
+               else if i >= 1 andalso i <= n then #post_state (nth steps (i - 1))
+               else error ("State " ^ string_of_int state_idx ^ " out of range (0.." ^
+                           string_of_int n ^ ")")
+      val r : repl = {origin = From_REPL (pid, i), base_state = st, steps = []}
+  in update_repl id r;
+     Synchronized.change current_repl (K id);
+     out ("Forked REPL " ^ quote id ^ " from " ^ quote pid ^
+          " at state " ^ string_of_int i ^ ", set as current")
+  end;
+
+fun focus id =
+  (ignore (the_repl id);
+   Synchronized.change current_repl (K id);
+   out ("Focused on REPL " ^ quote id));
+
+fun step text =
+  let val (id, r) = the_current ()
+      val pre = last_state r
+      val post = exec_text text pre
+      val s : repl_step = {text = text, pre_state = pre, post_state = post, stale = false}
+      val r' : repl = {origin = #origin r, base_state = #base_state r,
+                        steps = #steps r @ [s]}
+  in update_repl id r';
+     out (pretty_state post)
+  end;
+
+fun step_file path = step (File.read (Path.explode path));
+
+fun state state_idx =
+  let val (_, r) = the_current ()
+      val steps = #steps r
+      val n = length steps
+      (* state 0 = base, state 1 = after step 0, ..., state n = after step n-1 *)
+      val i = if state_idx < 0 then n + 1 + state_idx else state_idx
+      val st = if i = 0 then #base_state r
+               else if i >= 1 andalso i <= n then #post_state (nth steps (i - 1))
+               else error ("State " ^ string_of_int state_idx ^ " out of range (0.." ^
+                           string_of_int n ^ ")")
+  in out (pretty_state st) end;
+
+fun show () =
+  let val (id, r) = the_current ()
+      val cur_id = Synchronized.value current_repl
+      val orig = case #origin r of
+          From_Theory t => "theory " ^ t
+        | From_Segment (t, i) => t ^ ":" ^ string_of_int i
+        | From_REPL (p, i) => "REPL " ^ quote p ^ " state " ^ string_of_int i
+      val n = length (#steps r)
+      val _ = out ("REPL " ^ quote id ^
+                   (if id = cur_id then " \027[1m(current)\027[0m" else "") ^
+                   " (" ^ string_of_int n ^ " steps, from " ^ orig ^ ")")
+      val _ = out ("  base  level=" ^ string_of_int (Toplevel.level (#base_state r)))
+      fun pr _ [] = ()
+        | pr i (({text, stale, pre_state, ...} : repl_step) :: rest) =
+            let val stale_mark = if stale then " \027[31m[stale]\027[0m" else ""
+                val lvl = Toplevel.level pre_state
+                val indent = StringCvt.padLeft #" " (2 * lvl) ""
+            in out ("  " ^ StringCvt.padLeft #" " 3 (string_of_int i) ^ "  " ^
+                    indent ^ fmt_text text ^ stale_mark);
+               pr (i + 1) rest
+            end
+  in pr 0 (#steps r) end;
+
+fun text () =
+  let val (_, r) = the_current ()
+      val t = map #text (#steps r)
+  in out (String.concatWith "\n" t) end;
+
+fun replay () =
+  let val (id, r) = the_current ()
+      fun go _ [] acc = rev acc
+        | go prev_post (s :: rest) acc =
+            if #stale (s : repl_step) then
+              let val post = exec_text (#text s) prev_post
+                  val s' : repl_step = {text = #text s, pre_state = prev_post,
+                                         post_state = post, stale = false}
+              in go post rest (s' :: acc) end
+            else go (#post_state s) rest (s :: acc)
+      val steps' = go (#base_state r) (#steps r) []
+      val r' : repl = {origin = #origin r, base_state = #base_state r, steps = steps'}
+  in update_repl id r';
+     out ("Replayed " ^ string_of_int (length (filter #stale (#steps r))) ^ " stale steps")
+  end;
+
+fun edit idx new_text =
+  let val (id, r) = the_current ()
+      val steps = #steps r
+      val _ = if idx < 0 orelse idx >= length steps
+              then error ("Step " ^ string_of_int idx ^ " out of range") else ()
+      val pre = if idx = 0 then #base_state r
+                else #post_state (nth steps (idx - 1))
+      val post = exec_text new_text pre
+      val edited : repl_step = {text = new_text, pre_state = pre, post_state = post, stale = false}
+      val before_steps = List.take (steps, idx)
+      val after_steps = List.drop (steps, idx + 1)
+        |> map (fn s : repl_step => {text = #text s, pre_state = #pre_state s,
+                                      post_state = #post_state s, stale = true})
+      val r' : repl = {origin = #origin r, base_state = #base_state r,
+                        steps = before_steps @ [edited] @ after_steps}
+  in update_repl id r';
+     out ("Edited step " ^ string_of_int idx ^ ", " ^
+          string_of_int (length after_steps) ^ " subsequent steps marked stale");
+     if #auto_replay (get_cfg ()) andalso not (null after_steps) then replay () else ()
+  end;
+
+fun truncate idx =
+  let val (id, r) = the_current ()
+      val steps = #steps r
+      val _ = if idx < 0 orelse idx >= length steps
+              then error ("Step " ^ string_of_int idx ^ " out of range") else ()
+      (* Remove sub-REPLs attached to dropped steps *)
+      val dropped = length steps - idx - 1
+      val _ = Synchronized.change repl_tab (fn tab =>
+        Symtab.fold (fn (rid, r') =>
+          case #origin (r' : repl) of
+            From_REPL (pid, si) =>
+              if pid = id andalso si > idx then Symtab.delete rid else I
+          | _ => I) tab tab)
+      val r' : repl = {origin = #origin r, base_state = #base_state r,
+                        steps = List.take (steps, idx + 1)}
+  in update_repl id r';
+     out ("Truncated to step " ^ string_of_int idx ^ ", dropped " ^
+          string_of_int dropped ^ " steps")
+  end;
+
+fun merge () =
+  let val (id, r) = the_current ()
+      val (pid, pidx) =
+        case #origin r of
+          From_REPL (p, i) => (p, i)
+        | _ => error ("REPL " ^ quote id ^ " is not a sub-REPL")
+      val merged_text = String.concatWith "\n" (map #text (#steps r))
+      (* Switch to parent, edit the step at the fork point *)
+      val _ = Synchronized.change repl_tab (Symtab.delete_safe id)
+      val _ = Synchronized.change current_repl (K pid)
+      (* pidx is state index; step pidx has pre_state = state pidx *)
+      val target = pidx
+  in if target < length (#steps (the_repl pid))
+     then (edit target merged_text;
+           out ("Merged " ^ quote id ^ " into " ^ quote pid ^
+                " (replaced step " ^ string_of_int target ^ ")"))
+     else (step merged_text;
+           out ("Merged " ^ quote id ^ " into " ^ quote pid ^
+                " (appended as new step)"))
+  end;
+
+fun remove id =
+  let val _ = the_repl id (* check exists *)
+      fun is_descendant rid =
+        case #origin (the_repl rid) of
+          From_REPL (pid, _) => pid = id orelse is_descendant pid
+        | _ => false
+      val all_ids = Symtab.keys (Synchronized.value repl_tab)
+      val to_remove = id :: filter is_descendant all_ids
+      val _ = List.app (fn rid =>
+        Synchronized.change repl_tab (Symtab.delete_safe rid)) to_remove
+      val _ = if member (op =) to_remove (Synchronized.value current_repl)
+              then (Synchronized.change current_repl (K "");
+                    out "Current REPL was removed. Use Explore.focus or Explore.init to select another.")
+              else ()
+  in out ("Removed " ^ commas (map quote to_remove)) end;
+
+fun repls () =
+  let val cur_id = Synchronized.value current_repl
+  in Symtab.fold (fn (id, r : repl) => fn () =>
+    let val n = length (#steps r)
+        val is_cur = id = cur_id
+        val orig = case #origin r of
+            From_Theory t => "theory " ^ t
+          | From_Segment (t, i) => t ^ ":" ^ string_of_int i
+          | From_REPL (p, i) => "REPL " ^ quote p ^ " state " ^ string_of_int i
+        val stale = length (filter #stale (#steps r))
+        val desc = id ^ " (" ^ string_of_int n ^ " steps" ^
+            (if stale > 0 then ", " ^ string_of_int stale ^ " stale" else "") ^
+            ", from " ^ orig ^ ")"
+    in out (if is_cur then "  \027[1m> " ^ desc ^ "\027[0m" else "    " ^ desc)
+    end) (Synchronized.value repl_tab) ()
+  end;
+
+fun theories () =
+  List.app (fn s => out ("  " ^ s)) (Thy_Info.get_names ());
+
+(* Sledgehammer via compiler bridge *)
+
+fun sledgehammer timeout_secs =
+  let val st = last_state (snd (the_current ()))
+      val _ = Toplevel.proof_of st
+      val thy = Toplevel.theory_of st
+      val _ = sh_state_ref := st
+      val _ = sh_timeout_ref := timeout_secs
+      val buf = Unsynchronized.ref ([] : string list)
+      fun capture ss = buf := implode ss :: !buf
+      val old_writeln = ! Private_Output.writeln_fn
+      val old_warning = ! Private_Output.warning_fn
+      val code =
+        "val _ = sh_result_ref := (let " ^
+        "val prf = Toplevel.proof_of (! sh_state_ref) " ^
+        "val params = Sledgehammer_Commands.default_params " ^
+        "  (Proof_Context.theory_of (Proof.context_of prf)) " ^
+        "  [(\"timeout\", Int.toString (! sh_timeout_ref))] " ^
+        "val (_, (_, msg)) = Sledgehammer.run_sledgehammer params " ^
+        "  Sledgehammer_Prover.Normal NONE 1 " ^
+        "  Sledgehammer_Fact.no_fact_override prf " ^
+        "in msg end)"
+      val _ = Private_Output.writeln_fn := capture
+      val _ = Private_Output.warning_fn := (K ())
+      val result = Exn.capture (fn () =>
+        Context.setmp_generic_context (SOME (Context.Theory thy)) (fn () =>
+          ML_Compiler.eval ML_Compiler.flags Position.none
+            (ML_Lex.tokenize code)) ()) ()
+      val _ = Private_Output.writeln_fn := old_writeln
+      val _ = Private_Output.warning_fn := old_warning
+      val _ = Exn.release result
+      val all_text = rev (!buf) |> String.concatWith "\n"
+      val lines = String.fields (fn c => c = #"\n") all_text
+      val tries = filter (fn l => String.isSubstring "Try this" l) lines
+  in if null tries then out all_text
+     else List.app out tries
+  end;
+
+fun help () = out
+  "=== Explore API ===\n\
+  \\n\
+  \  init id spec       create REPL from \"Theory\" or \"Theory:idx\"\n\
+  \  fork id state_idx  fork sub-REPL from current at state (~1=latest)\n\
+  \  focus id           switch current REPL\n\
+  \  step \"isar text\"   append step to current REPL\n\
+  \  step_file path     append step from file (supports unicode)\n\
+  \  show ()            describe current REPL (origin, steps, staleness)\n\
+  \  state idx          show Toplevel.state (0=base, 1=after step 0, ~1=latest)\n\
+  \  text ()            print concatenated text of current REPL\n\
+  \  edit idx \"text\"    edit step, replay if auto_replay=true\n\
+  \  replay ()          re-execute stale steps\n\
+  \  truncate idx       discard steps after idx\n\
+  \  merge ()           inline current sub-REPL into parent\n\
+  \  sledgehammer secs  run sledgehammer on current proof state\n\
+  \  timeout secs       set step timeout (0=unlimited, default 5s)\n\
+  \  remove id          remove REPL and its sub-REPLs\n\
+  \  repls ()           list all REPLs\n\
+  \  theories ()   list loaded theories\n\
+  \  source thy s e   list command spans (s e = range, ~N = from end)\n\
+  \  config f           update config: color, show_ignored, full_spans,\n\
+  \                     show_theory_in_source, auto_replay\n\
+  \  help ()            this help\n\
+  \\n\
+  \=== Quick start ===\n\
+  \\n\
+  \  Explore.init \"R\" \"MySession.MyTheory\";\n\
+  \  Explore.step \"lemma \\\"True\\\"\";\n\
+  \  Explore.step \"by simp\";\n\
+  \  Explore.show ();\n\
+  \  Explore.state ~1;\n\
+  \\n\
+  \=== Forking and merging ===\n\
+  \\n\
+  \  Explore.step \"lemma \\\"P\\\"\";\n\
+  \  Explore.step \"sorry\";\n\
+  \  Explore.fork \"S\" 1;          (* fork from state before sorry *)\n\
+  \  Explore.step \"by auto\";\n\
+  \  Explore.merge ();             (* replace sorry with proof *)\n\
+  \\n\
+  \=== Editing ===\n\
+  \\n\
+  \  Explore.edit 0 \"lemma \\\"Q\\\"\";  (* edit first step, replays rest *)\n\
+  \  Explore.truncate 1;             (* keep only steps 0 and 1 *)\n\
+  \\n\
+  \=== Segments (stored theories) ===\n\
+  \\n\
+  \  Explore.source \"MySession.MyTheory\" 0 ~1;  (* all *)\n\
+  \  Explore.source \"MySession.MyTheory\" 0 10;  (* first 11 *)\n\
+  \  Explore.init \"R\" \"MySession.MyTheory:42\";    (* from source 42 *)";
+
+end;
+
+val _ = writeln (case ! stored_segments_probe of
+    NONE => "Explore: source commands not available (heap has no stored segments)"
+  | SOME sv =>
+      let val n = length (Synchronized.value sv)
+      in if n = 0 then "Explore: source commands not available (no theories stored)"
+         else "Explore: source commands available (" ^ string_of_int n ^ " theories)"
+      end);

--- a/ir/explore_mcp.py
+++ b/ir/explore_mcp.py
@@ -1,0 +1,206 @@
+#!/usr/bin/env python3
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: MIT
+
+"""
+MCP server exposing the Explore REPL.
+
+Connects to a running repl.py instance over TCP (via the `connect` tool)
+and exposes each Explore function as an MCP tool.  Runs on stdio transport.
+
+Usage:
+    python3 explore_mcp.py
+"""
+
+import socket
+from mcp.server.fastmcp import FastMCP
+
+SENTINEL = "<<DONE>>"
+
+# ---------------------------------------------------------------------------
+# TCP client for repl.py
+# ---------------------------------------------------------------------------
+
+class ReplClient:
+    """Synchronous TCP client for the Explore REPL server."""
+
+    def __init__(self, host: str = "127.0.0.1", port: int = 9147):
+        self.host = host
+        self.port = port
+        self.sock: socket.socket | None = None
+
+    def connect(self, host: str | None = None, port: int | None = None):
+        self.disconnect()
+        if host is not None:
+            self.host = host
+        if port is not None:
+            self.port = port
+        self.sock = socket.create_connection((self.host, self.port))
+
+    def disconnect(self):
+        if self.sock is not None:
+            try:
+                self.sock.close()
+            except OSError:
+                pass
+            self.sock = None
+
+    @property
+    def connected(self) -> bool:
+        return self.sock is not None
+
+    def send(self, ml_command: str) -> str:
+        """Send an ML command and return the output."""
+        if self.sock is None:
+            raise RuntimeError("Not connected — call the 'connect' tool first")
+        self.sock.sendall((ml_command.strip() + "\n").encode())
+        buf = b""
+        while True:
+            chunk = self.sock.recv(4096)
+            if not chunk:
+                self.sock = None
+                raise EOFError("Connection closed by repl.py")
+            buf += chunk
+            text = buf.decode("utf-8", errors="replace")
+            if SENTINEL in text:
+                return text[:text.index(SENTINEL)].strip()
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def ml_str(s: str) -> str:
+    """Escape a Python string as an ML string literal."""
+    return '"' + s.replace("\\", "\\\\").replace('"', '\\"') + '"'
+
+def ml_int(n: int) -> str:
+    """Format a Python int as an ML int literal (negative = ~N)."""
+    return f"~{-n}" if n < 0 else str(n)
+
+# ---------------------------------------------------------------------------
+# MCP server
+# ---------------------------------------------------------------------------
+
+mcp = FastMCP("Explore REPL",
+              instructions="Isabelle/ML Explore REPL for interactive theory exploration. "
+              "Use `list` to see REPLs, `init` to create one, `step` to advance, "
+              "`show` to inspect, `state` to view proof state.")
+
+repl = ReplClient()
+
+@mcp.tool(description="Connect to the Explore REPL server. Call this before using any other tool. Can also reconnect after a dropped connection.")
+def connect(port: int = 9147, host: str = "127.0.0.1") -> str:
+    repl.connect(host, port)
+    return f"Connected to {repl.host}:{repl.port}"
+
+@mcp.tool(description="Disconnect from the Explore REPL server.")
+def disconnect() -> str:
+    if not repl.connected:
+        return "Already disconnected"
+    repl.disconnect()
+    return "Disconnected"
+
+@mcp.tool(description="Create a new REPL session. `thy` is \"TheoryName\" or \"TheoryName:source_idx\".")
+def init(id: str, thy: str) -> str:
+    return repl.send(f"Explore.init {ml_str(id)} {ml_str(thy)};")
+
+@mcp.tool(description="Fork a sub-REPL from the current REPL at the given state index (0=base, -1=latest).")
+def fork(id: str, state_idx: int) -> str:
+    return repl.send(f"Explore.fork {ml_str(id)} {ml_int(state_idx)};")
+
+@mcp.tool(description="Switch the current REPL to the one with the given id.")
+def focus(id: str) -> str:
+    return repl.send(f"Explore.focus {ml_str(id)};")
+
+@mcp.tool(description="Append an Isar proof step to the current REPL.")
+def step(isar_text: str) -> str:
+    return repl.send(f"Explore.step {ml_str(isar_text)};")
+
+@mcp.tool(description="Append a step by reading Isar text from a file path.")
+def step_file(path: str) -> str:
+    return repl.send(f"Explore.step_file {ml_str(path)};")
+
+@mcp.tool(description="Show the current REPL: origin, steps, and staleness.")
+def show() -> str:
+    return repl.send("Explore.show ();")
+
+@mcp.tool(description="Print the Toplevel.state at the given index (0=base, 1=after step 0, -1=latest).")
+def state(state_idx: int) -> str:
+    return repl.send(f"Explore.state {ml_int(state_idx)};")
+
+@mcp.tool(description="Print the concatenated Isar text of all steps in the current REPL.")
+def text() -> str:
+    return repl.send("Explore.text ();")
+
+@mcp.tool(description="Replace the step at `idx` with new Isar text. Subsequent steps are replayed if auto_replay is on.")
+def edit(idx: int, isar_text: str) -> str:
+    return repl.send(f"Explore.edit {ml_int(idx)} {ml_str(isar_text)};")
+
+@mcp.tool(description="Re-execute all stale steps in the current REPL.")
+def replay() -> str:
+    return repl.send("Explore.replay ();")
+
+@mcp.tool(description="Discard all steps after the given index.")
+def truncate(idx: int) -> str:
+    return repl.send(f"Explore.truncate {ml_int(idx)};")
+
+@mcp.tool(description="Merge the current sub-REPL back into its parent.")
+def merge() -> str:
+    return repl.send("Explore.merge ();")
+
+@mcp.tool(description="Run Sledgehammer on the current proof state with the given timeout in seconds.")
+def sledgehammer(timeout_secs: int) -> str:
+    return repl.send(f"Explore.sledgehammer {ml_int(timeout_secs)};")
+
+@mcp.tool(description="Set step timeout in seconds (0=unlimited, default 5s).")
+def timeout(secs: int) -> str:
+    return repl.send(f"Explore.timeout {ml_int(secs)};")
+
+@mcp.tool(description="Remove a REPL and all its sub-REPLs.")
+def remove(id: str) -> str:
+    return repl.send(f"Explore.remove {ml_str(id)};")
+
+@mcp.tool(description="List all REPL sessions.")
+def repls() -> str:
+    return repl.send("Explore.repls ();")
+
+@mcp.tool(description="List all loaded Isabelle theories.")
+def theories() -> str:
+    return repl.send("Explore.theories ();")
+
+@mcp.tool(description="List command spans of a stored theory. Use negative indices to count from the end.")
+def source(theory_name: str, start: int, stop: int) -> str:
+    return repl.send(f"Explore.source {ml_str(theory_name)} {ml_int(start)} {ml_int(stop)};")
+
+@mcp.tool(description="Update Explore config. Only provided fields are changed; others are left as-is.")
+def config(color: bool | None = None, show_ignored: bool | None = None,
+           full_spans: bool | None = None, show_theory_in_source: bool | None = None,
+           auto_replay: bool | None = None) -> str:
+    fields = {"color": color, "show_ignored": show_ignored, "full_spans": full_spans,
+              "show_theory_in_source": show_theory_in_source, "auto_replay": auto_replay}
+    parts = []
+    for name, val in fields.items():
+        if val is not None:
+            parts.append(f"{name} = {'true' if val else 'false'}")
+        else:
+            parts.append(f"{name} = #{name} c")
+    ml = "fn c => {" + ", ".join(parts) + "}"
+    return repl.send(f"Explore.config ({ml});")
+
+@mcp.tool(description="Show the Explore help text.")
+def help() -> str:
+    return repl.send("Explore.help ();")
+
+@mcp.tool(description="Send a raw ML expression to the Poly/ML console. Use for anything not covered by other tools.")
+def raw_ml(ml_code: str) -> str:
+    return repl.send(ml_code)
+
+# ---------------------------------------------------------------------------
+# Main
+# ---------------------------------------------------------------------------
+
+def main():
+    mcp.run(transport="stdio")
+
+if __name__ == "__main__":
+    main()

--- a/ir/repl.py
+++ b/ir/repl.py
@@ -1,0 +1,732 @@
+#!/usr/bin/env python3
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: MIT
+
+"""
+TCP server wrapping an Isabelle/Poly/ML console with the Explore REPL.
+
+Starts an Isabelle console process, loads explore.ML, then listens for
+TCP connections on localhost. Clients send commands as single lines
+(terminated by newline). The server responds with the output followed
+by a sentinel line "<<DONE>>\\n". Multiple commands can be sent on the
+same connection. Commands are serialized across all clients.
+
+The server operator gets a management console on stdin/stdout:
+  - Lines starting with / are management commands
+  - Everything else is sent to the REPL directly
+
+Management commands:
+  /connections   Show number of open client connections
+  /log           Toggle verbose logging
+  /quit          Shut down the server
+  /help          Show available commands
+
+Usage:
+    python3 repl.py [--port PORT] [--isabelle PATH] [--session SESSION]
+                    [--dir DIR]
+"""
+
+import argparse
+import os
+import re
+import select
+import shlex
+import signal
+import socket
+import subprocess
+import sys
+import threading
+import time
+
+from prompt_toolkit import PromptSession
+from prompt_toolkit.completion import Completer, Completion
+from prompt_toolkit.filters import Always
+from prompt_toolkit.formatted_text import HTML
+from prompt_toolkit.history import FileHistory
+from prompt_toolkit.patch_stdout import patch_stdout
+
+EXPLORE_CMDS = {
+    'Explore.init':           'id thy  — create REPL "id" at "Theory" or "Theory:idx"',
+    'Explore.fork':           'id state_idx  — fork new REPL from current at given state (0=base, ~1=latest)',
+    'Explore.focus':          'id  — switch to REPL "id"',
+    'Explore.step':           '"isar text"  — execute Isar text as next step in current REPL',
+    'Explore.step_file':      'path  — execute Isar text from file as next step',
+    'Explore.show':           '()  — show current REPL: origin, steps, staleness',
+    'Explore.state':          'idx  — show proof state at step idx in current REPL (0=base, ~1=latest)',
+    'Explore.text':           '()  — print concatenated Isar text of current REPL',
+    'Explore.edit':           'idx "text"  — replace step idx in current REPL, mark later steps stale',
+    'Explore.replay':         '()  — re-execute all stale steps in current REPL',
+    'Explore.truncate':       'idx  — keep steps 0..idx in current REPL, discard the rest',
+    'Explore.merge':          '()  — inline current sub-REPL back into its parent',
+    'Explore.remove':         'id  — delete REPL "id" and all its sub-REPLs',
+    'Explore.repls':           '()  — list all REPLs with step counts and origins',
+    'Explore.theories':  '()  — list all theories loaded in the session',
+    'Explore.source':       'thy start stop  — list theory commands (start/stop are 0-based, ~N from end)',
+    'Explore.sledgehammer':   'secs  — run sledgehammer on current proof goal with timeout',
+    'Explore.timeout':        'secs  — set step timeout (0=unlimited, default 5s)',
+    'Explore.explode':        'idx  — split multi-command step idx into individual steps',
+    'Explore.config':         'f  — update config (color, show_ignored, full_spans, auto_replay)',
+    'Explore.help':           '()  — show full help text',
+    '/connections':           'show open client connections',
+    '/log':                   'toggle verbose logging',
+    '/quit':                  'shut down the server',
+    '/help':                  'show available commands',
+}
+
+# Structured signatures: (params_list, description)
+EXPLORE_SIGS = {
+    'Explore.init':          (['id', 'thy'], 'create REPL "id" at "Theory" or "Theory:idx"'),
+    'Explore.fork':          (['id', 'state_idx'], 'fork new REPL from current at given state (0=base, ~1=latest)'),
+    'Explore.focus':         (['id'], 'switch to REPL "id"'),
+    'Explore.step':          (['"isar text"'], 'execute Isar text as next step in current REPL'),
+    'Explore.step_file':     (['path'], 'execute Isar text from file as next step'),
+    'Explore.show':          ([], 'show current REPL: origin, steps, staleness'),
+    'Explore.state':         (['idx'], 'show proof state at step idx in current REPL (0=base, ~1=latest)'),
+    'Explore.text':          ([], 'print concatenated Isar text of current REPL'),
+    'Explore.edit':          (['idx', '"text"'], 'replace step idx in current REPL, mark later steps stale'),
+    'Explore.replay':        ([], 're-execute all stale steps in current REPL'),
+    'Explore.truncate':      (['idx'], 'keep steps 0..idx in current REPL, discard the rest'),
+    'Explore.merge':         ([], 'inline current sub-REPL back into its parent'),
+    'Explore.remove':        (['id'], 'delete REPL "id" and all its sub-REPLs'),
+    'Explore.repls':          ([], 'list all REPLs with step counts and origins'),
+    'Explore.theories': ([], 'list all theories loaded in the session'),
+    'Explore.source':      (['thy', 'start', 'stop'], 'list theory commands (start/stop 0-based, ~N from end)'),
+    'Explore.sledgehammer':  (['secs'], 'run sledgehammer on current proof goal with timeout'),
+    'Explore.timeout':       (['secs'], 'set step timeout (0=unlimited, default 5s)'),
+    'Explore.explode':       (['idx'], 'split multi-command step idx into individual steps'),
+    'Explore.config':        (['f'], 'update config (color, show_ignored, full_spans, auto_replay)'),
+    'Explore.help':          ([], 'show full help text'),
+}
+
+# Maps (command, argument_index) to completion type
+_ARG_COMPLETIONS = {
+    ('Explore.init', 1): 'theory',      # 2nd arg is theory
+    ('Explore.source', 0): 'theory',   # 1st arg is theory
+    ('Explore.focus', 0): 'repl',
+    ('Explore.remove', 0): 'repl',
+    ('Explore.fork', 0): 'repl',
+}
+
+
+class ExploreCompleter(Completer):
+    """Context-aware completer for the Explore REPL."""
+
+    def __init__(self):
+        self.theories = []
+        self.repl_ids = []
+        self.source_cache = {}  # theory_name -> [(idx, text), ...]
+
+    def learn_theories(self, output):
+        self.theories = [l.strip() for l in output.splitlines() if l.strip()]
+
+    def learn_source(self, theory, output):
+        """Parse output of Explore.source and cache per theory."""
+        entries = []
+        for line in output.splitlines():
+            m = re.match(r'\s*(\d+)\s+(.*)', line)
+            if m:
+                entries.append((int(m.group(1)), m.group(2).strip()))
+        self.source_cache[theory] = entries
+
+    def learn_repls(self, output):
+        import re
+        self.repl_ids = re.findall(r'[>]?\s*(\S+)\s+\(', output)
+
+    def _parse_context(self, text):
+        """Parse text to determine: command name, whether we're inside an
+        open string, and which argument position the cursor is at.
+        Returns (cmd, in_string, arg_idx, partial)."""
+        cmd = ""
+        in_string = False
+        arg_idx = 0
+        string_start = 0
+        in_bare = False
+
+        m = re.match(r'(\S+)', text)
+        if m:
+            cmd = m.group(1)
+
+        # Start scanning after the command
+        i = len(cmd)
+        while i < len(text):
+            c = text[i]
+            if in_string:
+                if c == '\\' and i + 1 < len(text):
+                    i += 2
+                    continue
+                if c == '"':
+                    in_string = False
+                    in_bare = False
+            else:
+                if c == '"':
+                    in_string = True
+                    in_bare = False
+                    string_start = i + 1
+                elif c == ' ' or c == '\t':
+                    if in_bare:
+                        in_bare = False
+                elif not in_bare and not in_string:
+                    in_bare = True
+            # Count transitions into a new argument
+            if (in_string or in_bare) and i > len(cmd):
+                pass  # inside an argument
+            i += 1
+
+        # Count arguments: split the part after the command
+        after_cmd = text[len(cmd):]
+        # Tokenize respecting quotes
+        args = []
+        current = ""
+        qs = False
+        for ch in after_cmd:
+            if qs:
+                current += ch
+                if ch == '"':
+                    qs = False
+                    args.append(current)
+                    current = ""
+            elif ch == '"':
+                qs = True
+                current += ch
+            elif ch in ' \t':
+                if current:
+                    args.append(current)
+                    current = ""
+            else:
+                current += ch
+        # current holds the in-progress token (if any)
+        arg_idx = len(args)  # completed args = index of current/next arg
+        in_string = qs
+        partial = current[1:] if qs and current.startswith('"') else ""
+
+        return cmd, in_string, arg_idx, partial
+
+    def _yield_for_type(self, comp_type, partial):
+        if comp_type == 'theory':
+            for t in self.theories:
+                if t.startswith(partial):
+                    yield Completion(t, start_position=-len(partial))
+        elif comp_type == 'repl':
+            for r in self.repl_ids:
+                if r.startswith(partial):
+                    yield Completion(r, start_position=-len(partial))
+
+    def get_completions(self, document, complete_event):
+        text = document.text_before_cursor
+        cmd, in_string, arg_idx, partial = self._parse_context(text)
+
+        if in_string:
+            key = (cmd, arg_idx)
+            yield from self._yield_for_type(_ARG_COMPLETIONS.get(key), partial)
+            return
+
+        # Between arguments — preview what the next string arg would complete
+        if ' ' in text:
+            key = (cmd, arg_idx)
+            comp_type = _ARG_COMPLETIONS.get(key)
+            if comp_type:
+                for c in self._yield_for_type(comp_type, ""):
+                    yield c
+            return
+
+        # Command completion — only while typing the first token
+        word = document.get_word_before_cursor(WORD=True)
+        for c, sig in EXPLORE_CMDS.items():
+            if c.startswith(word):
+                yield Completion(c, start_position=-len(word), display_meta=sig)
+
+PROMPT = "Poly/ML> "
+PROMPT_RE = re.compile(re.escape(PROMPT) + r"$")
+SENTINEL = "<<DONE>>"
+
+
+def _load_symbols(isabelle_bin):
+    """Load unicode-to-Isabelle-ASCII mapping from $ISABELLE_HOME/etc/symbols."""
+    isabelle_home = subprocess.check_output(
+        [isabelle_bin, "getenv", "-b", "ISABELLE_HOME"],
+        text=True, timeout=10).strip()
+    symbols_path = os.path.join(isabelle_home, "etc", "symbols")
+    unicode_to_ascii = {}
+    with open(symbols_path, "r") as f:
+        for line in f:
+            line = line.strip()
+            if not line or line.startswith("#"):
+                continue
+            parts = line.split()
+            if len(parts) >= 3 and parts[1] == "code:":
+                sym = parts[0].replace('\\', '\\\\')
+                cp = int(parts[2], 16)
+                unicode_to_ascii[chr(cp)] = sym
+    return unicode_to_ascii
+
+
+UNICODE_TO_ASCII = {}
+
+
+def unicode_to_isabelle(text):
+    """Replace unicode characters with Isabelle ASCII encoding."""
+    return "".join(UNICODE_TO_ASCII.get(c, c) for c in text)
+
+# ANSI colors
+RST = "\033[0m"
+BOLD = "\033[1m"
+DIM = "\033[2m"
+RED = "\033[31m"
+GREEN = "\033[32m"
+YELLOW = "\033[33m"
+BLUE = "\033[34m"
+CYAN = "\033[36m"
+
+
+class BashServer:
+    """Starts an Isabelle Bash.Server for external tool support (e.g. Sledgehammer)."""
+
+    def __init__(self, isabelle):
+        cmd = [isabelle, "scala", "-e",
+               '{ val server = isabelle.Bash.Server.start(debugging = false); '
+               'println("BASH_SERVER_ADDRESS=" + server.address); '
+               'println("BASH_SERVER_PASSWORD=" + server.password); '
+               'Thread.sleep(Long.MaxValue) }']
+        self.proc = subprocess.Popen(
+            cmd, stdin=subprocess.DEVNULL,
+            stdout=subprocess.PIPE, stderr=subprocess.PIPE,
+            start_new_session=True)
+        self.address = None
+        self.password = None
+        done = threading.Event()
+        t = threading.Thread(target=spinner, args=("Starting Bash.Server...", done), daemon=True)
+        t.start()
+        while True:
+            line = self.proc.stdout.readline().decode().strip()
+            if not line and self.proc.poll() is not None:
+                done.set(); t.join()
+                err = self.proc.stderr.read().decode()
+                raise RuntimeError(f"Bash.Server failed to start: {err}")
+            if line.startswith("BASH_SERVER_ADDRESS="):
+                self.address = line.split("=", 1)[1]
+            elif line.startswith("BASH_SERVER_PASSWORD="):
+                self.password = line.split("=", 1)[1]
+            if self.address and self.password:
+                break
+        done.set()
+        t.join()
+
+    def close(self):
+        if self.proc.poll() is None:
+            os.killpg(self.proc.pid, signal.SIGTERM)
+            try:
+                self.proc.wait(timeout=5)
+            except subprocess.TimeoutExpired:
+                os.killpg(self.proc.pid, signal.SIGKILL)
+
+
+def spinner(label, done_event):
+    """Print a spinner with elapsed time to stderr until done_event is set."""
+    frames = ['⠋', '⠙', '⠹', '⠸', '⠼', '⠴', '⠦', '⠧', '⠇', '⠏']
+    start = time.time()
+    i = 0
+    while not done_event.is_set():
+        elapsed = int(time.time() - start)
+        sys.stderr.write(f"\r{frames[i % len(frames)]} {label} ({elapsed}s)  ")
+        sys.stderr.flush()
+        done_event.wait(0.1)
+        i += 1
+    sys.stderr.write(f"\r\033[K")  # clear the spinner line
+    sys.stderr.flush()
+
+
+class PolyMLProcess:
+    """Manages a long-running Poly/ML console process."""
+
+    def __init__(self, isabelle, session, directory, bash_server=None,
+                 verbose=False, no_build=True):
+        cmd = [isabelle, "console"]
+        if directory:
+            cmd += ["-d", directory]
+        cmd += ["-l", session]
+        remote = os.environ.get("ISABELLE_REMOTE")
+        if remote:
+            print(f"{BOLD}ISABELLE_REMOTE detected — using remote ML prover{RST}", flush=True)
+            cmd += shlex.split(remote)
+        if no_build:
+            cmd.append("-n")
+        if bash_server:
+            cmd += ["-o", f"bash_process_address={bash_server.address}",
+                    "-o", f"bash_process_password={bash_server.password}"]
+
+        self.proc = subprocess.Popen(
+            cmd,
+            stdin=subprocess.PIPE,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.STDOUT,
+            bufsize=0,
+        )
+        done = threading.Event()
+        t = threading.Thread(target=spinner, args=("Loading heap...", done), daemon=True)
+        t.start()
+        startup = self._read_until_prompt()
+        done.set()
+        t.join()
+        if verbose:
+            print(startup, end="", flush=True)
+
+    def _read_until_prompt(self):
+        buf = b""
+        while True:
+            select.select([self.proc.stdout], [], [])
+            chunk = os.read(self.proc.stdout.fileno(), 4096)
+            if not chunk:
+                rc = self.proc.wait()
+                raise EOFError(
+                    f"Poly/ML process terminated (rc={rc}), output so far:\n"
+                    + buf.decode("utf-8", errors="replace"))
+            buf += chunk
+            text = buf.decode("utf-8", errors="replace")
+            if PROMPT_RE.search(text):
+                return text
+
+    def send(self, command):
+        line = unicode_to_isabelle(command.strip()) + "\n"
+        self.proc.stdin.write(line.encode("utf-8"))
+        self.proc.stdin.flush()
+        raw = self._read_until_prompt()
+        return self._clean_output(raw)
+
+    @staticmethod
+    def _clean_output(raw):
+        text = PROMPT_RE.sub("", raw)
+        text = re.sub(r"\nval it = \(\): unit\n?$", "", text)
+        text = text.lstrip("\n")
+        return text
+
+    def alive(self):
+        return self.proc.poll() is None
+
+    def close(self):
+        self.proc.stdin.close()
+        self.proc.wait(timeout=5)
+
+
+class Server:
+    """TCP server that serializes client commands to the Poly/ML process."""
+
+    def __init__(self, poly, port):
+        self.poly = poly
+        self.port = port
+        self.lock = threading.Lock()
+        self.sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+        self.sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+        self.sock.bind(("127.0.0.1", port))
+        self.sock.listen(8)
+        self.running = True
+        self.verbose = False
+        self.clients = {}
+        self.clients_lock = threading.Lock()
+        print(f"Explore server listening on 127.0.0.1:{port}")
+
+    def log(self, msg):
+        """Print from background thread — patch_stdout handles redisplay."""
+        print(msg)
+
+    def serve_forever(self):
+        self.sock.settimeout(1.0)
+        while self.running:
+            try:
+                client, addr = self.sock.accept()
+            except socket.timeout:
+                continue
+            except OSError:
+                break
+            with self.clients_lock:
+                self.clients[client] = {
+                    "peer": f"{addr[0]}:{addr[1]}",
+                    "started": time.time(),
+                    "last_active": time.time(),
+                    "commands": 0,
+                    "bytes_in": 0,
+                    "bytes_out": 0,
+                }
+            self.log(f"{GREEN}[+] {addr[0]}:{addr[1]} connected ({self.num_clients} total){RST}")
+            threading.Thread(
+                target=self._handle_client, args=(client,), daemon=True
+            ).start()
+
+    def _handle_client(self, client):
+        buf = b""
+        cmd_lines = []
+        with self.clients_lock:
+            peer = self.clients[client]["peer"] if client in self.clients else "?"
+        try:
+            while True:
+                chunk = client.recv(4096)
+                if not chunk:
+                    break
+                buf += chunk
+                with self.clients_lock:
+                    if client in self.clients:
+                        self.clients[client]["bytes_in"] += len(chunk)
+                while b"\n" in buf:
+                    line, buf = buf.split(b"\n", 1)
+                    text = line.decode("utf-8")
+                    cmd_lines.append(text)
+                    if not text.rstrip().endswith(";"):
+                        continue
+                    command = " ".join(cmd_lines).strip()
+                    cmd_lines = []
+                    if not command:
+                        continue
+                    if self.verbose:
+                        self.log(f"{CYAN}[{peer}]{RST} {YELLOW}>>>{RST} {command}")
+                    with self.lock:
+                        if not self.poly.alive():
+                            msg = f"ERR: Poly/ML process terminated\n{SENTINEL}\n"
+                            client.sendall(msg.encode("utf-8"))
+                            self.running = False
+                            return
+                        output = self.poly.send(command)
+                    if self.verbose:
+                        for ln in output.splitlines():
+                            self.log(f"{CYAN}[{peer}]{RST} {DIM}<<<{RST} {ln}")
+                    response = (output + "\n" + SENTINEL + "\n").encode("utf-8")
+                    client.sendall(response)
+                    with self.clients_lock:
+                        if client in self.clients:
+                            self.clients[client]["commands"] += 1
+                            self.clients[client]["bytes_out"] += len(response)
+                            self.clients[client]["last_active"] = time.time()
+        except (ConnectionResetError, BrokenPipeError):
+            pass
+        finally:
+            with self.clients_lock:
+                info = self.clients.pop(client, None)
+            client.close()
+            peer = info["peer"] if info else "unknown"
+            self.log(f"{RED}[-] {peer} disconnected ({self.num_clients} total){RST}")
+
+    def client_info(self):
+        with self.clients_lock:
+            return list(self.clients.values())
+
+    @property
+    def num_clients(self):
+        with self.clients_lock:
+            return len(self.clients)
+
+    def shutdown(self):
+        self.running = False
+        self.sock.close()
+
+
+def make_toolbar(completer):
+    """Create a bottom toolbar that shows the current command's signature,
+    and source context when typing Theory:N arguments."""
+    def toolbar():
+        app = __import__('prompt_toolkit').application.get_app()
+        text = app.current_buffer.text
+        cmd, in_string, arg_idx, partial = completer._parse_context(text)
+
+        # Check if we're typing a Theory:N argument (2nd arg of init, 1st of source)
+        if in_string and partial and ':' in partial:
+            thy, idx_str = partial.rsplit(':', 1)
+            segs = completer.source_cache.get(thy)
+            if segs and idx_str.lstrip('~').isdigit():
+                try:
+                    n = int(idx_str)
+                    if idx_str.startswith('~'):
+                        n = max(s[0] for s in segs) + 1 + n
+                except ValueError:
+                    n = 0
+                # Show 5 source lines around n
+                ctx = 3
+                lines = []
+                ansi_re = re.compile(r'\033\[[0-9;]*m')
+                for idx, txt in segs:
+                    if abs(idx - n) <= ctx:
+                        display = ansi_re.sub('', txt)
+                        if len(display) > 60:
+                            display = display[:60] + '...'
+                        display = display.replace('&', '&amp;').replace('<', '&lt;').replace('>', '&gt;')
+                        if idx == n:
+                            lines.append(f"<b>   {idx:4d}  {display}</b>")
+                        else:
+                            lines.append(f"<ansigray>   {idx:4d}  {display}</ansigray>")
+                    if idx == n:
+                        lines.append(f"<ansigreen>   ---- REPL starts here ----</ansigreen>")
+                if lines:
+                    return HTML('\n'.join(lines))
+
+        sig = EXPLORE_SIGS.get(cmd)
+        if not sig:
+            return ""
+        params, desc = sig
+        if not params:
+            return HTML(f" <b>{cmd}</b> ()  <i>{desc}</i>")
+        parts = []
+        for i, p in enumerate(params):
+            if i == arg_idx:
+                parts.append(f"<b><u>{p}</u></b>")
+            else:
+                parts.append(f"<ansigray>{p}</ansigray>")
+        return HTML(f" <b>{cmd}</b> {' '.join(parts)}  <i>{desc}</i>")
+    return toolbar
+
+
+def console_loop(server, session):
+    """Interactive console for the server operator."""
+    cmd_lines = []
+    last_interrupt = 0
+    while server.running:
+        try:
+            prompt = HTML("<b><ansicyan>%&gt;</ansicyan></b> ") if not cmd_lines \
+                else HTML("<ansigray>.. </ansigray>")
+            line = session.prompt(prompt, bottom_toolbar=make_toolbar(session.completer))
+            last_interrupt = 0
+        except KeyboardInterrupt:
+            now = time.time()
+            if now - last_interrupt < 2:
+                break
+            last_interrupt = now
+            if cmd_lines:
+                cmd_lines = []
+                print(f"{YELLOW}Input cancelled.{RST}")
+            else:
+                print(f"{YELLOW}Press Ctrl+C again to quit.{RST}")
+            continue
+        except EOFError:
+            break
+
+        stripped = line.strip()
+        if not stripped and not cmd_lines:
+            continue
+
+        if stripped.startswith("/") and not cmd_lines:
+            cmd = stripped.split()[0].lower()
+            if cmd == "/connections":
+                infos = server.client_info()
+                print(f"{DIM}Listening on 127.0.0.1:{server.port}{RST}")
+                if not infos:
+                    print(f"{DIM}No open connections.{RST}")
+                else:
+                    now = time.time()
+                    print(f"{BOLD}{len(infos)} open connection(s):{RST}")
+                    for i, c in enumerate(infos):
+                        age = int(now - c["started"])
+                        idle = int(now - c["last_active"])
+                        print(f"  {CYAN}{i}: {c['peer']}{RST}  "
+                              f"age={age}s  "
+                              f"idle={idle}s  "
+                              f"cmds={c['commands']}  "
+                              f"in={c['bytes_in']}B out={c['bytes_out']}B")
+            elif cmd == "/quit":
+                break
+            elif cmd == "/log":
+                server.verbose = not server.verbose
+                state = f"{GREEN}ON{RST}" if server.verbose else f"{RED}OFF{RST}"
+                print(f"Verbose logging {state}")
+            elif cmd == "/help":
+                print(f"{BOLD}Management commands:{RST}")
+                log_state = f"{GREEN}ON{RST}" if server.verbose else f"{RED}OFF{RST}"
+                print(f"  {YELLOW}/connections{RST}   Show open client connections")
+                print(f"  {YELLOW}/log{RST}           Toggle verbose logging (currently {log_state})")
+                print(f"  {YELLOW}/quit{RST}          Shut down the server")
+                print(f"  {YELLOW}/help{RST}          This help")
+                print("Anything else is sent to the REPL.")
+            else:
+                print(f"{RED}Unknown command: {cmd}{RST} (try /help)")
+        else:
+            cmd_lines.append(line)
+            if not line.rstrip().endswith(";"):
+                continue
+            command = " ".join(cmd_lines).strip()
+            cmd_lines = []
+            with server.lock:
+                if not server.poly.alive():
+                    print(f"{RED}ERR: Poly/ML process terminated{RST}")
+                    break
+                output = server.poly.send(command)
+            print(output)
+            # Update completer from command output
+            if "theories" in command:
+                session.completer.learn_theories(output)
+            elif command.startswith("Explore.repls"):
+                session.completer.learn_repls(output)
+            elif command.startswith("Explore.source"):
+                m = re.match(r'Explore\.source\s+"([^"]+)"', command)
+                if m:
+                    session.completer.learn_source(m.group(1), output)
+
+
+def main():
+    p = argparse.ArgumentParser(description="Explore REPL TCP server")
+    p.add_argument("--port", type=int, default=9147)
+    p.add_argument("--isabelle", default=os.path.expanduser(
+        "~/Isabelle2025-2-experimental.app/bin/isabelle"))
+    p.add_argument("--session", default="AutoCorrode")
+    p.add_argument("--dir", default=None)
+    p.add_argument("-v", "--verbose", action="store_true",
+                   help="Print the Isabelle/Poly/ML command being invoked")
+    p.add_argument("--check-heap", action="store_true",
+                   help="Check and rebuild session heap if needed (default: load as-is)")
+    p.add_argument("--no-bash-server", action="store_true",
+                   help="Skip Bash.Server startup (disables sledgehammer)")
+    args = p.parse_args()
+
+    ml_path = os.path.join(os.path.dirname(os.path.abspath(__file__)), "explore.ML")
+
+    global UNICODE_TO_ASCII
+    UNICODE_TO_ASCII = _load_symbols(args.isabelle)
+
+    bash_server = None
+    if not args.no_bash_server:
+        print(f"{BOLD}Starting Bash.Server...{RST}", flush=True)
+        bash_server = BashServer(args.isabelle)
+        print(f"{GREEN}Bash.Server ready at {bash_server.address}{RST}", flush=True)
+    else:
+        print(f"{DIM}Bash.Server skipped (sledgehammer unavailable){RST}", flush=True)
+
+    def _signal_cleanup(signum, frame):
+        if bash_server:
+            bash_server.close()
+        sys.exit(128 + signum)
+    signal.signal(signal.SIGTERM, _signal_cleanup)
+    signal.signal(signal.SIGHUP, _signal_cleanup)
+
+    print(f"{BOLD}Starting Isabelle console (session={args.session})...{RST}", flush=True)
+    poly = PolyMLProcess(args.isabelle, args.session, args.dir,
+                         bash_server=bash_server, verbose=args.verbose,
+                         no_build=not args.check_heap)
+    print(f"{GREEN}Isabelle console ready.{RST}", flush=True)
+
+    print(f"Loading {BOLD}{ml_path}{RST}...", flush=True)
+    ml_code = open(ml_path).read().replace('\n', ' ')
+    out = poly.send(ml_code)
+    if "Exception" in out or "ML error" in out:
+        print(f"{RED}Failed to load {ml_path}:{RST}\n{out}", file=sys.stderr)
+        poly.close()
+        sys.exit(1)
+    print(f"{GREEN}Explore loaded.{RST}", flush=True)
+
+    histfile = os.path.expanduser("~/.explore_repl_history")
+    completer = ExploreCompleter()
+    session = PromptSession(history=FileHistory(histfile), completer=completer,
+                            complete_while_typing=Always())
+
+    server = Server(poly, args.port)
+    accept_thread = threading.Thread(target=server.serve_forever, daemon=True)
+    accept_thread.start()
+
+    try:
+        with patch_stdout(raw=True):
+            console_loop(server, session)
+    except KeyboardInterrupt:
+        pass
+    finally:
+        print("Shutting down...", flush=True)
+        server.shutdown()
+        poly.close()
+        if bash_server:
+            bash_server.close()
+
+
+if __name__ == "__main__":
+    main()

--- a/ir/requirements.txt
+++ b/ir/requirements.txt
@@ -1,0 +1,2 @@
+prompt_toolkit>=3.0
+mcp>=1.0

--- a/ir/test_console.py
+++ b/ir/test_console.py
@@ -1,0 +1,195 @@
+#!/usr/bin/env python3
+"""Test explore.ML via isabelle console.
+
+Assumes the session heap is already built.
+
+Usage: python3 test_console.py [--isabelle PATH] [--session SESSION] [--dir DIR]
+"""
+import argparse
+import os
+import re
+import shutil
+import subprocess
+import sys
+import time
+
+SCRIPT_DIR = os.path.dirname(os.path.abspath(__file__))
+EXPLORE_ML = os.path.join(SCRIPT_DIR, "explore.ML")
+
+# ANSI
+_RED = "\033[31m"
+_GREEN = "\033[32m"
+_YELLOW = "\033[33m"
+_BOLD = "\033[1m"
+_DIM = "\033[2m"
+_RESET = "\033[0m"
+_SYM_OK = f"{_GREEN}✓{_RESET}"
+_SYM_FAIL = f"{_RED}✗{_RESET}"
+_SYM_SKIP = f"{_YELLOW}–{_RESET}"
+_SYM_BUSY = f"{_YELLOW}↻{_RESET}"
+_CLEAR_LINE = "\r\033[2K"
+
+passed = 0
+failed = 0
+
+
+def run_console(isabelle, session, directory, ml_commands):
+    """Pipe ml_commands into isabelle console, return (exit_code, output)."""
+    cmd = [isabelle, "console"]
+    if directory:
+        cmd += ["-d", directory]
+    cmd += ["-l", session, "-n"]
+    result = subprocess.run(
+        cmd, input=ml_commands + "\n",
+        capture_output=True, text=True, timeout=120)
+    return result.returncode, result.stdout + result.stderr
+
+
+def run_test(name, isabelle, session, directory, ml_commands):
+    global passed, failed
+    print(f"  {_SYM_BUSY} {name}", end="", flush=True)
+    t0 = time.time()
+    try:
+        rc, output = run_console(isabelle, session, directory, ml_commands)
+        elapsed = time.time() - t0
+        if rc != 0 or re.search(r"^Exception-|^exception .+ raised|^Error[- ]|^ML error",
+                                    output, re.MULTILINE):
+            print(f"{_CLEAR_LINE}  {_SYM_FAIL} {name} {_DIM}({elapsed:.1f}s){_RESET}")
+            for line in output.splitlines()[-5:]:
+                print(f"    {_DIM}{line}{_RESET}")
+            failed += 1
+        else:
+            print(f"{_CLEAR_LINE}  {_SYM_OK} {name} {_DIM}({elapsed:.1f}s){_RESET}")
+            passed += 1
+    except Exception as e:
+        elapsed = time.time() - t0
+        print(f"{_CLEAR_LINE}  {_SYM_FAIL} {name}: {e} {_DIM}({elapsed:.1f}s){_RESET}")
+        failed += 1
+
+
+def use(ml):
+    return f'use "{EXPLORE_ML}"; {ml}'
+
+
+def main():
+    p = argparse.ArgumentParser(description="Test explore.ML via isabelle console")
+    p.add_argument("--isabelle", default=os.environ.get("ISABELLE", "isabelle"))
+    p.add_argument("--session", default="HOL")
+    p.add_argument("--dir", default=None)
+    p.add_argument("--require-source", action="store_true",
+                   help="Fail if source commands are not available")
+    args = p.parse_args()
+
+    # Preflight checks
+    if not shutil.which(args.isabelle):
+        print(f"{_SYM_FAIL} isabelle not found: {args.isabelle}", file=sys.stderr)
+        sys.exit(1)
+    if not os.path.isfile(EXPLORE_ML):
+        print(f"{_SYM_FAIL} explore.ML not found: {EXPLORE_ML}", file=sys.stderr)
+        sys.exit(1)
+
+    # Probe source availability up front
+    print(f"{_BOLD}Probing{_RESET} source availability "
+          f"{_DIM}(session={args.session}){_RESET}", flush=True)
+    print(f"  {_SYM_BUSY} loading heap", end="", flush=True)
+    t0 = time.time()
+    _, probe_output = run_console(
+        args.isabelle, args.session, args.dir, f'use "{EXPLORE_ML}";')
+    has_source = "source commands available" in probe_output and "not available" not in probe_output
+    avail_thy = None
+
+    if has_source:
+        m = re.search(r"source commands available \((\d+) theories?\)", probe_output)
+        n_theories = m.group(1) if m else "?"
+        _, seg_output = run_console(
+            args.isabelle, args.session, args.dir,
+            use('(Explore.source "Main" 0 0 handle ERROR msg => writeln msg);'))
+        m = re.search(r'Available: (\S+)', seg_output)
+        if m:
+            avail_thy = m.group(1).rstrip(',')
+        elapsed = time.time() - t0
+        print(f"{_CLEAR_LINE}  {_SYM_OK} source commands available "
+              f"({n_theories} theories, sample: {avail_thy or 'none'}) "
+              f"{_DIM}({elapsed:.1f}s){_RESET}")
+    else:
+        elapsed = time.time() - t0
+        print(f"{_CLEAR_LINE}  {_SYM_SKIP} source commands not available "
+              f"{_DIM}({elapsed:.1f}s){_RESET}")
+        if args.require_source:
+            print(f"{_SYM_FAIL} --require-source set but source commands not available")
+            sys.exit(1)
+
+    # Run tests
+    print(f"\n{_BOLD}Running{_RESET} explore.ML console tests "
+          f"{_DIM}(session={args.session}){_RESET}")
+
+    run = lambda name, ml: run_test(name, args.isabelle, args.session, args.dir, ml)
+
+    run("load explore.ML",
+        f'use "{EXPLORE_ML}";')
+
+    run("help",
+        use('Explore.help ();'))
+
+    run("theories",
+        use('Explore.theories ();'))
+
+    run("init + show",
+        use('Explore.init "t1" "Main"; Explore.show ();'))
+
+    run("step + state",
+        use('Explore.init "t1" "Main"; Explore.step "lemma True by simp"; Explore.state ~1;'))
+
+    run("text",
+        use('Explore.init "t1" "Main"; Explore.step "lemma True by simp"; Explore.text ();'))
+
+    run("edit + replay",
+        use('Explore.init "t1" "Main"; Explore.step "lemma True by simp"; '
+            'Explore.edit 0 "lemma True by auto"; Explore.replay ();'))
+
+    run("truncate",
+        use('Explore.init "t1" "Main"; Explore.step "lemma True by simp"; '
+            'Explore.step "lemma True by auto"; Explore.truncate 0;'))
+
+    run("fork + focus + merge",
+        use('Explore.init "t1" "Main"; Explore.step "lemma True by simp"; '
+            'Explore.fork "t2" 0; Explore.focus "t2"; '
+            'Explore.step "lemma True by auto"; Explore.merge ();'))
+
+    run("repls + remove",
+        use('Explore.init "t1" "Main"; Explore.init "t2" "Main"; '
+            'Explore.repls (); Explore.remove "t2";'))
+
+    if has_source:
+        run_test("source (missing theory)", args.isabelle, args.session, args.dir,
+                 use('(Explore.source "Main" 0 0 handle ERROR msg => '
+                     'if String.isSubstring "No stored segments" msg '
+                     'then writeln "OK: expected error" '
+                     'else raise (ERROR msg));'))
+        if avail_thy:
+            run_test("source", args.isabelle, args.session, args.dir,
+                     use(f'Explore.source "{avail_thy}" 0 3;'))
+        else:
+            print(f"  {_SYM_SKIP} source listing {_DIM}(no stored theories){_RESET}")
+    else:
+        run_test("source (graceful error without segments)",
+                 args.isabelle, args.session, args.dir,
+                 use('(Explore.source "Main" 0 3 handle ERROR _ => ());'))
+
+    run("config",
+        use('Explore.config (fn c => {color = false, show_ignored = #show_ignored c, '
+            'full_spans = #full_spans c, show_theory_in_source = #show_theory_in_source c, '
+            'auto_replay = #auto_replay c});'))
+
+    # Summary
+    total = passed + failed
+    if failed == 0:
+        print(f"\n{_SYM_OK} {_BOLD}{passed}/{total} passed{_RESET}")
+    else:
+        print(f"\n{_SYM_FAIL} {_BOLD}{passed}/{total} passed, "
+              f"{_RED}{failed} failed{_RESET}")
+    sys.exit(0 if failed == 0 else 1)
+
+
+if __name__ == "__main__":
+    main()

--- a/ir/test_repl.py
+++ b/ir/test_repl.py
@@ -1,0 +1,287 @@
+#!/usr/bin/env python3
+"""Test repl.py TCP server: single-client and multi-client.
+
+Assumes the session heap is already built.
+
+Usage: python3 test_repl.py [--isabelle PATH] [--session SESSION] [--dir DIR]
+"""
+import argparse
+import os
+import signal
+import socket
+import subprocess
+import sys
+import threading
+import time
+
+SENTINEL = "<<DONE>>"
+SCRIPT_DIR = os.path.dirname(os.path.abspath(__file__))
+
+# ANSI
+_RED = "\033[31m"
+_GREEN = "\033[32m"
+_YELLOW = "\033[33m"
+_BOLD = "\033[1m"
+_DIM = "\033[2m"
+_RESET = "\033[0m"
+_SYM_OK = f"{_GREEN}✓{_RESET}"
+_SYM_FAIL = f"{_RED}✗{_RESET}"
+_SYM_BUSY = f"{_YELLOW}↻{_RESET}"
+_CLEAR_LINE = "\r\033[2K"
+
+
+def find_free_port():
+    with socket.socket() as s:
+        s.bind(("127.0.0.1", 0))
+        return s.getsockname()[1]
+
+
+def send_recv(sock, cmd):
+    """Send a command and read until sentinel."""
+    sock.sendall((cmd.strip() + "\n").encode())
+    buf = b""
+    while True:
+        chunk = sock.recv(4096)
+        if not chunk:
+            raise EOFError("Connection closed")
+        buf += chunk
+        text = buf.decode("utf-8", errors="replace")
+        if SENTINEL in text:
+            return text[:text.index(SENTINEL)].strip()
+
+
+def connect(port, retries=120, delay=2.0):
+    """Connect to the server, retrying until ready."""
+    for i in range(retries):
+        try:
+            s = socket.create_connection(("127.0.0.1", port), timeout=5)
+            return s
+        except (ConnectionRefusedError, OSError):
+            time.sleep(delay)
+    raise RuntimeError(f"Server not ready after {retries * delay}s")
+
+
+passed = 0
+failed = 0
+
+
+def run_test(name, fn):
+    global passed, failed
+    print(f"  {_SYM_BUSY} {name}", end="", flush=True)
+    t0 = time.time()
+    try:
+        fn()
+        elapsed = time.time() - t0
+        print(f"{_CLEAR_LINE}  {_SYM_OK} {name} {_DIM}({elapsed:.1f}s){_RESET}")
+        passed += 1
+        return True
+    except AssertionError as e:
+        elapsed = time.time() - t0
+        print(f"{_CLEAR_LINE}  {_SYM_FAIL} {name} {_DIM}({elapsed:.1f}s){_RESET}")
+        for line in str(e).splitlines():
+            print(f"    {_DIM}{line}{_RESET}")
+        failed += 1
+        return False
+    except Exception as e:
+        elapsed = time.time() - t0
+        print(f"{_CLEAR_LINE}  {_SYM_FAIL} {name}: {type(e).__name__}: {e} "
+              f"{_DIM}({elapsed:.1f}s){_RESET}")
+        failed += 1
+        return False
+
+
+def main():
+    p = argparse.ArgumentParser(description="Test repl.py TCP server")
+    p.add_argument("--isabelle", default=os.environ.get(
+        "ISABELLE", "isabelle"))
+    p.add_argument("--session", default="HOL")
+    p.add_argument("--dir", default=None)
+    args = p.parse_args()
+
+    port = find_free_port()
+    repl_py = os.path.join(SCRIPT_DIR, "repl.py")
+
+    # Start repl.py
+    print(f"{_BOLD}Starting{_RESET} repl.py "
+          f"{_DIM}(port={port}, session={args.session}){_RESET}", flush=True)
+    print(f"  {_SYM_BUSY} loading heap", end="", flush=True)
+    t0 = time.time()
+
+    cmd = [sys.executable, repl_py,
+         "--port", str(port),
+         "--isabelle", args.isabelle,
+         "--session", args.session]
+    if args.dir:
+        cmd += ["--dir", args.dir]
+
+    proc = subprocess.Popen(
+        cmd,
+        stdin=subprocess.PIPE,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+        start_new_session=True,
+    )
+
+    try:
+        try:
+            sock = connect(port)
+        except RuntimeError:
+            elapsed = time.time() - t0
+            print(f"{_CLEAR_LINE}  {_SYM_FAIL} server failed to start "
+                  f"{_DIM}({elapsed:.1f}s){_RESET}")
+            # Kill the process so we can drain its output
+            os.killpg(proc.pid, signal.SIGTERM)
+            try:
+                out, _ = proc.communicate(timeout=10)
+                if out:
+                    print(f"  Server output (last 3000 chars):")
+                    for line in out.decode("utf-8", errors="replace")[-3000:].splitlines():
+                        print(f"    {_DIM}{line}{_RESET}")
+            except Exception as e:
+                print(f"    {_DIM}(could not read output: {e}){_RESET}")
+            sys.exit(1)
+
+        elapsed = time.time() - t0
+        print(f"{_CLEAR_LINE}  {_SYM_OK} connected "
+              f"{_DIM}({elapsed:.1f}s){_RESET}")
+
+        # -- Single-client tests --
+        print(f"\n{_BOLD}Running{_RESET} single-client tests")
+
+        def test_help():
+            out = send_recv(sock, 'Explore.help ();')
+            assert "Explore.init" in out, f"Expected help text, got:\n{out}"
+
+        def test_theories():
+            out = send_recv(sock, 'Explore.theories ();')
+            assert "Main" in out, f"Expected Main theory, got:\n{out}"
+
+        def test_init_show():
+            send_recv(sock, 'Explore.init "t1" "Main";')
+            out = send_recv(sock, 'Explore.show ();')
+            assert "t1" in out, f"Expected REPL t1, got:\n{out}"
+
+        def test_step():
+            out = send_recv(sock, 'Explore.step "lemma dummy: True by simp";')
+            assert "theorem dummy: True" in out, f"Unexpected output: \n{out}"
+
+        def test_state():
+            send_recv(sock, 'Explore.step "lemma foo: True";')
+            out = send_recv(sock, 'Explore.state ~1;')
+            assert "goal (1 subgoal):", f"Unexpected state:\n{out}"
+
+        def test_text():
+            out = send_recv(sock, 'Explore.text ();')
+            assert "lemma" in out, f"Expected lemma text, got:\n{out}"
+
+        def test_edit_replay():
+            send_recv(sock, 'Explore.edit 0 "lemma True by auto";')
+            send_recv(sock, 'Explore.replay ();')
+
+        def test_fork_focus_merge():
+            send_recv(sock, 'Explore.fork "t2" 0;')
+            send_recv(sock, 'Explore.focus "t2";')
+            send_recv(sock, 'Explore.step "lemma True by auto";')
+            send_recv(sock, 'Explore.merge ();')
+
+        def test_repls():
+            out = send_recv(sock, 'Explore.repls ();')
+            assert "t1" in out, f"Expected t1 in repls, got:\n{out}"
+
+        def test_source():
+            send_recv(sock, 'Explore.source "Main" 0 3 handle ERROR _ => ();')
+
+        def test_remove():
+            send_recv(sock, 'Explore.init "tmp" "Main";')
+            send_recv(sock, 'Explore.remove "tmp";')
+
+        def test_config():
+            send_recv(sock, 'Explore.config (fn c => '
+                      '{color = false, show_ignored = #show_ignored c, '
+                      'full_spans = #full_spans c, '
+                      'show_theory_in_source = #show_theory_in_source c, '
+                      'auto_replay = #auto_replay c});')
+
+        for t in [test_help, test_theories, test_init_show, test_step,
+                  test_state, test_text, test_edit_replay, test_fork_focus_merge,
+                  test_repls, test_source, test_remove, test_config]:
+            run_test(t.__name__, t)
+
+        sock.close()
+
+        # Cleanup from single-client tests
+        cleanup_sock = connect(port)
+        send_recv(cleanup_sock, 'Explore.remove "t1";')
+        cleanup_sock.close()
+
+        # -- Multi-client tests --
+        print(f"\n{_BOLD}Running{_RESET} multi-client tests")
+
+        def test_concurrent_clients():
+            """Two clients send commands concurrently; both get valid responses."""
+            s1 = connect(port)
+            s2 = connect(port)
+            results = [None, None]
+            errors = [None, None]
+
+            def client(idx, sock, cmd):
+                try:
+                    results[idx] = send_recv(sock, cmd)
+                except Exception as e:
+                    errors[idx] = e
+
+            send_recv(s1, 'Explore.init "mc1" "Main";')
+            send_recv(s1, 'Explore.init "mc2" "Main";')
+
+            t1 = threading.Thread(target=client,
+                                  args=(0, s1, 'Explore.focus "mc1"; Explore.theories ();'))
+            t2 = threading.Thread(target=client,
+                                  args=(1, s2, 'Explore.focus "mc2"; Explore.theories ();'))
+            t1.start()
+            t2.start()
+            t1.join(timeout=60)
+            t2.join(timeout=60)
+
+            for i in range(2):
+                if errors[i]:
+                    raise errors[i]
+                assert results[i] is not None, f"Client {i} got no result"
+
+            send_recv(s1, 'Explore.remove "mc1";')
+            send_recv(s1, 'Explore.remove "mc2";')
+            s1.close()
+            s2.close()
+
+        def test_client_disconnect():
+            """A client disconnects; server stays alive for new clients."""
+            s1 = connect(port)
+            send_recv(s1, 'Explore.help ();')
+            s1.close()
+            time.sleep(0.5)
+            s2 = connect(port)
+            out = send_recv(s2, 'Explore.help ();')
+            assert "Explore.init" in out
+            s2.close()
+
+        for t in [test_concurrent_clients, test_client_disconnect]:
+            run_test(t.__name__, t)
+
+    finally:
+        os.killpg(proc.pid, signal.SIGTERM)
+        try:
+            proc.wait(timeout=10)
+        except subprocess.TimeoutExpired:
+            os.killpg(proc.pid, signal.SIGKILL)
+
+    # Summary
+    total = passed + failed
+    if failed == 0:
+        print(f"\n{_SYM_OK} {_BOLD}{passed}/{total} passed{_RESET}")
+    else:
+        print(f"\n{_SYM_FAIL} {_BOLD}{passed}/{total} passed, "
+              f"{_RED}{failed} failed{_RESET}")
+    sys.exit(0 if failed == 0 else 1)
+
+
+if __name__ == "__main__":
+    main()

--- a/segment_storage.ML
+++ b/segment_storage.ML
@@ -1,0 +1,22 @@
+(* Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+   SPDX-License-Identifier: MIT *)
+
+(* Build hook that optionally stores all document segments in a global
+   table, keyed by theory name. Controlled by the system option
+   "store_segments". When enabled, segments survive into the heap image. *)
+
+val stored_segments : (string * Document_Output.segment list) list Synchronized.var
+  = Synchronized.var "stored_segments" [];
+
+val _ = Build.add_hook (fn qualifier => fn loaded_theories =>
+  if (Options.default_bool "store_segments" handle ERROR _ => false) then
+    let val entries = map (fn (thy, segs) =>
+            (Context.theory_long_name thy, segs)) loaded_theories
+        val _ = List.app (fn (name, segs) =>
+            writeln ("Segment_Storage: " ^ name ^ " (" ^
+                     string_of_int (length segs) ^ " segments) [STORING]")) entries
+    in Synchronized.change stored_segments (fn old => entries @ old)
+    end
+  else
+    writeln ("Segment_Storage: store_segments=false, skipping " ^
+             string_of_int (length loaded_theories) ^ " theories"));


### PR DESCRIPTION
This PR adds Isabelle/REPL (I/R), a tool for interactively
exploring Isabelle theories outside of jEdit, designed for use
from the command line or programmatically via TCP/MCP.

I/R consists of three components:

- explore.ML: An Isabelle/ML library loaded into a Poly/ML console
  session. It provides named, forkable REPL sessions rooted at
  arbitrary theory positions, with support for stepping through
  Isar text, editing and replaying steps, viewing proof state,
  inspecting theory source, and invoking sledgehammer. Multiple
  REPLs can coexist and be merged back into their parents.

- repl.py: A Python TCP server wrapping the Poly/ML console.
  It starts an Isabelle console process, loads explore.ML, and
  multiplexes client connections over a single serialized ML
  session. Includes an interactive management console with
  tab completion for Explore commands and Isabelle symbols,
  Unicode-to-Isabelle symbol translation, and a Bash.Server
  for external tool support (e.g. sledgehammer).

- explore_mcp.py: An MCP (Model Context Protocol) server that
  exposes each Explore function as an MCP tool, allowing LLM
  agents to drive Isabelle proof exploration over a structured
  tool interface. Connects to repl.py over TCP.