### PR TITLE
New Micro Rust example: the Number Theoretic Transform (NTT) from MLKEM

### DIFF
--- a/Micro_Rust_Examples/MLKEM_NTT.thy
+++ b/Micro_Rust_Examples/MLKEM_NTT.thy
@@ -1,0 +1,604 @@
+(* Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+   SPDX-License-Identifier: MIT *)
+
+theory MLKEM_NTT
+  imports
+    MLKEM_Polynomial
+begin
+
+text\<open>
+  NTT (Number Theoretic Transform) for MLKEM. This theory contains:
+  \<^item> Pure properties of the NTT specification from @{theory Micro_Rust_Examples.MLKEM_Specification}
+  \<^item> Array lens disjointness lemmas
+  \<^item> \<mu>Rust NTT implementation with three nested loop invariants
+\<close>
+
+section\<open>NTT pure properties\<close>
+
+lemma ntt_butterfly_updates_only:
+    fixes len
+  assumes \<open>j + len < mlkem_n\<close>
+    shows \<open>\<forall>k < mlkem_n. k \<noteq> j \<and> k \<noteq> j + len \<longrightarrow>
+            array_nth (ntt_butterfly zeta j len p) k = array_nth p k\<close>
+using assms by (auto simp add: ntt_butterfly_def Let_def mlkem_n_def)
+
+lemma ntt_inner_loop_bounds:
+    fixes len start count
+  assumes \<open>start + count + len \<le> mlkem_n\<close>
+    shows \<open>\<forall>k < mlkem_n. k < start \<or> k \<ge> start + count + len \<longrightarrow>
+            array_nth (ntt_inner_loop zeta start len count p) k = array_nth p k\<close>
+using assms proof (induction count arbitrary: start p)
+  case 0
+  then show ?case by simp
+next case (Suc count)
+  have \<open>\<forall>k < mlkem_n. k < Suc start \<or> k \<ge> Suc start + count + len \<longrightarrow>
+          array_nth (ntt_inner_loop zeta (Suc start) len count
+            (ntt_butterfly zeta start len p)) k
+          = array_nth (ntt_butterfly zeta start len p) k\<close>
+    using Suc.IH Suc.prems by auto
+  moreover have \<open>\<forall>k < mlkem_n. k < start \<or> k \<ge> start + Suc count + len \<longrightarrow>
+                  k \<noteq> start \<and> k \<noteq> start + len\<close>
+    using Suc.prems by auto
+  moreover have \<open>\<forall>k < mlkem_n. k \<noteq> start \<and> k \<noteq> start + len \<longrightarrow>
+                  array_nth (ntt_butterfly zeta start len p) k = array_nth p k\<close>
+    using ntt_butterfly_updates_only Suc.prems by (auto simp add: mlkem_n_def)
+  ultimately show ?case
+    by auto
+qed
+
+text\<open>Key lemma: enables the inner loop inductive step by showing that applying
+one more butterfly at the end is equivalent to extending the count.\<close>
+lemma ntt_inner_loop_snoc:
+  fixes start count len
+  shows \<open>ntt_butterfly zeta (start + count) len
+           (ntt_inner_loop zeta start len count p) =
+         ntt_inner_loop zeta start len (Suc count) p\<close>
+proof (induction count arbitrary: start p)
+case 0
+  show ?case
+    by simp
+next case (Suc count)
+  have \<open>ntt_butterfly zeta (start + Suc count) len
+          (ntt_inner_loop zeta start len (Suc count) p) =
+        ntt_butterfly zeta (Suc start + count) len
+          (ntt_inner_loop zeta (Suc start) len count (ntt_butterfly zeta start len p))\<close>
+    by simp
+  also have \<open>\<dots> = ntt_inner_loop zeta (Suc start) len (Suc count) (ntt_butterfly zeta start len p)\<close>
+    by (rule Suc.IH)
+  also have \<open>\<dots> = ntt_inner_loop zeta start len (Suc (Suc count)) p\<close>
+    by simp
+  finally show ?case
+    .
+qed
+
+section\<open>Array lens disjointness\<close>
+
+text\<open>Needed for the NTT butterfly which simultaneously holds focused references
+to @{term \<open>f[j]\<close>} and @{term \<open>f[j+l]\<close>} where @{term \<open>l > 0\<close>}.\<close>
+
+lemma nth_lens_array_disjoint:
+  assumes \<open>i \<noteq> j\<close>
+      and \<open>i < LENGTH('l)\<close>
+      and \<open>j < LENGTH('l)\<close>
+    shows \<open>disjoint_lenses
+             (nth_lens_array i :: (('a,'l::len) array, 'a) lens)
+             (nth_lens_array j)\<close>
+using assms by (intro disjoint_lensesI)
+   (simp add: nth_lens_array_def lens_modify_def array_update_swap)
+
+section\<open>NTT index bounds\<close>
+
+lemma ntt_j_plus_len_bound:
+    fixes len :: \<open>nat\<close>
+  assumes \<open>block < num_blocks\<close>
+      and \<open>j_off < len\<close>
+      and \<open>num_blocks * (2 * len) = 256\<close>
+    shows \<open>block * (2 * len) + j_off + len < 256\<close>
+proof -
+  have \<open>block + 1 \<le> num_blocks\<close>
+    using assms(1) by linarith
+  then have \<open>(block + 1) * (2 * len) \<le> num_blocks * (2 * len)\<close>
+    by (rule mult_le_mono1)
+  then have \<open>block * (2 * len) + 2 * len \<le> 256\<close>
+    using assms(3) by (simp add: algebra_simps)
+  then show ?thesis
+    using assms(2) by linarith
+qed
+
+lemma ntt_butterfly_disjoint_indices:
+    fixes len :: \<open>nat\<close>
+      and start :: \<open>nat\<close>
+  assumes \<open>j_off < len\<close>
+      and \<open>0 < len\<close>
+    shows \<open>start + j_off \<noteq> start + j_off + len\<close>
+using assms by linarith
+
+lemma ntt_k_plus_pow2_bound:
+  assumes \<open>k \<le> (2::nat) ^ n\<close>
+      and \<open>n < 7\<close>
+    shows \<open>k + 2 ^ n \<le> 128\<close>
+proof -
+  from assms(1) have \<open>k + 2 ^ n \<le> 2 * 2 ^ n\<close>
+    by linarith
+  also have \<open>\<dots> = 2 ^ Suc n\<close>
+    by simp
+  also from assms(2) have \<open>(2::nat) ^ Suc n \<le> 2 ^ 7\<close>
+    by (intro power_increasing) simp_all
+  finally show ?thesis
+    by simp
+qed
+
+lemma ntt_k_block_bound:
+  assumes \<open>k \<le> (2::nat) ^ n\<close>
+      and \<open>b < 2 ^ n\<close>
+      and \<open>n < 7\<close>
+    shows \<open>k + b < 128\<close>
+using assms ntt_k_plus_pow2_bound[OF assms(1) assms(3)] by linarith
+
+lemma drop_bit_le_self_nat:
+  shows \<open>drop_bit n (m::nat) \<le> m\<close>
+by (simp add: drop_bit_eq_div)
+
+section\<open>NTT locale and \<mu>Rust implementation\<close>
+
+locale mlkem_ntt_context =
+    mlkem_polynomial_context _ _ _ _ _ _ _ reference_types word16_prism word32_prism poly_prism
+  + ref_word64: reference_allocatable reference_types _ _ _ _ _ _ _ word64_prism
+  for
+    reference_types ::
+      \<open>'s::{sepalg} \<Rightarrow> 'addr \<Rightarrow> 'gv \<Rightarrow> 'abort \<Rightarrow> 'i prompt \<Rightarrow> 'o prompt_output \<Rightarrow> unit\<close>
+  and word16_prism :: \<open>('gv, 16 word) prism\<close>
+  and word32_prism :: \<open>('gv, 32 word) prism\<close>
+  and poly_prism :: \<open>('gv, mlkem_poly) prism\<close>
+  and word64_prism :: \<open>('gv, 64 word) prism\<close>
+begin
+
+adhoc_overloading store_reference_const \<rightleftharpoons> ref_word64.new
+
+definition ntt :: \<open>('addr, 'gv, mlkem_poly) Global_Store.ref \<Rightarrow>
+     ('s::{sepalg}, unit, 'abort, 'i prompt, 'o prompt_output) function_body\<close> where
+  \<open>ntt f_ref \<equiv> FunctionBody \<lbrakk>
+     let mut k = 1;
+
+     for layer in 0..7 {
+       let len = 128 >> layer;
+       let num_blocks = 1 << layer;
+
+       for block in 0..num_blocks {
+         let start = block * (2_u64 * len);
+         let zeta = zetas_table[*k];
+         k = *k + 1_u64;
+
+         for j_off in 0..len {
+           let j = start + j_off;
+           let fj_ref = f_ref[j];
+           let fjl_ref = f_ref[j + len];
+
+           let t = zq_mul(zeta, *fjl_ref);
+           fjl_ref = zq_sub(*fj_ref, t);
+           fj_ref = zq_add(*fj_ref, t)
+         }
+       }
+     }
+  \<rbrakk>\<close>
+
+definition ntt_contract ::
+    \<open>(('addr, 'gv) gref, 'gv, mlkem_poly) focused \<Rightarrow> 'gv \<Rightarrow> mlkem_poly \<Rightarrow>
+     ('s::{sepalg}, unit, 'b) function_contract\<close> where
+  [crush_contracts]: \<open>ntt_contract f_ref g p \<equiv>
+     let pre  = f_ref \<mapsto>\<langle>\<top>\<rangle> g\<down>p \<star>
+                \<langle>poly_wf p\<rangle> \<star>
+                can_alloc_reference;
+         post = \<lambda>_. (\<Squnion> g'. f_ref \<mapsto>\<langle>\<top>\<rangle> g'\<down>(MLKEM_Specification.ntt p)) \<star>
+                \<langle>poly_wf (MLKEM_Specification.ntt p)\<rangle> \<star>
+                can_alloc_reference
+      in make_function_contract pre post\<close>
+ucincl_auto ntt_contract
+
+text\<open>The NTT proof is the most involved verification in this development.
+It requires three nested loop invariants, each using the ``backwards'' approach:
+relating the remaining pure computation from the current state to the full
+computation from the initial state.
+
+The proof proceeds bottom-up: inner loop (butterfly), middle loop (blocks),
+outer loop (layers). Each loop is verified using @{thm wp_raw_for_loop_framedI'}.
+
+Key facts used:
+\<^item> @{thm ntt_inner_loop_snoc}: enables the inner loop inductive step
+\<^item> @{thm nth_lens_array_disjoint}: allows simultaneous focused refs to \<open>f[j]\<close> and \<open>f[j+len]\<close>
+\<^item> @{thm ntt_butterfly_wf}: butterfly preserves well-formedness
+\<close>
+
+lemma ntt_outer_loop_step:
+  assumes \<open>layer < (7::nat)\<close>
+      and \<open>ntt_middle_loop k (2 ^ (7 - layer)) (2 ^ layer) (2 ^ layer) pcur = (k', p')\<close>
+    shows \<open>ntt_outer_loop k (7 - layer) pcur = ntt_outer_loop k' (7 - Suc layer) p'\<close>
+proof (cases \<open>7 - layer\<close>)
+  case 0 with assms show ?thesis by simp
+next
+  case (Suc n)
+  with assms(1) have \<open>n = 6 - layer\<close> and \<open>6 - n = layer\<close>
+    by simp_all
+  with Suc assms show ?thesis
+    by (simp add: ntt_outer_loop.simps Let_def case_prod_beta)
+qed
+
+lemma ntt_num_blocks_length:
+  assumes \<open>layer < (7::nat)\<close>
+    shows \<open>length (list.map word64_of_nat
+           [0..<unat ((2::64 word) ^ unat (word64_of_nat layer))]) = 2 ^ layer\<close>
+using assms by (simp add: unat_of_nat_eq unat_power_lower)
+
+lemma ntt_middle_loop_terminal:
+  assumes \<open>layer < (7::nat)\<close>
+    shows \<open>MLKEM_Specification.ntt_middle_loop
+            (k + unat ((2::64 word) ^ unat (word64_of_nat layer)))
+            (2 ^ (7 - layer))
+            (2 ^ layer - unat ((2::64 word) ^ unat (word64_of_nat layer)))
+            (2 ^ layer) p
+          = (k + 2 ^ layer, p)\<close>
+using assms by (simp add: unat_of_nat_eq unat_power_lower)
+
+lemma word64_of_nat_add_pow_layer:
+  assumes \<open>layer < (7::nat)\<close>
+    shows \<open>word64_of_nat k + ((2::64 word) ^ unat (word64_of_nat layer))
+              = word64_of_nat (k + 2 ^ layer)\<close>
+using assms by (simp add: unat_of_nat_eq unat_power_lower)
+
+lemma word64_of_nat_add_pow_nat:
+  shows \<open>word64_of_nat k + (2::64 word) ^ n = word64_of_nat (k + 2 ^ n)\<close>
+  by (metis word_unat_power of_nat_add)
+
+lemma ntt_inner_len_length:
+  assumes \<open>layer < (7::nat)\<close>
+    shows \<open>length (list.map word64_of_nat [0..<unat (drop_bit (unat (word64_of_nat layer)) (0x80::64 word))]) =
+              2 ^ (7 - layer)\<close>
+proof -
+  have \<open>unat (drop_bit (unat (word64_of_nat layer)) (0x80::64 word)) =
+          drop_bit layer (128::nat)\<close>
+    using assms by (simp add: unat_of_nat_eq unat_drop_bit_eq)
+  also have \<open>drop_bit layer (128::nat) = 2 ^ (7 - layer)\<close>
+    using assms by (simp add: drop_bit_eq_div power_diff)
+  finally show ?thesis
+    by simp
+qed
+
+lemma ntt_inner_len_val:
+  assumes \<open>layer < (7::nat)\<close>
+    shows \<open>unat (drop_bit layer (0x80::64 word)) = 2 ^ (7 - layer)\<close>
+using assms by (simp add: unat_drop_bit_eq drop_bit_eq_div power_diff unat_div unat_power_lower)
+
+lemma ntt_middle_loop_step:
+  assumes \<open>block < (2::nat) ^ layer\<close>
+    shows \<open>MLKEM_Specification.ntt_middle_loop (k + block) ln (2 ^ layer - block) (2 ^ layer) p =
+            MLKEM_Specification.ntt_middle_loop (k + Suc block) ln (2 ^ layer - Suc block) (2 ^ layer)
+              (MLKEM_Specification.ntt_inner_loop (array_nth zetas_table (k + block)) (block * (2 * ln)) ln ln p)\<close>
+proof -
+  from assms have \<open>2 ^ layer - block = Suc (2 ^ layer - Suc block)\<close>
+    by linarith
+  moreover from assms have \<open>2 ^ layer - Suc (2 ^ layer - Suc block) = block\<close>
+    by linarith
+  ultimately show ?thesis
+    by (simp add: MLKEM_Specification.ntt_middle_loop.simps(2) Let_def)
+qed
+
+text\<open>
+  Word arithmetic side-conditions for the NTT inner loop step.
+  These convert between \<^verbatim>\<open>word64\<close> operations and nat-level arithmetic,
+  establishing index bounds needed by the VCG.
+\<close>
+
+lemma lt_7_cases:
+  assumes \<open>layer < (7::nat)\<close>
+    shows \<open>layer \<in> {0, 1, 2, 3, 4, 5, 6}\<close>
+using assms by auto
+
+lemma ntt_inner_j_bound:
+  assumes \<open>layer < (7::nat)\<close>
+      and \<open>block < 2 ^ layer\<close>
+      and \<open>i < unat (drop_bit layer (0x80::64 word))\<close>
+    shows \<open>unat (word64_of_nat block * (2 * drop_bit layer (0x80::64 word)) + word64_of_nat i) < 256\<close>
+using assms by (auto dest!: lt_7_cases simp add: unat_word_ariths
+    unat_of_nat unat_drop_bit_eq drop_bit_eq_div)
+
+lemma ntt_inner_j_plus_len_bound:
+  assumes \<open>layer < (7::nat)\<close>
+      and \<open>block < 2 ^ layer\<close>
+      and \<open>i < unat (drop_bit layer (0x80::64 word))\<close>
+    shows \<open>unat (word64_of_nat block * (2 * drop_bit layer (0x80::64 word)) + word64_of_nat i + drop_bit layer (0x80::64 word)) < 256\<close>
+using assms by (auto dest!: lt_7_cases simp add: unat_word_ariths
+    unat_of_nat unat_drop_bit_eq drop_bit_eq_div)
+
+lemma ntt_inner_zeta_wf:
+  assumes \<open>layer < (7::nat)\<close>
+      and \<open>k_val \<le> 2 ^ layer\<close>
+      and \<open>block < 2 ^ layer\<close>
+    shows \<open>unat (array_nth zetas_table (unat (word64_of_nat k_val + word64_of_nat block))) < mlkem_q\<close>
+using assms by (auto dest!: lt_7_cases simp add: unat_word_ariths
+    unat_of_nat unat_drop_bit_eq drop_bit_eq_div zetas_table_wf)
+
+lemma ntt_inner_entry_wf:
+  assumes \<open>layer < (7::nat)\<close>
+      and \<open>block < 2 ^ layer\<close>
+      and \<open>i < unat (drop_bit layer (0x80::64 word))\<close>
+      and \<open>poly_wf q\<close>
+    shows \<open>unat (array_nth q (unat (word64_of_nat block * (2 * drop_bit layer (0x80::64 word)) + word64_of_nat i))) < mlkem_q\<close>
+using assms by (auto dest!: lt_7_cases simp add: unat_word_ariths
+    unat_of_nat unat_drop_bit_eq drop_bit_eq_div mlkem_q_def poly_wf_def mlkem_n_def)
+
+lemma ntt_inner_entry_plus_len_wf:
+  assumes \<open>layer < (7::nat)\<close>
+      and \<open>block < 2 ^ layer\<close>
+      and \<open>i < unat (drop_bit layer (0x80::64 word))\<close>
+      and \<open>poly_wf q\<close>
+    shows \<open>unat (array_nth q (unat (word64_of_nat block * (2 * drop_bit layer (0x80::64 word)) + word64_of_nat i + drop_bit layer (0x80::64 word)))) < mlkem_q\<close>
+using assms by (auto dest!: lt_7_cases simp add: unat_word_ariths
+    unat_of_nat unat_drop_bit_eq drop_bit_eq_div mlkem_q_def poly_wf_def mlkem_n_def)
+
+lemma ntt_inner_j_add_len_no_overflow:
+  assumes \<open>layer < (7::nat)\<close>
+      and \<open>block < 2 ^ layer\<close>
+      and \<open>i < unat (drop_bit layer (0x80::64 word))\<close>
+    shows \<open>unat (word64_of_nat block * (2 * drop_bit layer (0x80::64 word)) + word64_of_nat i) + unat (drop_bit layer (0x80::64 word)) < 18446744073709551616\<close>
+using assms by (auto dest!: lt_7_cases simp add: unat_word_ariths
+    unat_of_nat unat_drop_bit_eq drop_bit_eq_div)
+
+lemma ntt_inner_base_add_i_no_overflow:
+  assumes \<open>layer < (7::nat)\<close>
+      and \<open>block < 2 ^ layer\<close>
+      and \<open>i < unat (drop_bit layer (0x80::64 word))\<close>
+    shows \<open>unat (word64_of_nat block * (2 * drop_bit layer (0x80::64 word))) +
+              unat (word64_of_nat i) < 18446744073709551616\<close>
+using assms by (auto dest!: lt_7_cases simp add: unat_word_ariths
+    unat_of_nat unat_drop_bit_eq drop_bit_eq_div)
+
+lemma focus_modify_mlkem_poly:
+    fixes arr :: mlkem_poly
+  assumes \<open>idx < (256::nat)\<close>
+    shows \<open>\<nabla>{nth_focus_array idx} f arr = array_update arr idx (f (array_nth arr idx))\<close>
+using assms by (simp add: nth_focus_array_components)
+
+lemma array_nth_update_mlkem:
+    fixes arr :: mlkem_poly
+  assumes \<open>j < (256::nat)\<close>
+    shows \<open>array_nth (array_update arr i v) j = (if i = j then v else array_nth arr j)\<close>
+using assms by (simp add: array_nth_update)
+
+lemma poly_wf_update:
+    fixes p :: mlkem_poly
+  assumes \<open>poly_wf p\<close>
+      and \<open>unat v < mlkem_q\<close>
+      and \<open>idx < mlkem_n\<close>
+    shows \<open>poly_wf (array_update p idx v)\<close>
+using assms by (auto simp add: poly_wf_def array_nth_update mlkem_n_def)
+
+lemma ntt_inner_j_unat:
+  assumes \<open>layer < (7::nat)\<close>
+      and \<open>block < 2 ^ layer\<close>
+      and \<open>i < unat (drop_bit layer (0x80::64 word))\<close>
+    shows \<open>unat (word64_of_nat block * (2 * drop_bit layer (0x80::64 word)) + word64_of_nat i) =
+            block * (2 * 2 ^ (7 - layer)) + i\<close>
+using assms by (auto dest!: lt_7_cases simp add: unat_word_ariths unat_of_nat unat_drop_bit_eq drop_bit_eq_div)
+
+lemma ntt_inner_jl_unat:
+  assumes \<open>layer < (7::nat)\<close>
+      and \<open>block < 2 ^ layer\<close>
+      and \<open>i < unat (drop_bit layer (0x80::64 word))\<close>
+    shows \<open>unat (word64_of_nat block * (2 * drop_bit layer (0x80::64 word)) +
+            word64_of_nat i + drop_bit layer (0x80::64 word)) =
+          block * (2 * 2 ^ (7 - layer)) + i + 2 ^ (7 - layer)\<close>
+using assms by (auto dest!: lt_7_cases simp add: unat_word_ariths unat_of_nat unat_drop_bit_eq drop_bit_eq_div)
+
+lemma ntt_inner_k_unat:
+  assumes \<open>layer < (7::nat)\<close>
+      and \<open>k_val \<le> 2 ^ layer\<close>
+      and \<open>block < 2 ^ layer\<close>
+    shows \<open>unat (word64_of_nat k_val + word64_of_nat block) = k_val + block\<close>
+using assms by (auto dest!: lt_7_cases simp add: unat_word_ariths unat_of_nat)
+
+lemma ntt_butterfly_fold:
+  shows \<open>array_update (array_update p (j + half)
+          (MLKEM_Specification.zq_sub (array_nth p j)
+            (MLKEM_Specification.zq_mul zeta (array_nth p (j + half))))) j
+          (MLKEM_Specification.zq_add (array_nth p j)
+            (MLKEM_Specification.zq_mul zeta (array_nth p (j + half)))) =
+         ntt_butterfly zeta j half p\<close>
+by (simp add: ntt_butterfly_def Let_def)
+
+lemma ntt_inner_step_wf:
+  assumes \<open>layer < (7::nat)\<close>
+      and \<open>block < 2 ^ layer\<close>
+      and \<open>i < unat (drop_bit layer (0x80::64 word))\<close>
+      and \<open>poly_wf p\<close>
+      and \<open>k_val \<le> 2 ^ layer\<close>
+    shows \<open>poly_wf (ntt_inner_loop (array_nth zetas_table (k_val + block))
+            (Suc (block * (2 * 2 ^ (7 - layer)))) (2 ^ (7 - layer)) i
+            (ntt_butterfly (array_nth zetas_table (k_val + block))
+              (block * (2 * 2 ^ (7 - layer))) (2 ^ (7 - layer)) p))\<close>
+proof -
+  have zeta_wf: \<open>unat (array_nth zetas_table (k_val + block)) < mlkem_q\<close>
+    using assms by (auto dest!: lt_7_cases simp add: zetas_table_wf)
+  have bound1: \<open>block * (2 * 2 ^ (7 - layer)) + 2 ^ (7 - layer) < mlkem_n\<close>
+    using assms by (auto dest!: lt_7_cases simp add: mlkem_n_def)
+  have bound2: \<open>Suc (block * (2 * 2 ^ (7 - layer))) + i + 2 ^ (7 - layer) \<le> mlkem_n\<close>
+    using assms by (auto dest!: lt_7_cases simp add: mlkem_n_def
+      unat_drop_bit_eq drop_bit_eq_div unat_of_nat)
+  have len_pos: \<open>(0::nat) < 2 ^ (7 - layer)\<close>
+    by simp
+  have \<open>poly_wf (ntt_butterfly (array_nth zetas_table (k_val + block))
+    (block * (2 * 2 ^ (7 - layer))) (2 ^ (7 - layer)) p)\<close>
+    using assms(4) zeta_wf bound1 by (rule ntt_butterfly_wf)
+  then show ?thesis
+    using zeta_wf bound2 len_pos by (rule ntt_inner_loop_wf)
+qed
+
+lemma ntt_spec:
+  notes points_to_aentails_crule_focusedL[crush_aentails_cond_crules]
+  shows \<open>\<Gamma>; ntt f_ref \<Turnstile>\<^sub>F ntt_contract f_ref g p\<close>
+proof (crush_boot f: ntt_def contract: ntt_contract_def, goal_cases)
+  case 1
+  moreover note ntt_inner_loop_snoc ntt_butterfly_wf ntt_inner_loop_wf
+                MLKEM_Specification.ntt_wf
+                ntt_j_plus_len_bound ntt_butterfly_disjoint_indices
+                nth_lens_array_disjoint zetas_table_wf poly_wf_nth
+                MLKEM_Specification.ntt_middle_loop_fst
+                ntt_outer_loop_step
+                ntt_k_plus_pow2_bound ntt_k_block_bound
+  ultimately show ?case
+    apply crush_base
+    subgoal for k_ref
+      apply (ucincl_discharge\<open>rule_tac
+        INV=\<open>\<lambda>_ layer. \<Squnion> k_val g_f g_k p_cur.
+          f_ref \<mapsto> \<langle>\<top>\<rangle>g_f \<down> p_cur
+          \<star> k_ref \<mapsto> \<langle>\<top>\<rangle>g_k \<down> (word_of_nat k_val :: 64 word)
+          \<star> \<langle>MLKEM_Specification.ntt_outer_loop k_val (7 - layer) p_cur
+             = MLKEM_Specification.ntt_outer_loop 1 7 p\<rangle>
+          \<star> \<langle>poly_wf p_cur\<rangle>
+          \<star> \<langle>k_val \<le> 2 ^ layer\<rangle>\<close>
+        and \<tau>=\<open>\<lambda>_. \<langle>False\<rangle>\<close> and \<theta>=\<open>\<lambda>_. \<langle>False\<rangle>\<close>
+      in wp_raw_for_loop_framedI'\<close>)
+       subgoal \<comment> \<open>Init/frame: establish INV[0] and frame INV[7] to postcondition\<close>
+         apply (crush_base simp add: MLKEM_Specification.ntt_def)
+         apply auto
+         done
+       subgoal for layer \<comment> \<open>Outer loop step: one NTT layer\<close>
+         apply crush_base
+         subgoal for k_val g_f g_k p_cur \<comment> \<open>middle loop WP\<close>
+           apply (ucincl_discharge\<open>rule_tac
+             INV=\<open>\<lambda>_ block. \<Squnion> g_f_m g_k_m p_mid.
+               f_ref \<mapsto> \<langle>\<top>\<rangle>g_f_m \<down> p_mid
+               \<star> k_ref \<mapsto> \<langle>\<top>\<rangle>g_k_m \<down> word64_of_nat (k_val + block)
+               \<star> \<langle>MLKEM_Specification.ntt_middle_loop (k_val + block)
+                    (2 ^ (7 - layer)) (2 ^ layer - block) (2 ^ layer) p_mid
+                  = MLKEM_Specification.ntt_middle_loop k_val
+                    (2 ^ (7 - layer)) (2 ^ layer) (2 ^ layer) p_cur\<rangle>
+               \<star> \<langle>poly_wf p_mid\<rangle>
+               \<star> \<langle>k_val + 2 ^ layer \<le> 128\<rangle>\<close>
+             and \<tau>=\<open>\<lambda>_. \<langle>False\<rangle>\<close>
+             and \<theta>=\<open>\<lambda>_. \<langle>False\<rangle>\<close>
+           in wp_raw_for_loop_framedI'\<close>)
+          subgoal \<comment> \<open>middle init/frame\<close>
+            apply (crush_base no_schematics
+                              simp add: ntt_num_blocks_length ntt_middle_loop.simps(1)
+                                        ntt_middle_loop_terminal
+                                        unat_of_nat_eq unat_power_lower
+                              simp del: of_nat_add of_nat_power)
+            \<comment> \<open>Instantiate init existentials (g_f_m=g_f, g_k_m=g_k, p_mid=p_cur)\<close>
+            apply (rule_tac x=g_f in aexists_entailsR)
+            apply (rule_tac x=g_k in aexists_entailsR)
+            apply (rule_tac x=p_cur in aexists_entailsR)
+            \<comment> \<open>Now crush can match init heap cells and handle the frame wand\<close>
+            apply (crush_base no_schematics simp del: of_nat_add of_nat_power)
+            \<comment> \<open>Instantiate outer loop next-iteration existentials\<close>
+            apply (rule_tac x=\<open>k_val + 2 ^ layer\<close> in aexists_entailsR)
+            apply (rule_tac x=x in aexists_entailsR)
+            apply (rule_tac x=xa in aexists_entailsR)
+            apply (rule_tac x=xb in aexists_entailsR)
+            apply crush_base
+            apply (metis ntt_outer_loop_step)
+            done
+          subgoal for block \<comment> \<open>middle step\<close>
+            apply crush_base
+            subgoal for g_f_m g_k_m p_mid \<comment> \<open>inner for loop\<close>
+              apply (ucincl_discharge\<open>rule_tac
+                INV=\<open>\<lambda>_ j_off. \<Squnion> g_f_inner.
+                  f_ref \<mapsto> \<langle>\<top>\<rangle> g_f_inner \<down> (ntt_inner_loop
+                    (array_nth zetas_table (k_val + block))
+                    (block * (2 * 2 ^ (7 - layer)))
+                    (2 ^ (7 - layer))
+                    j_off
+                    p_mid)
+                  \<star> \<langle>poly_wf (ntt_inner_loop
+                    (array_nth zetas_table (k_val + block))
+                    (block * (2 * 2 ^ (7 - layer)))
+                    (2 ^ (7 - layer))
+                    j_off
+                    p_mid)\<rangle>\<close>
+                and \<tau>=\<open>\<lambda>_. \<langle>False\<rangle>\<close> and \<theta>=\<open>\<lambda>_. \<langle>False\<rangle>\<close>
+              in wp_raw_for_loop_framedI'\<close>)
+              subgoal \<comment> \<open>inner init/frame\<close>
+                apply (crush_base simp add: simp add: ntt_inner_len_val unat_of_nat_eq unat_power_lower)
+                apply (simp only: add_Suc_right[symmetric] ntt_middle_loop_step[symmetric])
+                done
+              subgoal for i \<comment> \<open>inner step\<close>
+                apply (clarsimp simp add: ntt_inner_len_length unat_of_nat_eq unat_power_lower)
+                apply (crush_base intro!: ntt_inner_entry_wf ntt_inner_j_bound ntt_inner_zeta_wf
+                  ntt_inner_entry_plus_len_wf ntt_inner_j_plus_len_bound
+                  ntt_inner_j_add_len_no_overflow ntt_inner_base_add_i_no_overflow)
+                apply (all \<open>frule (2) ntt_inner_j_bound\<close>, all \<open>frule (2) ntt_inner_j_plus_len_bound\<close>)
+                apply (simp_all only: focus_modify_mlkem_poly)
+                subgoal by (rule ntt_inner_step_wf; assumption)
+                subgoal by (simp add: ntt_inner_j_unat ntt_inner_jl_unat ntt_inner_k_unat
+                              array_nth_update ntt_butterfly_fold)
+                subgoal
+                  apply (simp only: ntt_inner_jl_unat focus_modify_mlkem_poly)
+                  by (rule poly_wf_update; (assumption | simp add: mlkem_n_def))
+                done
+            done
+            subgoal
+              apply (simp add: unat_of_nat_eq unat_power_lower)
+              apply (frule (2) ntt_k_block_bound)
+              apply (subgoal_tac \<open>k_val + block < 2 ^ 64\<close>)
+              apply (subgoal_tac \<open>unat (word64_of_nat k_val + word64_of_nat block) = k_val + block\<close>)
+              apply linarith
+              apply (simp del: of_nat_add add: of_nat_add[symmetric] unat_of_nat_eq)
+              apply (rule less_le_trans[of _ 128])
+              apply assumption
+              apply simp
+              done
+            subgoal
+              apply (simp add: unat_of_nat_eq unat_power_lower)
+              apply (frule (2) ntt_k_block_bound)
+              apply (subgoal_tac \<open>k_val + block < 2 ^ 64\<close>)
+              apply (subgoal_tac \<open>unat (word64_of_nat k_val + word64_of_nat block) = k_val + block\<close>)
+              apply linarith
+              apply (simp del: of_nat_add add: of_nat_add[symmetric] unat_of_nat_eq)
+              apply (rule less_le_trans[of _ 128])
+              apply assumption
+              apply simp
+              done
+            subgoal
+              apply unat_arith
+              apply (clarsimp simp: unat_of_nat_eq unat_power_lower unat_drop_bit_eq
+                                    drop_bit_eq_div unat_word_ariths)
+              apply (subgoal_tac \<open>128 div 2 ^ layer \<le> 128\<close>)
+              prefer 2
+                apply (rule div_le_dividend)
+              apply (subgoal_tac \<open>128 div 2 ^ layer mod 18446744073709551616 = 128 div 2 ^ layer\<close>)
+              prefer 2
+                apply (rule mod_less, linarith)
+              apply (subgoal_tac \<open>2 * (128 div 2 ^ layer) mod 18446744073709551616
+                                   = 2 * (128 div 2 ^ layer)\<close>)
+              prefer 2
+                apply (rule mod_less, linarith)
+              apply simp
+              apply (subgoal_tac \<open>block * (128 div 2 ^ layer) < 129\<close>)
+              apply simp
+              apply (rule le_less_trans[where y=\<open>2 ^ layer * (128 div 2 ^ layer)\<close>])
+              apply (rule mult_le_mono1)
+              apply linarith
+              apply (rule le_less_trans[where y=128])
+              apply (rule thd)
+              apply simp
+              done
+            subgoal
+              apply (auto simp: unat_of_nat_eq unat_power_lower unat_arith_simps
+                             unat_drop_bit_eq drop_bit_eq_div
+                        intro!: le_less_trans[OF div_le_dividend])
+              done
+            done
+          done
+        subgoal
+          apply (auto simp: unat_of_nat_eq)
+          done
+        subgoal
+          apply (auto simp: unat_of_nat_eq)
+          done
+      done
+    done
+  done
+qed
+
+end
+
+end

--- a/Micro_Rust_Examples/MLKEM_Parameters.thy
+++ b/Micro_Rust_Examples/MLKEM_Parameters.thy
@@ -1,0 +1,99 @@
+(* Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+   SPDX-License-Identifier: MIT *)
+
+theory MLKEM_Parameters
+  imports
+    Misc.Array
+    "HOL-Library.Word"
+begin
+
+text\<open>
+  MLKEM (Module Lattice-based Key Encapsulation Mechanism, FIPS 203) parameters.
+  This theory defines the core constants, types, zeta table, and well-formedness
+  predicates used throughout the MLKEM development.
+\<close>
+
+section\<open>Constants\<close>
+
+definition mlkem_q :: \<open>nat\<close> where
+  \<open>mlkem_q \<equiv> 3329\<close>
+
+definition mlkem_q_word :: \<open>16 word\<close> where
+  \<open>mlkem_q_word \<equiv> 3329\<close>
+
+definition mlkem_n :: \<open>nat\<close> where
+  \<open>mlkem_n \<equiv> 256\<close>
+
+definition mlkem_zeta :: \<open>nat\<close> where
+  \<open>mlkem_zeta \<equiv> 17\<close>
+
+section\<open>Types\<close>
+
+type_synonym mlkem_poly = \<open>(16 word, 256) array\<close>
+
+section\<open>Zeta table\<close>
+
+text\<open>128 entries: powers of 17 mod 3329 in bit-reversed order per FIPS 203.\<close>
+definition zetas_table :: \<open>(16 word, 128) array\<close> where
+  \<open>zetas_table \<equiv> array_of_list
+    [1, 1729, 2580, 3289, 2642, 630, 1897, 848,
+     1062, 1919, 193, 797, 2786, 3260, 569, 1746,
+     296, 2447, 1339, 1476, 3046, 56, 2240, 1333,
+     1426, 2094, 535, 2882, 2393, 2879, 1974, 821,
+     289, 331, 3253, 1756, 1197, 2304, 2277, 2055,
+     650, 1977, 2513, 632, 2865, 33, 1320, 1915,
+     2319, 1435, 807, 452, 1438, 2868, 1534, 2402,
+     2647, 2617, 1481, 648, 2474, 3110, 1227, 910,
+     17, 2761, 583, 2649, 1637, 723, 2288, 1100,
+     1409, 2662, 3281, 233, 756, 2156, 3015, 3050,
+     1703, 1651, 2789, 1789, 1847, 952, 1461, 2687,
+     939, 2308, 2437, 2388, 733, 2337, 268, 641,
+     1584, 2298, 2037, 3220, 375, 2549, 2090, 1645,
+     1063, 319, 2773, 757, 2099, 561, 2466, 2594,
+     2804, 1092, 403, 1026, 1143, 2150, 2775, 886,
+     1722, 1212, 1874, 1029, 2110, 2935, 885, 2154]\<close>
+
+section\<open>Well-formedness\<close>
+
+definition poly_wf :: \<open>mlkem_poly \<Rightarrow> bool\<close> where
+  \<open>poly_wf p \<equiv> \<forall>i < mlkem_n. unat (array_nth p i) < mlkem_q\<close>
+
+section\<open>Basic lemmas\<close>
+
+lemma mlkem_q_pos:
+  shows \<open>0 < mlkem_q\<close>
+by (simp add: mlkem_q_def)
+
+lemma mlkem_q_nonzero_word:
+  shows \<open>mlkem_q_word \<noteq> 0\<close>
+by (simp add: mlkem_q_word_def)
+
+lemma mlkem_q_bound16:
+  shows \<open>mlkem_q < 2 ^ 16\<close>
+by (simp add: mlkem_q_def)
+
+lemma mlkem_q_bound32:
+  shows \<open>mlkem_q < 2 ^ 32\<close>
+by (simp add: mlkem_q_def)
+
+lemma mlkem_q_word_unat:
+  shows \<open>unat mlkem_q_word = mlkem_q\<close>
+by (simp add: mlkem_q_word_def mlkem_q_def)
+
+lemma poly_wf_nth:
+  assumes \<open>poly_wf p\<close>
+      and \<open>i < mlkem_n\<close>
+    shows \<open>unat (array_nth p i) < mlkem_q\<close>
+using assms by (simp add: poly_wf_def)
+
+lemma zetas_table_wf:
+  assumes \<open>i < 128\<close>
+    shows \<open>unat (array_nth zetas_table i) < mlkem_q\<close>
+proof -
+  have \<open>list_all (\<lambda>j. unat (array_nth zetas_table j) < mlkem_q) [0..<128]\<close>
+    by eval
+  thus ?thesis
+    using assms by (auto simp: list_all_iff)
+qed
+
+end

--- a/Micro_Rust_Examples/MLKEM_Polynomial.thy
+++ b/Micro_Rust_Examples/MLKEM_Polynomial.thy
@@ -1,0 +1,168 @@
+(* Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+   SPDX-License-Identifier: MIT *)
+
+theory MLKEM_Polynomial
+  imports
+    MLKEM_Zq
+    Micro_Rust_Std_Lib.StdLib_Slice
+begin
+
+text\<open>
+  \<mu>Rust polynomial operations with contracts proving refinement against the
+  pure specifications from @{theory Micro_Rust_Examples.MLKEM_Specification}.
+\<close>
+
+section\<open>Locale\<close>
+
+locale mlkem_polynomial_context =
+    mlkem_zq_context _ _ _ _ _ _ _ reference_types word16_prism word32_prism
+  + ref_poly: reference_allocatable reference_types _ _ _ _ _ _ _ poly_prism
+  for
+    reference_types :: \<open>'s::{sepalg} \<Rightarrow> 'addr \<Rightarrow> 'gv \<Rightarrow> 'abort \<Rightarrow> 'i prompt \<Rightarrow>
+        'o prompt_output \<Rightarrow> unit\<close>
+  and word16_prism :: \<open>('gv, 16 word) prism\<close>
+  and word32_prism :: \<open>('gv, 32 word) prism\<close>
+  and poly_prism :: \<open>('gv, mlkem_poly) prism\<close>
+begin
+
+adhoc_overloading store_reference_const \<rightleftharpoons> ref_poly.new
+
+section\<open>Splice helper lemmas\<close>
+
+text\<open>These lemmas relate the loop body operation (array update at index i) to the
+\<^verbatim>\<open>array\_splice\<close> characterization used in the loop invariant.\<close>
+
+lemma poly_add_splice_step:
+  assumes \<open>i < mlkem_n\<close>
+    shows \<open>array_update (array_splice i (MLKEM_Specification.poly_add a b) a) i
+             (MLKEM_Specification.zq_add (array_nth a i) (array_nth b i)) =
+            array_splice (Suc i) (MLKEM_Specification.poly_add a b) a\<close>
+using assms by (simp add: array_splice_Suc MLKEM_Specification.poly_add_def array_map2_nth mlkem_n_def)
+
+lemma poly_add_splice_full:
+  shows \<open>array_splice mlkem_n (MLKEM_Specification.poly_add a b) a =
+          MLKEM_Specification.poly_add a b\<close>
+by (intro array_extI) (simp add: mlkem_n_def)
+
+lemma poly_sub_splice_step:
+  assumes \<open>i < mlkem_n\<close>
+    shows \<open>array_update (array_splice i (MLKEM_Specification.poly_sub a b) a) i
+             (MLKEM_Specification.zq_sub (array_nth a i) (array_nth b i)) =
+            array_splice (Suc i) (MLKEM_Specification.poly_sub a b) a\<close>
+using assms by (simp add: array_splice_Suc MLKEM_Specification.poly_sub_def array_map2_nth mlkem_n_def)
+
+lemma poly_sub_splice_full:
+  shows \<open>array_splice mlkem_n (MLKEM_Specification.poly_sub a b) a =
+          MLKEM_Specification.poly_sub a b\<close>
+by (intro array_extI) (simp add: mlkem_n_def)
+
+section\<open>Polynomial addition\<close>
+
+definition poly_add :: \<open>mlkem_poly \<Rightarrow> mlkem_poly \<Rightarrow>
+     ('s, mlkem_poly, 'abort, 'i prompt, 'o prompt_output) function_body\<close> where
+  \<open>poly_add a b \<equiv> FunctionBody \<lbrakk>
+     let mut result = a;
+
+     for i in 0..256_u64 {
+       let elem_ref = result[i];
+
+       let ai = *elem_ref;
+       let bi = b[i];
+
+       elem_ref = zq_add(ai, bi)
+     };
+
+     *result
+  \<rbrakk>\<close>
+
+definition poly_add_contract :: \<open>mlkem_poly \<Rightarrow> mlkem_poly \<Rightarrow>
+        ('s::{sepalg}, mlkem_poly, 'b) function_contract\<close> where
+  [crush_contracts]: \<open>poly_add_contract a b \<equiv>
+     let pre  = can_alloc_reference \<star>
+                \<langle>poly_wf a\<rangle> \<star>
+                \<langle>poly_wf b\<rangle>;
+         post = \<lambda>r. can_alloc_reference \<star>
+                \<langle>r = MLKEM_Specification.poly_add a b\<rangle> \<star>
+                \<langle>poly_wf r\<rangle>
+      in make_function_contract pre post\<close>
+ucincl_auto poly_add_contract
+
+lemma poly_add_spec [crush_specs]:
+  shows \<open>\<Gamma>; poly_add a b \<Turnstile>\<^sub>F poly_add_contract a b\<close>
+  apply (crush_boot f: poly_add_def contract: poly_add_contract_def)
+  apply crush_base
+  subgoal for result_ref
+    apply (ucincl_discharge\<open>
+        rule_tac
+          INV=\<open>\<lambda>_ i. \<Squnion> g.
+            result_ref \<mapsto>\<langle>\<top>\<rangle> g\<down>(array_splice i (MLKEM_Specification.poly_add a b) a)\<close>
+          and \<tau>=\<open>\<lambda>_. \<langle>False\<rangle>\<close>
+          and \<theta>=\<open>\<lambda>_. \<langle>False\<rangle>\<close>
+        in wp_raw_for_loop_framedI'\<close>)
+    using poly_add_splice_step poly_add_splice_full MLKEM_Specification.poly_add_wf
+      apply (crush_base
+            specs add: zq_add_spec
+            contracts add: zq_add_contract_def
+            simp add: poly_wf_nth mlkem_n_def
+                     poly_add_splice_step
+                     MLKEM_Specification.poly_add_def array_map2_nth
+                     nth_focus_array_components unat_ucast_eq)
+  done
+done
+
+section\<open>Polynomial subtraction\<close>
+
+definition poly_sub :: \<open>mlkem_poly \<Rightarrow> mlkem_poly \<Rightarrow>
+     ('s, mlkem_poly, 'abort, 'i prompt, 'o prompt_output) function_body\<close> where
+  \<open>poly_sub a b \<equiv> FunctionBody \<lbrakk>
+     let mut result = a;
+
+     for i in 0..256_u64 {
+       let elem_ref = result[i];
+       let ai = *elem_ref;
+       let bi = b[i];
+
+       elem_ref = zq_sub(ai, bi)
+     };
+
+     *result
+  \<rbrakk>\<close>
+
+definition poly_sub_contract :: \<open>mlkem_poly \<Rightarrow> mlkem_poly \<Rightarrow>
+      ('s::{sepalg}, mlkem_poly, 'b) function_contract\<close> where
+  [crush_contracts]: \<open>poly_sub_contract a b \<equiv>
+     let pre  = can_alloc_reference \<star>
+                \<langle>poly_wf a\<rangle> \<star>
+                \<langle>poly_wf b\<rangle>;
+         post = \<lambda>r. can_alloc_reference \<star>
+                \<langle>r = MLKEM_Specification.poly_sub a b\<rangle> \<star>
+                \<langle>poly_wf r\<rangle>
+      in make_function_contract pre post\<close>
+ucincl_auto poly_sub_contract
+
+lemma poly_sub_spec [crush_specs]:
+  shows \<open>\<Gamma>; poly_sub a b \<Turnstile>\<^sub>F poly_sub_contract a b\<close>
+  apply (crush_boot f: poly_sub_def contract: poly_sub_contract_def)
+  apply crush_base
+  subgoal for result_ref
+    apply (ucincl_discharge\<open>
+        rule_tac
+          INV=\<open>\<lambda>_ i. \<Squnion> g.
+            result_ref \<mapsto>\<langle>\<top>\<rangle> g\<down>(array_splice i (MLKEM_Specification.poly_sub a b) a)\<close>
+          and \<tau>=\<open>\<lambda>_. \<langle>False\<rangle>\<close>
+          and \<theta>=\<open>\<lambda>_. \<langle>False\<rangle>\<close>
+        in wp_raw_for_loop_framedI'\<close>)
+    using poly_sub_splice_step poly_sub_splice_full MLKEM_Specification.poly_sub_wf
+      apply (crush_base
+            specs add: zq_sub_spec
+            contracts add: zq_sub_contract_def
+            simp add: poly_wf_nth mlkem_n_def
+                     poly_sub_splice_step
+                     MLKEM_Specification.poly_sub_def array_map2_nth
+                     nth_focus_array_components unat_ucast_eq)
+  done
+done
+
+end
+
+end

--- a/Micro_Rust_Examples/MLKEM_Specification.thy
+++ b/Micro_Rust_Examples/MLKEM_Specification.thy
@@ -1,0 +1,361 @@
+(* Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+   SPDX-License-Identifier: MIT *)
+
+theory MLKEM_Specification
+  imports
+    MLKEM_Parameters
+begin
+
+text\<open>
+  Pure mathematical specification of MLKEM operations.
+  All definitions are non-monadic HOL functions serving as reference specifications
+  for the \<mu>Rust implementations proved correct in subsequent theories.
+\<close>
+
+section\<open>Utility: array\_map2\<close>
+
+definition array_map2 ::
+    \<open>('a \<Rightarrow> 'b \<Rightarrow> 'c) \<Rightarrow> ('a, 'l::{len}) array \<Rightarrow> ('b, 'l) array \<Rightarrow> ('c, 'l) array\<close> where
+  \<open>array_map2 f xs ys \<equiv>
+     array_of_list (map2 f (array_to_list xs) (array_to_list ys))\<close>
+
+lemma array_map2_nth:
+  assumes \<open>i < LENGTH('l)\<close>
+    shows \<open>array_nth (array_map2 f (xs :: ('a, 'l::len) array) ys) i =
+           f (array_nth xs i) (array_nth ys i)\<close>
+  using assms by (simp add: array_map2_def)
+
+section\<open>Modular arithmetic in Z\_q\<close>
+
+definition zq_add :: \<open>16 word \<Rightarrow> 16 word \<Rightarrow> 16 word\<close> where
+  \<open>zq_add a b \<equiv> (a + b) mod mlkem_q_word\<close>
+
+definition zq_sub :: \<open>16 word \<Rightarrow> 16 word \<Rightarrow> 16 word\<close> where
+  \<open>zq_sub a b \<equiv> (a + mlkem_q_word - b) mod mlkem_q_word\<close>
+
+definition zq_mul :: \<open>16 word \<Rightarrow> 16 word \<Rightarrow> 16 word\<close> where
+  \<open>zq_mul a b \<equiv> word_of_nat ((unat a * unat b) mod mlkem_q)\<close>
+
+subsection\<open>Overflow and range lemmas\<close>
+
+lemma zq_add_no_overflow:
+  assumes \<open>unat a < mlkem_q\<close>
+      and \<open>unat b < mlkem_q\<close>
+    shows \<open>unat a + unat b < 2 ^ 16\<close>
+proof -
+  have \<open>unat a + unat b < 3329 + 3329\<close>
+    using assms by (simp add: mlkem_q_def)
+  also have \<open>\<dots> = 6658\<close> by simp
+  also have \<open>\<dots> < 2 ^ 16\<close> by simp
+  finally show ?thesis .
+qed
+
+lemma zq_sub_no_overflow:
+  assumes \<open>unat a < mlkem_q\<close>
+      and \<open>unat b < mlkem_q\<close>
+    shows \<open>unat a + mlkem_q < 2 ^ 16\<close>
+proof -
+  have \<open>unat a + mlkem_q < 3329 + 3329\<close>
+    using assms by (simp add: mlkem_q_def)
+  also have \<open>\<dots> = 6658\<close> by simp
+  also have \<open>\<dots> < 2 ^ 16\<close> by simp
+  finally show ?thesis .
+qed
+
+lemma zq_mul_no_overflow_32:
+  assumes \<open>unat a < mlkem_q\<close>
+      and \<open>unat b < mlkem_q\<close>
+    shows \<open>unat a * unat b < 2 ^ 32\<close>
+proof -
+  have \<open>unat a * unat b < 3329 * 3329\<close>
+    using assms by (intro mult_strict_mono; simp add: mlkem_q_def)
+  also have \<open>\<dots> = 11082241\<close> by simp
+  also have \<open>\<dots> < 2 ^ 32\<close> by simp
+  finally show ?thesis .
+qed
+
+lemma zq_mul_result_fits_16:
+  assumes \<open>unat a < mlkem_q\<close>
+      and \<open>unat b < mlkem_q\<close>
+    shows \<open>(unat a * unat b) mod mlkem_q < 2 ^ 16\<close>
+proof -
+  have \<open>(unat a * unat b) mod mlkem_q < mlkem_q\<close>
+    by (simp add: mlkem_q_def)
+  also have \<open>mlkem_q < 2 ^ 16\<close>
+    by (simp add: mlkem_q_def)
+  finally show ?thesis .
+qed
+
+lemma zq_add_range:
+  assumes \<open>unat a < mlkem_q\<close>
+      and \<open>unat b < mlkem_q\<close>
+    shows \<open>unat (zq_add a b) < mlkem_q\<close>
+proof -
+  have no_ov: \<open>unat a + unat b < 2 ^ 16\<close>
+    using assms by (rule zq_add_no_overflow)
+  have \<open>unat (zq_add a b) = unat ((a + b) mod mlkem_q_word)\<close>
+    by (simp add: zq_add_def)
+  also have \<open>\<dots> = unat (a + b) mod unat mlkem_q_word\<close>
+    by (simp add: unat_mod)
+  also have \<open>unat (a + b) = unat a + unat b\<close>
+    using no_ov by (simp add: unat_add_lem[THEN iffD1])
+  also have \<open>(unat a + unat b) mod unat mlkem_q_word < unat mlkem_q_word\<close>
+    by (simp add: mlkem_q_word_def)
+  finally show ?thesis
+    by (simp add: mlkem_q_word_unat mlkem_q_def)
+qed
+
+lemma zq_sub_range:
+  assumes \<open>unat a < mlkem_q\<close>
+      and \<open>unat b < mlkem_q\<close>
+    shows \<open>unat (zq_sub a b) < mlkem_q\<close>
+proof -
+  have a_bound: \<open>unat a + mlkem_q < 2 ^ 16\<close>
+    using assms by (rule zq_sub_no_overflow)
+  have b_le: \<open>unat b \<le> unat a + unat mlkem_q_word\<close>
+    using assms by (simp add: mlkem_q_word_def mlkem_q_def)
+  have \<open>unat (zq_sub a b) = unat ((a + mlkem_q_word - b) mod mlkem_q_word)\<close>
+    by (simp add: zq_sub_def)
+  also have \<open>\<dots> = unat (a + mlkem_q_word - b) mod unat mlkem_q_word\<close>
+    by (simp add: unat_mod)
+  also have \<open>\<dots> < unat mlkem_q_word\<close>
+    by (simp add: mlkem_q_word_def)
+  finally show ?thesis
+    by (simp add: mlkem_q_word_unat)
+qed
+
+lemma zq_mul_range:
+  assumes \<open>unat a < mlkem_q\<close>
+      and \<open>unat b < mlkem_q\<close>
+    shows \<open>unat (zq_mul a b) < mlkem_q\<close>
+proof -
+  have fits: \<open>(unat a * unat b) mod mlkem_q < 2 ^ 16\<close>
+    using assms by (rule zq_mul_result_fits_16)
+  have \<open>unat (zq_mul a b) = unat (word_of_nat ((unat a * unat b) mod mlkem_q) :: 16 word)\<close>
+    by (simp add: zq_mul_def)
+  also have \<open>\<dots> = (unat a * unat b) mod mlkem_q\<close>
+    using fits by (simp add: unat_of_nat take_bit_nat_eq_self_iff)
+  also have \<open>\<dots> < mlkem_q\<close>
+    by (simp add: mlkem_q_def)
+  finally show ?thesis .
+qed
+
+section\<open>Polynomial operations\<close>
+
+definition poly_add :: \<open>mlkem_poly \<Rightarrow> mlkem_poly \<Rightarrow> mlkem_poly\<close> where
+  \<open>poly_add a b \<equiv> array_map2 zq_add a b\<close>
+
+definition poly_sub :: \<open>mlkem_poly \<Rightarrow> mlkem_poly \<Rightarrow> mlkem_poly\<close> where
+  \<open>poly_sub a b \<equiv> array_map2 zq_sub a b\<close>
+
+lemma poly_add_nth:
+  assumes \<open>i < mlkem_n\<close>
+    shows \<open>array_nth (poly_add a b) i = zq_add (array_nth a i) (array_nth b i)\<close>
+  using assms by (simp add: poly_add_def array_map2_nth mlkem_n_def)
+
+lemma poly_sub_nth:
+  assumes \<open>i < mlkem_n\<close>
+    shows \<open>array_nth (poly_sub a b) i = zq_sub (array_nth a i) (array_nth b i)\<close>
+  using assms by (simp add: poly_sub_def array_map2_nth mlkem_n_def)
+
+lemma poly_add_wf:
+  assumes \<open>poly_wf a\<close>
+      and \<open>poly_wf b\<close>
+    shows \<open>poly_wf (poly_add a b)\<close>
+  using assms by (auto simp add: poly_wf_def poly_add_nth intro: zq_add_range poly_wf_nth)
+
+lemma poly_sub_wf:
+  assumes \<open>poly_wf a\<close>
+      and \<open>poly_wf b\<close>
+    shows \<open>poly_wf (poly_sub a b)\<close>
+  using assms by (auto simp add: poly_wf_def poly_sub_nth intro: zq_sub_range poly_wf_nth)
+
+section\<open>NTT specification\<close>
+
+definition ntt_butterfly ::
+    \<open>16 word \<Rightarrow> nat \<Rightarrow> nat \<Rightarrow> mlkem_poly \<Rightarrow> mlkem_poly\<close> where
+  \<open>ntt_butterfly zeta j len p \<equiv>
+     let t = zq_mul zeta (array_nth p (j + len)) in
+     let p' = array_update p (j + len) (zq_sub (array_nth p j) t) in
+     array_update p' j (zq_add (array_nth p j) t)\<close>
+
+fun ntt_inner_loop ::
+    \<open>16 word \<Rightarrow> nat \<Rightarrow> nat \<Rightarrow> nat \<Rightarrow> mlkem_poly \<Rightarrow> mlkem_poly\<close> where
+  \<open>ntt_inner_loop zeta start len 0 p = p\<close>
+| \<open>ntt_inner_loop zeta start len (Suc count) p =
+     ntt_inner_loop zeta (Suc start) len count (ntt_butterfly zeta start len p)\<close>
+
+fun ntt_middle_loop ::
+    \<open>nat \<Rightarrow> nat \<Rightarrow> nat \<Rightarrow> nat \<Rightarrow> mlkem_poly \<Rightarrow> nat \<times> mlkem_poly\<close> where
+  \<open>ntt_middle_loop k len 0 num_blocks p = (k, p)\<close>
+| \<open>ntt_middle_loop k len (Suc remaining) num_blocks p =
+     (let block = num_blocks - Suc remaining in
+      let start = block * (2 * len) in
+      let zeta = array_nth zetas_table k in
+      let p' = ntt_inner_loop zeta start len len p in
+      ntt_middle_loop (Suc k) len remaining num_blocks p')\<close>
+
+fun ntt_outer_loop ::
+    \<open>nat \<Rightarrow> nat \<Rightarrow> mlkem_poly \<Rightarrow> mlkem_poly\<close> where
+  \<open>ntt_outer_loop k 0 p = p\<close>
+| \<open>ntt_outer_loop k (Suc layer_rem) p =
+     (let len = 2 ^ (Suc layer_rem) in
+      let num_blocks = 2 ^ (6 - layer_rem) in
+      let (k', p') = ntt_middle_loop k len num_blocks num_blocks p in
+      ntt_outer_loop k' layer_rem p')\<close>
+
+definition ntt :: \<open>mlkem_poly \<Rightarrow> mlkem_poly\<close> where
+  \<open>ntt p \<equiv> ntt_outer_loop 1 7 p\<close>
+
+subsection\<open>NTT well-formedness\<close>
+
+lemma ntt_butterfly_wf:
+  assumes \<open>poly_wf p\<close>
+      and \<open>unat zeta < mlkem_q\<close>
+      and \<open>j + len < mlkem_n\<close>
+    shows \<open>poly_wf (ntt_butterfly zeta j len p)\<close>
+  using assms
+  by (auto simp add: ntt_butterfly_def poly_wf_def Let_def mlkem_n_def
+           intro!: zq_add_range zq_sub_range zq_mul_range)
+
+lemma ntt_inner_loop_wf:
+  assumes \<open>poly_wf p\<close>
+      and \<open>unat zeta < mlkem_q\<close>
+      and \<open>start + count + len \<le> mlkem_n\<close>
+      and \<open>0 < len\<close>
+    shows \<open>poly_wf (ntt_inner_loop zeta start len count p)\<close>
+  using assms
+proof (induction count arbitrary: start p)
+  case 0
+  then show ?case by simp
+next
+  case (Suc count)
+  have jl: \<open>start + len < mlkem_n\<close>
+    using Suc.prems(3) by linarith
+  have bf_wf: \<open>poly_wf (ntt_butterfly zeta start len p)\<close>
+    by (rule ntt_butterfly_wf[OF Suc.prems(1,2) jl])
+  have bound': \<open>Suc start + count + len \<le> mlkem_n\<close>
+    using Suc.prems(3) by linarith
+  show ?case
+    by (simp add: Suc.IH[OF bf_wf Suc.prems(2) bound' Suc.prems(4)])
+qed
+
+lemma ntt_middle_loop_wf:
+  assumes \<open>poly_wf p\<close>
+      and \<open>remaining \<le> num_blocks\<close>
+      and \<open>num_blocks * (2 * len) \<le> mlkem_n\<close>
+      and \<open>0 < len\<close>
+      and \<open>\<And>i. i < remaining \<Longrightarrow> unat (array_nth zetas_table (k + i)) < mlkem_q\<close>
+      and \<open>k + remaining \<le> 128\<close>
+    shows \<open>poly_wf (snd (ntt_middle_loop k len remaining num_blocks p))\<close>
+  using assms
+proof (induction remaining arbitrary: k p)
+  case 0
+  then show ?case by simp
+next
+  case (Suc remaining)
+  let ?block = \<open>num_blocks - Suc remaining\<close>
+  let ?start = \<open>?block * (2 * len)\<close>
+  let ?zeta = \<open>array_nth zetas_table k\<close>
+  let ?p' = \<open>ntt_inner_loop ?zeta ?start len len p\<close>
+  have zeta_range: \<open>unat ?zeta < mlkem_q\<close>
+    using Suc.prems(5)[of 0] by simp
+  have block_bound: \<open>?block + 1 \<le> num_blocks\<close>
+    using Suc.prems(2) by linarith
+  have start_bound: \<open>?start + len + len \<le> mlkem_n\<close>
+  proof -
+    have \<open>(?block + 1) * (2 * len) \<le> num_blocks * (2 * len)\<close>
+      using block_bound by (intro mult_le_mono1)
+    thus ?thesis using Suc.prems(3) by (simp add: algebra_simps)
+  qed
+  have p'_wf: \<open>poly_wf ?p'\<close>
+    by (rule ntt_inner_loop_wf[OF Suc.prems(1) zeta_range start_bound Suc.prems(4)])
+  have zeta_shift: \<open>\<And>i. i < remaining \<Longrightarrow> unat (array_nth zetas_table (Suc k + i)) < mlkem_q\<close>
+    using Suc.prems(5)[of \<open>Suc _\<close>] by simp
+  have k_bound: \<open>Suc k + remaining \<le> 128\<close>
+    using Suc.prems(6) by linarith
+  have rem_bound: \<open>remaining \<le> num_blocks\<close>
+    using Suc.prems(2) by linarith
+  show ?case
+    by (simp add: Let_def)
+       (rule Suc.IH[OF p'_wf rem_bound Suc.prems(3,4) zeta_shift k_bound])
+qed
+
+lemma ntt_middle_loop_fst:
+  shows \<open>fst (ntt_middle_loop k len remaining num_blocks p) = k + remaining\<close>
+  by (induction remaining arbitrary: k p) (simp_all add: Let_def)
+
+lemma ntt_outer_loop_wf:
+  assumes \<open>poly_wf p\<close>
+      and \<open>layer_rem \<le> 7\<close>
+      and \<open>k \<le> 2 ^ (7 - layer_rem)\<close>
+    shows \<open>poly_wf (ntt_outer_loop k layer_rem p)\<close>
+  using assms
+proof (induction layer_rem arbitrary: k p)
+  case 0
+  then show ?case by simp
+next
+  case (Suc layer_rem)
+  let ?len = \<open>2 ^ Suc layer_rem :: nat\<close>
+  let ?nb = \<open>2 ^ (6 - layer_rem) :: nat\<close>
+  have lr_le: \<open>layer_rem \<le> 6\<close>
+    using Suc.prems(2) by linarith
+  have nb_eq: \<open>?nb = 2 ^ (7 - Suc layer_rem)\<close>
+    using lr_le by (simp add: Suc_diff_le)
+  have size_eq: \<open>?nb * (2 * ?len) = mlkem_n\<close>
+  proof -
+    have \<open>?nb * (2 * ?len) = 2 ^ (6 - layer_rem) * 2 ^ (Suc (Suc layer_rem))\<close>
+      by simp
+    also have \<open>\<dots> = (2::nat) ^ (6 - layer_rem + Suc (Suc layer_rem))\<close>
+      by (simp add: power_add)
+    also have \<open>6 - layer_rem + Suc (Suc layer_rem) = 8\<close>
+      using lr_le by linarith
+    finally show ?thesis by (simp add: mlkem_n_def)
+  qed
+  have len_pos: \<open>0 < ?len\<close> by simp
+  have k_le_nb: \<open>k \<le> ?nb\<close>
+    unfolding nb_eq using Suc.prems(3) .
+  have k_nb: \<open>k + ?nb \<le> 2 * ?nb\<close>
+    using k_le_nb by linarith
+  have nb_le_64: \<open>?nb \<le> 64\<close>
+  proof -
+    have \<open>?nb \<le> (2::nat) ^ 6\<close>
+      by (intro power_increasing) simp_all
+    thus ?thesis by simp
+  qed
+  have k_nb_128: \<open>k + ?nb \<le> 128\<close>
+    using k_le_nb nb_le_64 by linarith
+  have zeta_range: \<open>\<And>i. i < ?nb \<Longrightarrow> unat (array_nth zetas_table (k + i)) < mlkem_q\<close>
+  proof -
+    fix i assume \<open>i < ?nb\<close>
+    then have \<open>k + i < k + ?nb\<close> by linarith
+    also have \<open>\<dots> \<le> 128\<close> by (rule k_nb_128)
+    finally show \<open>unat (array_nth zetas_table (k + i)) < mlkem_q\<close>
+      by (rule zetas_table_wf)
+  qed
+  let ?res = \<open>ntt_middle_loop k ?len ?nb ?nb p\<close>
+  have mid_wf: \<open>poly_wf (snd ?res)\<close>
+    by (rule ntt_middle_loop_wf[OF Suc.prems(1) le_refl _ len_pos zeta_range k_nb_128])
+       (use size_eq in linarith)
+  have k'_eq: \<open>fst ?res = k + ?nb\<close>
+    by (rule ntt_middle_loop_fst)
+  have k'_bound: \<open>k + ?nb \<le> 2 ^ (7 - layer_rem)\<close>
+  proof -
+    have \<open>Suc (6 - layer_rem) = 7 - layer_rem\<close> using lr_le by linarith
+    hence \<open>(2::nat) ^ (7 - layer_rem) = 2 * 2 ^ (6 - layer_rem)\<close>
+      by (metis power_Suc)
+    thus ?thesis using k_nb by linarith
+  qed
+  show ?case
+    using Suc.prems(2)
+    by (simp only: ntt_outer_loop.simps Let_def case_prod_beta k'_eq)
+       (rule Suc.IH[OF mid_wf _ k'_bound]; linarith)
+qed
+
+lemma ntt_wf:
+  assumes \<open>poly_wf p\<close>
+    shows \<open>poly_wf (ntt p)\<close>
+  unfolding ntt_def
+  by (rule ntt_outer_loop_wf[OF assms]) simp_all
+
+end

--- a/Micro_Rust_Examples/MLKEM_Zq.thy
+++ b/Micro_Rust_Examples/MLKEM_Zq.thy
@@ -1,0 +1,174 @@
+(* Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+   SPDX-License-Identifier: MIT *)
+
+theory MLKEM_Zq
+  imports
+    MLKEM_Specification
+    Micro_Rust_Std_Lib.StdLib_All
+    Crush.Crush
+begin
+
+text\<open>
+  \<mu>Rust implementations of Z\_q arithmetic operations with contracts proving refinement
+  against the pure specifications from @{theory Micro_Rust_Examples.MLKEM_Specification}.
+\<close>
+
+section\<open>Locale\<close>
+
+locale mlkem_zq_context =
+    reference reference_types +
+    ref_word16: reference_allocatable reference_types _ _ _ _ _ _ _ word16_prism +
+    ref_word32: reference_allocatable reference_types _ _ _ _ _ _ _ word32_prism
+  for
+    reference_types :: \<open>'s::{sepalg} \<Rightarrow> 'addr \<Rightarrow> 'gv \<Rightarrow> 'abort \<Rightarrow> 'i prompt \<Rightarrow>
+      'o prompt_output \<Rightarrow> unit\<close>
+  and word16_prism :: \<open>('gv, 16 word) prism\<close>
+  and word32_prism :: \<open>('gv, 32 word) prism\<close>
+begin
+
+adhoc_overloading store_reference_const \<rightleftharpoons> ref_word16.new
+adhoc_overloading store_reference_const \<rightleftharpoons> ref_word32.new
+adhoc_overloading store_update_const \<rightleftharpoons> update_fun
+
+section\<open>Helper lemmas for cast equivalence\<close>
+
+lemma ucast_u16_u32_unat:
+  shows \<open>unat (ucast (x::16 word)::32 word) = unat x\<close>
+by (simp add: unat_ucast_up)
+
+lemma zq_mul_ucast_equiv:
+  assumes \<open>unat a < mlkem_q\<close>
+      and \<open>unat b < mlkem_q\<close>
+    shows \<open>ucast ((ucast (a::16 word)::32 word) * ucast b mod ucast mlkem_q_word) =
+            MLKEM_Specification.zq_mul a b\<close>
+proof -
+  have ua: \<open>unat (ucast a::32 word) = unat a\<close>
+    by (rule ucast_u16_u32_unat)
+  have ub: \<open>unat (ucast b::32 word) = unat b\<close>
+    by (rule ucast_u16_u32_unat)
+  have uq: \<open>unat (ucast mlkem_q_word::32 word) = mlkem_q\<close>
+    by (simp add: ucast_u16_u32_unat mlkem_q_word_unat)
+  have no_ov: \<open>unat a * unat b < 2 ^ 32\<close>
+    using assms by (rule zq_mul_no_overflow_32)
+  have prod_eq: \<open>unat ((ucast a::32 word) * ucast b) = unat a * unat b\<close>
+    using no_ov by (simp add: ua ub unat_mult_lem[THEN iffD1])
+  have mod_eq: \<open>unat ((ucast a::32 word) * ucast b mod ucast mlkem_q_word::32 word)
+                = (unat a * unat b) mod mlkem_q\<close>
+    by (simp add: unat_mod uq prod_eq)
+  have mod_fits: \<open>(unat a * unat b) mod mlkem_q < 2 ^ 16\<close>
+    using assms by (rule zq_mul_result_fits_16)
+  have lhs_unat: \<open>unat (ucast ((ucast a::32 word) * ucast b mod ucast mlkem_q_word::32 word)::16 word) =
+                    (unat a * unat b) mod mlkem_q\<close>
+  proof -
+    have \<open>unat (ucast ((ucast a::32 word) * ucast b mod ucast mlkem_q_word :: 32 word)::16 word)
+          = unat ((ucast a::32 word) * ucast b mod ucast mlkem_q_word::32 word) mod 2 ^ 16\<close>
+      by (simp add: unat_ucast)
+    also have \<open>\<dots> = ((unat a * unat b) mod mlkem_q) mod 2 ^ 16\<close>
+      by (simp add: mod_eq)
+    also have \<open>\<dots> = (unat a * unat b) mod mlkem_q\<close>
+      using mod_fits by simp
+    finally show ?thesis .
+  qed
+  have rhs_unat: \<open>unat (MLKEM_Specification.zq_mul a b :: 16 word) = (unat a * unat b) mod mlkem_q\<close>
+    using mod_fits by (simp add: MLKEM_Specification.zq_mul_def unat_of_nat take_bit_nat_eq_self_iff)
+  show ?thesis
+    by (rule word_eq_unatI) (simp add: lhs_unat rhs_unat)
+qed
+
+section\<open>Modular addition\<close>
+
+definition zq_add :: \<open>16 word \<Rightarrow> 16 word \<Rightarrow>
+      ('s, 16 word, 'abort, 'i prompt, 'o prompt_output) function_body\<close> where
+  \<open>zq_add a b \<equiv> FunctionBody \<lbrakk>
+     let sum = a + b;
+     sum % mlkem_q_word
+  \<rbrakk>\<close>
+
+definition zq_add_contract :: \<open>16 word \<Rightarrow> 16 word \<Rightarrow>
+      ('s::{sepalg}, 16 word, 'b) function_contract\<close> where
+  [crush_contracts]: \<open>zq_add_contract a b \<equiv>
+    let pre  = \<langle>unat a < mlkem_q\<rangle> \<star>
+               \<langle>unat b < mlkem_q\<rangle>;
+        post = \<lambda>r. \<langle>r = MLKEM_Specification.zq_add a b\<rangle> \<star>
+               \<langle>unat r < mlkem_q\<rangle>
+     in make_function_contract pre post\<close>
+ucincl_auto zq_add_contract
+
+lemma zq_add_spec [crush_specs]:
+  shows \<open>\<Gamma>; zq_add a b \<Turnstile>\<^sub>F zq_add_contract a b\<close>
+  apply (crush_boot f: zq_add_def contract: zq_add_contract_def, goal_cases)
+  using zq_add_no_overflow mlkem_q_nonzero_word zq_add_range
+    apply (crush_base simp add: MLKEM_Specification.zq_add_def mlkem_q_word_unat mlkem_q_def)
+  done
+
+section\<open>Modular subtraction\<close>
+
+definition zq_sub :: \<open>16 word \<Rightarrow> 16 word \<Rightarrow>
+     ('s, 16 word, 'abort, 'i prompt, 'o prompt_output) function_body\<close> where
+  \<open>zq_sub a b \<equiv> FunctionBody \<lbrakk>
+     let sum = a + mlkem_q_word - b;
+
+     sum % mlkem_q_word
+  \<rbrakk>\<close>
+
+definition zq_sub_contract :: \<open>16 word \<Rightarrow> 16 word \<Rightarrow>
+      ('s::{sepalg}, 16 word, 'b) function_contract\<close> where
+  [crush_contracts]: \<open>zq_sub_contract a b \<equiv>
+     let pre  = \<langle>unat a < mlkem_q\<rangle> \<star>
+                \<langle>unat b < mlkem_q\<rangle>;
+         post = \<lambda>r. \<langle>r = MLKEM_Specification.zq_sub a b\<rangle> \<star>
+                \<langle>unat r < mlkem_q\<rangle>
+      in make_function_contract pre post\<close>
+ucincl_auto zq_sub_contract
+
+lemma zq_sub_spec [crush_specs]:
+  shows \<open>\<Gamma>; zq_sub a b \<Turnstile>\<^sub>F zq_sub_contract a b\<close>
+proof (crush_boot f: zq_sub_def contract: zq_sub_contract_def, goal_cases)
+case 1
+  moreover have \<open>\<And>a b. \<lbrakk>unat a < mlkem_q; unat b < mlkem_q\<rbrakk> \<Longrightarrow> b \<le> a + mlkem_q_word\<close>
+    by (simp add: word_le_nat_alt mlkem_q_word_def mlkem_q_def unat_add_lem[THEN iffD1])
+  ultimately show ?case
+    using zq_sub_no_overflow mlkem_q_nonzero_word zq_sub_range
+      by (crush_base simp add: MLKEM_Specification.zq_sub_def mlkem_q_word_unat mlkem_q_def)
+qed
+
+section\<open>Modular multiplication\<close>
+
+definition zq_mul :: \<open>16 word \<Rightarrow> 16 word \<Rightarrow>
+      ('s, 16 word, 'abort, 'i prompt, 'o prompt_output) function_body\<close> where
+  \<open>zq_mul a b \<equiv> FunctionBody \<lbrakk>
+     let a32 = a as u32;
+     let b32 = b as u32;
+
+     let product = a32 * b32;
+     let q32 = mlkem_q_word as u32;
+     let reduced = product % q32;
+
+     reduced as u16
+  \<rbrakk>\<close>
+
+definition zq_mul_contract :: \<open>16 word \<Rightarrow> 16 word \<Rightarrow>
+      ('s::{sepalg}, 16 word, 'b) function_contract\<close> where
+  [crush_contracts]: \<open>zq_mul_contract a b \<equiv>
+    let pre  = \<langle>unat a < mlkem_q\<rangle> \<star>
+               \<langle>unat b < mlkem_q\<rangle>;
+        post = \<lambda>r. \<langle>r = MLKEM_Specification.zq_mul a b\<rangle> \<star>
+               \<langle>unat r < mlkem_q\<rangle>
+     in make_function_contract pre post\<close>
+ucincl_auto zq_mul_contract
+
+lemma zq_mul_spec [crush_specs]:
+  shows \<open>\<Gamma>; zq_mul a b \<Turnstile>\<^sub>F zq_mul_contract a b\<close>
+proof (crush_boot f: zq_mul_def contract: zq_mul_contract_def, goal_cases)
+case 1
+  moreover have q_nz32: \<open>(ucast mlkem_q_word::32 word) \<noteq> 0\<close>
+    by (simp add: mlkem_q_word_def)
+  ultimately show ?case
+    using zq_mul_no_overflow_32 mlkem_q_nonzero_word zq_mul_range zq_mul_ucast_equiv
+      by (crush_base simp add: MLKEM_Specification.zq_mul_def mlkem_q_word_unat mlkem_q_def
+        ucast_u16_u32_unat zq_mul_ucast_equiv)
+qed
+
+end
+
+end

--- a/Micro_Rust_Examples/ROOT
+++ b/Micro_Rust_Examples/ROOT
@@ -21,6 +21,11 @@ session Micro_Rust_Examples = HOL +
     Linked_List_Executable_Physical_Memory
     Reference_Examples
     Showcase
+    MLKEM_Parameters
+    MLKEM_Specification
+    MLKEM_Zq
+    MLKEM_Polynomial
+    MLKEM_NTT
   theories [document=false]
     Micro_Rust_Examples
   document_files


### PR DESCRIPTION
Added a new Micro Rust example: the Number Theoretic Transform (NTT) from the MLKEM post-quantum cryptography standard.  This features three nested loops with some tricky dependent loop invariants.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
