### PR TITLE
I/P: Always run setup script on remote

### DIFF
--- a/ip/configure-remote.py
+++ b/ip/configure-remote.py
@@ -343,21 +343,17 @@ def cmd_setup(args):
                       f"{local_platform_dir(local_home, args.ml_platform)}\n"
                       f"Use --force-write-local to overwrite, or --copy-from-local to push to remote.")
 
-    # Install Isabelle on remote if needed
-    if ssh_check(host, "test", "-d", remote_home) is None:
-        setup_script = pick_setup_script(arch, os_id)
-        step(f"Installing Isabelle on remote ({os.path.basename(setup_script)})")
-        print("", file=sys.stderr)
-        install_dir = remote_home
-        setup_args = [setup_script, host, install_dir,
-                      "64" if args.use_64 else "32"]
-        if args.copy_from_local:
-            setup_args.append("skip_build")
-        rc = subprocess.call(setup_args)
-        if rc != 0:
-            step_fail("Remote Isabelle installation failed")
-    else:
-        step(f"Checking remote Isabelle installation: {remote_home} ({arch} {os_id})")
+    # Install Isabelle on remote (idempotent: setup scripts skip existing components)
+    setup_script = pick_setup_script(arch, os_id)
+    step(f"Setting up Isabelle on remote ({os.path.basename(setup_script)})")
+    print("", file=sys.stderr)
+    setup_args = [setup_script, host, remote_home,
+                  "64" if args.use_64 else "32"]
+    if args.copy_from_local:
+        setup_args.append("skip_build")
+    rc = subprocess.call(setup_args)
+    if rc != 0:
+        step_fail("Remote Isabelle installation failed")
 
     step("Identifying ML platform")
     base_platform = query_base_platform(host, remote_home, args.use_64)

--- a/ip/setup_al2.sh
+++ b/ip/setup_al2.sh
@@ -112,6 +112,9 @@ if [ "$BITS" = "64" ]; then
   ML_64_OPT="-o ML_system_64=true"
 fi
 
+# Remove pre-built system heaps so isabelle build writes to user directory
+rm -rf "$ISABELLE_HOME/heaps"
+
 echo "=== Building heaps (Pure + HOL, ${BITS}-bit) ==="
 "$ISABELLE_HOME/bin/isabelle" build -b $ML_64_OPT Pure
 "$ISABELLE_HOME/bin/isabelle" build -b $ML_64_OPT HOL

--- a/ip/setup_ubuntu.sh
+++ b/ip/setup_ubuntu.sh
@@ -67,6 +67,8 @@ fi
 ML_64_OPT=""
 if [ "$BITS" = "64" ]; then ML_64_OPT="-o ML_system_64=true"; fi
 if [ -z "$SKIP_BUILD" ]; then
+  # Remove pre-built system heaps so isabelle build writes to user directory
+  rm -rf "$INSTALL_DIR/heaps"
   echo "Building Pure + HOL (${BITS}-bit) ..."
   "$INSTALL_DIR"/bin/isabelle build -b $ML_64_OPT HOL
   echo "Done."


### PR DESCRIPTION
`ip/configure-remote.py setup` sets up a new remote by downloading and unpacking Isabelle and the Word_Lib AFP entry. It targets either 32-bit or 64-bit ML, as specified by --64 (default) or --32.

Previously, however, configure-remote.py would skip calling the underlying setup scripts if the target Isabelle directory is already present. This prevented setting up a 32-bit build after initially setting up a 64-bit build, or vice versa.

This commit modifies configure-remote.py to always invoke the underlying setup script. The setup scripts already skip over components they find are already setup, so this is OK.

The setup scripts are also modified to remove system heaps from the remote installation, as I/P currently gets confused by a mixture of system and user heaps.
