### PR TITLE
I/P: Improve robustness of remote process handling

### DIFF
--- a/ip/setup_al2.sh
+++ b/ip/setup_al2.sh
@@ -48,6 +48,10 @@ else
   rm "/tmp/$TARBALL"
   mkdir -p "$(dirname "$INSTALL_DIR")"
   mv "/tmp/Isabelle2025-2" "$INSTALL_DIR"
+  # Disable SystemOnTPTP
+  PREFS_DIR="$("$INSTALL_DIR"/bin/isabelle getenv -b ISABELLE_HOME_USER)/etc"
+  mkdir -p "$PREFS_DIR"
+  echo 'SystemOnTPTP = ""' >> "$PREFS_DIR/preferences"
   echo "Installed: $INSTALL_DIR"
 fi
 

--- a/ip/setup_ubuntu.sh
+++ b/ip/setup_ubuntu.sh
@@ -44,6 +44,10 @@ else
   rm "/tmp/$TARBALL"
   mkdir -p "$(dirname "$INSTALL_DIR")"
   mv "/tmp/Isabelle2025-2" "$INSTALL_DIR"
+  # Disable SystemOnTPTP
+  PREFS_DIR="$("$INSTALL_DIR"/bin/isabelle getenv -b ISABELLE_HOME_USER)/etc"
+  mkdir -p "$PREFS_DIR"
+  echo 'SystemOnTPTP = ""' >> "$PREFS_DIR/preferences"
   echo "Installed: $INSTALL_DIR"
 fi
 


### PR DESCRIPTION
The Isabelle/ML proxy used by I/P spawns a variety of processes on the remote, which in turn may spawn children and grandchildren. To avoid a build-up of orphaned processes on the remote, it is important to track the spawned processes and ensure that they are killed on both normal and abnormal execution of the proxy.

This commit aims to make the handling of remote processes spawned by ml_proxy.py more robust by starting processes in their own process group and thereby allowing the entire group (including the process' [grand]children) to be stopped in one `kill` command. It also registers uses `atexit` to ensure the cleanup routine is called on SIGTERM, SIGHUP, SIGINT.
