### PR TITLE
I/R: Rename 'explore' -> 'ir'

### DIFF
--- a/.github/workflows/ir.yml
+++ b/.github/workflows/ir.yml
@@ -36,7 +36,7 @@ jobs:
     - name: Build HOL heap
       run: $ISABELLE build -b HOL
 
-    - name: Test explore.ML via console
+    - name: Test ir.ML via console
       run: python3 ir/test_console.py --isabelle $ISABELLE --session HOL
 
     - name: Test repl.py TCP server
@@ -97,7 +97,7 @@ jobs:
     - name: "A: Build without option registered -- expect no source"
       run: |
         $ISABELLE build -d ir/Segment_Storage_Example -b Segment_Storage_Example
-        output=$(printf 'use "%s";' "$PWD/ir/explore.ML" \
+        output=$(printf 'use "%s";' "$PWD/ir/ir.ML" \
           | $ISABELLE console -d ir/Segment_Storage_Example -l Segment_Storage_Example -n 2>&1)
         echo "$output"
         echo "$output" | grep -q "source commands not available"
@@ -111,7 +111,7 @@ jobs:
     - name: "B: Build without store_segments -- expect no source"
       run: |
         $ISABELLE build -d ir/Segment_Storage_Example -c -b Segment_Storage_Example
-        output=$(printf 'use "%s";' "$PWD/ir/explore.ML" \
+        output=$(printf 'use "%s";' "$PWD/ir/ir.ML" \
           | $ISABELLE console -d ir/Segment_Storage_Example -l Segment_Storage_Example -n 2>&1)
         echo "$output"
         echo "$output" | grep -q "source commands not available"
@@ -119,7 +119,7 @@ jobs:
     - name: "C: Build with store_segments=true -- expect source"
       run: |
         $ISABELLE build -d ir/Segment_Storage_Example -c -b -o store_segments=true Segment_Storage_Example
-        output=$(printf 'use "%s";' "$PWD/ir/explore.ML" \
+        output=$(printf 'use "%s";' "$PWD/ir/ir.ML" \
           | $ISABELLE console -d ir/Segment_Storage_Example -l Segment_Storage_Example -n 2>&1)
         echo "$output"
         echo "$output" | grep -q "source commands available"
@@ -134,11 +134,11 @@ jobs:
         config:
           - name: local
             dockerfile: ir/docker/Dockerfile
-            tag: explore-repl:local
+            tag: isabelle-repl:local
             build_args: ""
           - name: standalone
             dockerfile: ir/docker/Dockerfile.standalone
-            tag: explore-repl:standalone
+            tag: isabelle-repl:standalone
             build_args: "--build-arg AUTOCORRODE_BRANCH=${{ github.head_ref || github.ref_name }} --build-arg AUTOCORRODE_REPO=${{ github.event.pull_request.head.repo.clone_url || format('https://github.com/{0}.git', github.repository) }}"
     steps:
       - uses: actions/checkout@v4
@@ -164,14 +164,14 @@ jobs:
             if python3 -c "
           import socket
           s = socket.create_connection(('127.0.0.1', 9147), timeout=2)
-          s.sendall(b'Explore.help ();\n')
+          s.sendall(b'Ir.help ();\n')
           buf = b''
           while b'<<DONE>>' not in buf:
               chunk = s.recv(4096)
               if not chunk: break
               buf += chunk
           s.close()
-          assert b'Explore.init' in buf
+          assert b'Ir.init' in buf
           " 2>/dev/null; then echo "REPL ready at attempt $i"; break; fi
             sleep 2
           done
@@ -180,7 +180,7 @@ jobs:
           python3 -c "
           import socket
           s = socket.create_connection(('127.0.0.1', 9147), timeout=30)
-          s.sendall(b'Explore.theories ();\n')
+          s.sendall(b'Ir.theories ();\n')
           buf = b''
           while b'<<DONE>>' not in buf:
               buf += s.recv(4096)
@@ -201,7 +201,7 @@ jobs:
                                'Accept':'application/json, text/event-stream'})
                   resp = urllib.request.urlopen(req, timeout=10)
                   body = resp.read().decode()
-                  assert 'Explore REPL' in body, f'Unexpected MCP response: {body[:200]}'
+                  assert 'I/R REPL' in body, f'Unexpected MCP response: {body[:200]}'
                   print(f'MCP OK (attempt {attempt+1})')
                   break
               except Exception:

--- a/ir/README.md
+++ b/ir/README.md
@@ -8,15 +8,15 @@ REPLs can be rooted in theories, locations within theories (assuming a suitably 
 Segments](#stored-segments-forking-repls-at-arbitrary-theory-points)), or at points within other REPLs (for sub-proof
 exploration).
 
-An MCP wrapper ([mcp.py](mcp.py)) is provided exposing I/R to AI agents. See [Agent Integration](#agent-integration).
+An MCP wrapper ([mcp_server.py](mcp_server.py)) is provided exposing I/R to AI agents. See [Agent Integration](#agent-integration).
 
 ## Quick Start
 
 ### Option A: Docker (no prerequisites)
 
 ```bash
-docker build -t explore-repl:standalone -f ir/docker/Dockerfile.standalone .
-docker run --rm -it -p 9148:9148 explore-repl:standalone
+docker build -t isabelle-repl:standalone -f ir/docker/Dockerfile.standalone .
+docker run --rm -it -p 9148:9148 isabelle-repl:standalone
 ```
 
 ### Option B: Local
@@ -36,7 +36,7 @@ Starting Bash.Server...
 ● Bash.Server ready at 127.0.0.1:64595
 Starting Isabelle console (session=HOL)...
 ● Isabelle console ready.
-Loading .../explore.ML...
+Loading .../ir.ML...
 ● REPL ready. Waiting for connections on 127.0.0.1:9147
 Starting MCP server...
 [MCP] INFO:     Started server process [4002]
@@ -50,25 +50,25 @@ Starting MCP server...
 ## Try It
 
 ```
-%> Explore.theories ();
+%> Ir.theories ();
   ... list of theories in HOL ...
 
-%> Explore.init "R" ["Main"];
+%> Ir.init "R" ["Main"];
 Created REPL "R", set as current
 
-%> Explore.step "lemma dummy: True";
+%> Ir.step "lemma dummy: True";
 proof (prove)
 goal (1 subgoal):
  1. True
 
-%> Explore.sledgehammer 5;
+%> Ir.sledgehammer 5;
 simp: Try this: by simp (0.1 ms)
 ...
 
-%> Explore.step "by simp";
+%> Ir.step "by simp";
 theorem dummy: True
 
-%> Explore.find_theorems 5 "name: conjI";
+%> Ir.find_theorems 5 "name: conjI";
 displaying 4 theorem(s):
 HOL.conjI: [| ?P; ?Q |] ==> ?P & ?Q
 ...
@@ -106,7 +106,7 @@ When an MCP client connects successfully, you should see:
 
 ## Stored Segments: Forking REPLs at Arbitrary Theory Points
 
-By default, `Explore.init` creates a REPL at the end of a theory.
+By default, `Ir.init` creates a REPL at the end of a theory.
 To fork REPLs at intermediate points (e.g. after a specific lemma,
 or within a proof), you need to store the intermediate proof states in the heap using
 `segment_storage.ML`.
@@ -164,7 +164,7 @@ On startup, you should see `source commands available` instead of
 Browse and fork from stored segments:
 
 ```
-%> Explore.source "My_Session.My_Theory" 0 ~1;
+%> Ir.source "My_Session.My_Theory" 0 ~1;
    0  theory My_Theory imports Main begin
    2  lemma foo: "True"
    4    by simp
@@ -172,7 +172,7 @@ Browse and fork from stored segments:
    8    by simp
   10  end
 
-%> Explore.init "R" ["My_Session.My_Theory:6"];
+%> Ir.init "R" ["My_Session.My_Theory:6"];
 Created REPL "R", set as current
 ```
 

--- a/ir/docker/README.md
+++ b/ir/docker/README.md
@@ -20,15 +20,15 @@ See [ir/README.md](../README.md) for usage instructions.
 
 ```bash
 # Local checkout
-docker build -t explore-repl:local -f ir/docker/Dockerfile .
-docker run --rm -it -p 9148:9148 explore-repl:local
+docker build -t isabelle-repl:local -f ir/docker/Dockerfile .
+docker run --rm -it -p 9148:9148 isabelle-repl:local
 
 # Standalone
-docker build -t explore-repl:standalone -f ir/docker/Dockerfile.standalone .
-docker run --rm -it -p 9148:9148 explore-repl:standalone
+docker build -t isabelle-repl:standalone -f ir/docker/Dockerfile.standalone .
+docker run --rm -it -p 9148:9148 isabelle-repl:standalone
 
 # From a fork/branch
-docker build -t explore-repl:standalone -f ir/docker/Dockerfile.standalone \
+docker build -t isabelle-repl:standalone -f ir/docker/Dockerfile.standalone \
   --build-arg AUTOCORRODE_REPO=https://github.com/user/autocorrode.git \
   --build-arg AUTOCORRODE_BRANCH=my-branch .
 ```

--- a/ir/ir.ML
+++ b/ir/ir.ML
@@ -4,7 +4,7 @@
 (* REPL for exploring Isabelle theories via Isar text.
    Designed for use from the Poly/ML console after loading a heap. *)
 
-signature EXPLORE =
+signature IR =
 sig
   type config = {color: bool, show_ignored: bool, full_spans: bool,
                  show_theory_in_source: bool, auto_replay: bool}
@@ -46,7 +46,7 @@ val _ = Exn.capture (fn () =>
   ML_Compiler.eval ML_Compiler.flags Position.none
     (ML_Lex.tokenize "stored_segments_probe := SOME stored_segments")) ();
 
-structure Explore : EXPLORE =
+structure Ir : IR =
 struct
 
 (** Configuration **)
@@ -54,14 +54,14 @@ struct
 type config = {color: bool, show_ignored: bool, full_spans: bool,
                show_theory_in_source: bool, auto_replay: bool};
 val cfg : config Synchronized.var =
-  Synchronized.var "Explore.cfg" {color = true, show_ignored = false, full_spans = false,
+  Synchronized.var "Ir.cfg" {color = true, show_ignored = false, full_spans = false,
                                    show_theory_in_source = false, auto_replay = true};
 fun config f = Synchronized.change cfg f;
 fun get_cfg () = Synchronized.value cfg;
 
 (** Step timeout (seconds, 0 = no limit) **)
 
-val step_timeout : int Synchronized.var = Synchronized.var "Explore.timeout" 5;
+val step_timeout : int Synchronized.var = Synchronized.var "Ir.timeout" 5;
 fun timeout secs =
   (Synchronized.change step_timeout (K secs);
    TextIO.print ("Timeout set to " ^ (if secs = 0 then "unlimited" else string_of_int secs ^ "s") ^ "\n"));
@@ -251,10 +251,10 @@ type repl = {
 };
 
 val repl_tab : repl Symtab.table Synchronized.var
-  = Synchronized.var "Explore.repls" Symtab.empty;
+  = Synchronized.var "Ir.repls" Symtab.empty;
 
 val current_repl : string Synchronized.var
-  = Synchronized.var "Explore.current_repl" "";
+  = Synchronized.var "Ir.current_repl" "";
 
 fun the_repl id =
   case Symtab.lookup (Synchronized.value repl_tab) id of
@@ -504,7 +504,7 @@ fun remove id =
         Synchronized.change repl_tab (Symtab.delete_safe rid)) to_remove
       val _ = if member (op =) to_remove (Synchronized.value current_repl)
               then (Synchronized.change current_repl (K "");
-                    out "Current REPL was removed. Use Explore.focus or Explore.init to select another.")
+                    out "Current REPL was removed. Use Ir.focus or Ir.init to select another.")
               else ()
   in out ("Removed " ^ commas (map quote to_remove)) end;
 
@@ -586,7 +586,7 @@ fun sledgehammer timeout_secs =
   end;
 
 fun help () = out
-  "=== Explore API ===\n\
+  "=== I/R API ===\n\
   \\n\
   \  Sessions start in the context of a named theory -- do NOT issue\n\
   \  'theory' commands. Steps are Isar: lemma, definition, fun, by, etc.\n\
@@ -617,37 +617,37 @@ fun help () = out
   \\n\
   \=== Quick start ===\n\
   \\n\
-  \  Explore.init \"R\" [\"MySession.MyTheory\"];\n\
-  \  Explore.step \"lemma \\\"True\\\"\";\n\
-  \  Explore.step \"by simp\";\n\
-  \  Explore.show ();\n\
-  \  Explore.state ~1;\n\
+  \  Ir.init \"R\" [\"MySession.MyTheory\"];\n\
+  \  Ir.step \"lemma \\\"True\\\"\";\n\
+  \  Ir.step \"by simp\";\n\
+  \  Ir.show ();\n\
+  \  Ir.state ~1;\n\
   \\n\
   \=== Forking and merging ===\n\
   \\n\
-  \  Explore.step \"lemma \\\"P\\\"\";\n\
-  \  Explore.step \"sorry\";\n\
-  \  Explore.fork \"S\" 1;          (* fork from state before sorry *)\n\
-  \  Explore.step \"by auto\";\n\
-  \  Explore.merge ();             (* replace sorry with proof *)\n\
+  \  Ir.step \"lemma \\\"P\\\"\";\n\
+  \  Ir.step \"sorry\";\n\
+  \  Ir.fork \"S\" 1;          (* fork from state before sorry *)\n\
+  \  Ir.step \"by auto\";\n\
+  \  Ir.merge ();             (* replace sorry with proof *)\n\
   \\n\
   \=== Editing ===\n\
   \\n\
-  \  Explore.edit 0 \"lemma \\\"Q\\\"\";  (* edit first step, replays rest *)\n\
-  \  Explore.truncate 1;             (* keep only steps 0 and 1 *)\n\
+  \  Ir.edit 0 \"lemma \\\"Q\\\"\";  (* edit first step, replays rest *)\n\
+  \  Ir.truncate 1;             (* keep only steps 0 and 1 *)\n\
   \\n\
   \=== Segments (stored theories) ===\n\
   \\n\
-  \  Explore.source \"MySession.MyTheory\" 0 ~1;  (* all *)\n\
-  \  Explore.source \"MySession.MyTheory\" 0 10;  (* first 11 *)\n\
-  \  Explore.init \"R\" [\"MySession.MyTheory:42\"];    (* from source 42 *)";
+  \  Ir.source \"MySession.MyTheory\" 0 ~1;  (* all *)\n\
+  \  Ir.source \"MySession.MyTheory\" 0 10;  (* first 11 *)\n\
+  \  Ir.init \"R\" [\"MySession.MyTheory:42\"];    (* from source 42 *)";
 
 end;
 
 val _ = writeln (case ! stored_segments_probe of
-    NONE => "Explore: source commands not available (heap has no stored segments)"
+    NONE => "Ir: source commands not available (heap has no stored segments)"
   | SOME sv =>
       let val n = length (Synchronized.value sv)
-      in if n = 0 then "Explore: source commands not available (no theories stored)"
-         else "Explore: source commands available (" ^ string_of_int n ^ " theories)"
+      in if n = 0 then "Ir: source commands not available (no theories stored)"
+         else "Ir: source commands available (" ^ string_of_int n ^ " theories)"
       end);

--- a/ir/mcp_server.py
+++ b/ir/mcp_server.py
@@ -3,22 +3,22 @@
 # SPDX-License-Identifier: MIT
 
 """
-MCP server exposing the Explore REPL.
+MCP server exposing the I/R REPL.
 
 Connects to a running repl.py instance over TCP (via the `connect` tool)
-and exposes each Explore function as an MCP tool.  Runs on stdio transport.
+and exposes each I/R function as an MCP tool.  Runs on stdio transport.
 
 Usage:
-    python3 explore_mcp.py
+    python3 mcp_server.py
 
 MCP configuration for communication via stdin/stdout. Adjust BASE as needed.
 
 ```json
   "mcpServers": {
     ...
-    "explore": {
+    "ir": {
       "command": "python3",
-      "args": ["{BASE}/ir/explore_mcp.py"]
+      "args": ["{BASE}/ir/mcp_server.py"]
     }
     ...
   }
@@ -30,7 +30,7 @@ MCP configuration for communication via streaming-http
 ```json
   "mcpServers": {
     ...
-    "explore": {
+    "ir": {
       "url": "http://localhost:9148/mcp",
     }
     ...
@@ -49,7 +49,7 @@ SENTINEL = "<<DONE>>"
 # ---------------------------------------------------------------------------
 
 class ReplClient:
-    """Synchronous TCP client for the Explore REPL server."""
+    """Synchronous TCP client for the I/R REPL server."""
 
     def __init__(self, host: str = "127.0.0.1", port: int = 9147):
         self.host = host
@@ -108,8 +108,8 @@ def ml_int(n: int) -> str:
 # MCP server
 # ---------------------------------------------------------------------------
 
-mcp = FastMCP("Explore REPL",
-              instructions="Isabelle/ML Explore REPL for interactive theory exploration. "
+mcp = FastMCP("I/R REPL",
+              instructions="Isabelle/ML I/R REPL for interactive theory exploration. "
               "Use `connect` first, then `theories` to list available theories, "
               "`init` to create a REPL session rooted at a theory, `step` to advance, "
               "`show` to inspect, `state` to view proof state. "
@@ -119,12 +119,12 @@ mcp = FastMCP("Explore REPL",
 
 repl = ReplClient()
 
-@mcp.tool(description="Connect to the Explore REPL server. Call this before using any other tool. Can also reconnect after a dropped connection.")
+@mcp.tool(description="Connect to the I/R REPL server. Call this before using any other tool. Can also reconnect after a dropped connection.")
 def connect(port: int = 9147, host: str = "127.0.0.1") -> str:
     repl.connect(host, port)
     return f"Connected to {repl.host}:{repl.port}"
 
-@mcp.tool(description="Disconnect from the Explore REPL server.")
+@mcp.tool(description="Disconnect from the I/R REPL server.")
 def disconnect() -> str:
     if not repl.connected:
         return "Already disconnected"
@@ -134,81 +134,81 @@ def disconnect() -> str:
 @mcp.tool(description="Create a new REPL session. `theories` is a list of theory specs: [\"TheoryName\"], [\"TheoryName:source_idx\"], or [\"T1\",\"T2\",...] to merge multiple theories. The session starts in the context of those theories — do NOT send a 'theory' command via step.")
 def init(id: str, theories: list[str]) -> str:
     ml_list = "[" + ", ".join(ml_str(t) for t in theories) + "]"
-    return repl.send(f"Explore.init {ml_str(id)} {ml_list};")
+    return repl.send(f"Ir.init {ml_str(id)} {ml_list};")
 
 @mcp.tool(description="Fork a sub-REPL from the current REPL at the given state index (0=base, -1=latest).")
 def fork(id: str, state_idx: int) -> str:
-    return repl.send(f"Explore.fork {ml_str(id)} {ml_int(state_idx)};")
+    return repl.send(f"Ir.fork {ml_str(id)} {ml_int(state_idx)};")
 
 @mcp.tool(description="Switch the current REPL to the one with the given id.")
 def focus(id: str) -> str:
-    return repl.send(f"Explore.focus {ml_str(id)};")
+    return repl.send(f"Ir.focus {ml_str(id)};")
 
 @mcp.tool(description="Append an Isar command to the current REPL. Examples: 'lemma \"True\"', 'by simp', 'definition ...'. Do NOT use 'theory' commands — the theory context is set by init.")
 def step(isar_text: str) -> str:
-    return repl.send(f"Explore.step {ml_str(isar_text)};")
+    return repl.send(f"Ir.step {ml_str(isar_text)};")
 
 @mcp.tool(description="Append a step by reading Isar text from a file path.")
 def step_file(path: str) -> str:
-    return repl.send(f"Explore.step_file {ml_str(path)};")
+    return repl.send(f"Ir.step_file {ml_str(path)};")
 
 @mcp.tool(description="Show the current REPL: origin, steps, and staleness.")
 def show() -> str:
-    return repl.send("Explore.show ();")
+    return repl.send("Ir.show ();")
 
 @mcp.tool(description="Print the Toplevel.state at the given index (0=base, 1=after step 0, -1=latest).")
 def state(state_idx: int) -> str:
-    return repl.send(f"Explore.state {ml_int(state_idx)};")
+    return repl.send(f"Ir.state {ml_int(state_idx)};")
 
 @mcp.tool(description="Print the concatenated Isar text of all steps in the current REPL.")
 def text() -> str:
-    return repl.send("Explore.text ();")
+    return repl.send("Ir.text ();")
 
 @mcp.tool(description="Replace the step at `idx` with new Isar text. Subsequent steps are replayed if auto_replay is on.")
 def edit(idx: int, isar_text: str) -> str:
-    return repl.send(f"Explore.edit {ml_int(idx)} {ml_str(isar_text)};")
+    return repl.send(f"Ir.edit {ml_int(idx)} {ml_str(isar_text)};")
 
 @mcp.tool(description="Re-execute all stale steps in the current REPL.")
 def replay() -> str:
-    return repl.send("Explore.replay ();")
+    return repl.send("Ir.replay ();")
 
 @mcp.tool(description="Discard all steps after the given index.")
 def truncate(idx: int) -> str:
-    return repl.send(f"Explore.truncate {ml_int(idx)};")
+    return repl.send(f"Ir.truncate {ml_int(idx)};")
 
 @mcp.tool(description="Merge the current sub-REPL back into its parent.")
 def merge() -> str:
-    return repl.send("Explore.merge ();")
+    return repl.send("Ir.merge ();")
 
 @mcp.tool(description="Run Sledgehammer on the current proof state with the given timeout in seconds.")
 def sledgehammer(timeout_secs: int) -> str:
-    return repl.send(f"Explore.sledgehammer {ml_int(timeout_secs)};")
+    return repl.send(f"Ir.sledgehammer {ml_int(timeout_secs)};")
 
 @mcp.tool(description="Search for theorems matching a query. Uses Isabelle's find_theorems syntax: name patterns (name:\"foo\"), intro/elim/dest/simp rules, or term patterns (e.g. \"_ + _ = _ + _\"). Prefix a criterion with - to negate.")
 def find_theorems(query: str, max_results: int = 40) -> str:
-    return repl.send(f"Explore.find_theorems {ml_int(max_results)} {ml_str(query)};")
+    return repl.send(f"Ir.find_theorems {ml_int(max_results)} {ml_str(query)};")
 
 @mcp.tool(description="Set step timeout in seconds (0=unlimited, default 5s).")
 def timeout(secs: int) -> str:
-    return repl.send(f"Explore.timeout {ml_int(secs)};")
+    return repl.send(f"Ir.timeout {ml_int(secs)};")
 
 @mcp.tool(description="Remove a REPL and all its sub-REPLs.")
 def remove(id: str) -> str:
-    return repl.send(f"Explore.remove {ml_str(id)};")
+    return repl.send(f"Ir.remove {ml_str(id)};")
 
 @mcp.tool(description="List all REPL sessions.")
 def repls() -> str:
-    return repl.send("Explore.repls ();")
+    return repl.send("Ir.repls ();")
 
 @mcp.tool(description="List all loaded Isabelle theories.")
 def theories() -> str:
-    return repl.send("Explore.theories ();")
+    return repl.send("Ir.theories ();")
 
 @mcp.tool(description="List command spans of a stored theory. Use negative indices to count from the end.")
 def source(theory_name: str, start: int, stop: int) -> str:
-    return repl.send(f"Explore.source {ml_str(theory_name)} {ml_int(start)} {ml_int(stop)};")
+    return repl.send(f"Ir.source {ml_str(theory_name)} {ml_int(start)} {ml_int(stop)};")
 
-@mcp.tool(description="Update Explore config. Only provided fields are changed; others are left as-is.")
+@mcp.tool(description="Update I/R config. Only provided fields are changed; others are left as-is.")
 def config(color: bool | None = None, show_ignored: bool | None = None,
            full_spans: bool | None = None, show_theory_in_source: bool | None = None,
            auto_replay: bool | None = None) -> str:
@@ -221,11 +221,11 @@ def config(color: bool | None = None, show_ignored: bool | None = None,
         else:
             parts.append(f"{name} = #{name} c")
     ml = "fn c => {" + ", ".join(parts) + "}"
-    return repl.send(f"Explore.config ({ml});")
+    return repl.send(f"Ir.config ({ml});")
 
-@mcp.tool(description="Show the Explore help text.")
+@mcp.tool(description="Show the I/R help text.")
 def help() -> str:
-    return repl.send("Explore.help ();")
+    return repl.send("Ir.help ();")
 
 @mcp.tool(description="Send a raw ML expression to the Poly/ML console. Use for anything not covered by other tools.")
 def raw_ml(ml_code: str) -> str:
@@ -237,7 +237,7 @@ def raw_ml(ml_code: str) -> str:
 
 def main():
     import argparse
-    p = argparse.ArgumentParser(description="Explore MCP server")
+    p = argparse.ArgumentParser(description="I/R MCP server")
     p.add_argument("--transport", choices=["stdio", "sse", "streamable-http"],
                    default="stdio")
     p.add_argument("--port", type=int, default=9148,

--- a/ir/test_console.py
+++ b/ir/test_console.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Test explore.ML via isabelle console.
+"""Test ir.ML via isabelle console.
 
 Assumes the session heap is already built.
 
@@ -14,7 +14,7 @@ import sys
 import time
 
 SCRIPT_DIR = os.path.dirname(os.path.abspath(__file__))
-EXPLORE_ML = os.path.join(SCRIPT_DIR, "explore.ML")
+IR_ML = os.path.join(SCRIPT_DIR, "ir.ML")
 
 # ANSI
 _RED = "\033[31m"
@@ -68,11 +68,11 @@ def run_test(name, isabelle, session, directory, ml_commands):
 
 
 def use(ml):
-    return f'use "{EXPLORE_ML}"; {ml}'
+    return f'use "{IR_ML}"; {ml}'
 
 
 def main():
-    p = argparse.ArgumentParser(description="Test explore.ML via isabelle console")
+    p = argparse.ArgumentParser(description="Test ir.ML via isabelle console")
     p.add_argument("--isabelle", default=os.environ.get("ISABELLE", "isabelle"))
     p.add_argument("--session", default="HOL")
     p.add_argument("--dir", default=None)
@@ -84,8 +84,8 @@ def main():
     if not shutil.which(args.isabelle):
         print(f"{_SYM_FAIL} isabelle not found: {args.isabelle}", file=sys.stderr)
         sys.exit(1)
-    if not os.path.isfile(EXPLORE_ML):
-        print(f"{_SYM_FAIL} explore.ML not found: {EXPLORE_ML}", file=sys.stderr)
+    if not os.path.isfile(IR_ML):
+        print(f"{_SYM_FAIL} ir.ML not found: {IR_ML}", file=sys.stderr)
         sys.exit(1)
 
     # Probe source availability up front
@@ -94,7 +94,7 @@ def main():
     print(f"  {_SYM_BUSY} loading heap", end="", flush=True)
     t0 = time.time()
     _, probe_output = run_console(
-        args.isabelle, args.session, args.dir, f'use "{EXPLORE_ML}";')
+        args.isabelle, args.session, args.dir, f'use "{IR_ML}";')
     has_source = "source commands available" in probe_output and "not available" not in probe_output
     avail_thy = None
 
@@ -103,7 +103,7 @@ def main():
         n_theories = m.group(1) if m else "?"
         _, seg_output = run_console(
             args.isabelle, args.session, args.dir,
-            use('(Explore.source "Main" 0 0 handle ERROR msg => writeln msg);'))
+            use('(Ir.source "Main" 0 0 handle ERROR msg => writeln msg);'))
         m = re.search(r'Available: (\S+)', seg_output)
         if m:
             avail_thy = m.group(1).rstrip(',')
@@ -120,64 +120,64 @@ def main():
             sys.exit(1)
 
     # Run tests
-    print(f"\n{_BOLD}Running{_RESET} explore.ML console tests "
+    print(f"\n{_BOLD}Running{_RESET} ir.ML console tests "
           f"{_DIM}(session={args.session}){_RESET}")
 
     run = lambda name, ml: run_test(name, args.isabelle, args.session, args.dir, ml)
 
-    run("load explore.ML",
-        f'use "{EXPLORE_ML}";')
+    run("load ir.ML",
+        f'use "{IR_ML}";')
 
     run("help",
-        use('Explore.help ();'))
+        use('Ir.help ();'))
 
     run("theories",
-        use('Explore.theories ();'))
+        use('Ir.theories ();'))
 
     run("init + show",
-        use('Explore.init "t1" "Main"; Explore.show ();'))
+        use('Ir.init "t1" "Main"; Ir.show ();'))
 
     run("step + state",
-        use('Explore.init "t1" "Main"; Explore.step "lemma True by simp"; Explore.state ~1;'))
+        use('Ir.init "t1" "Main"; Ir.step "lemma True by simp"; Ir.state ~1;'))
 
     run("text",
-        use('Explore.init "t1" "Main"; Explore.step "lemma True by simp"; Explore.text ();'))
+        use('Ir.init "t1" "Main"; Ir.step "lemma True by simp"; Ir.text ();'))
 
     run("edit + replay",
-        use('Explore.init "t1" "Main"; Explore.step "lemma True by simp"; '
-            'Explore.edit 0 "lemma True by auto"; Explore.replay ();'))
+        use('Ir.init "t1" "Main"; Ir.step "lemma True by simp"; '
+            'Ir.edit 0 "lemma True by auto"; Ir.replay ();'))
 
     run("truncate",
-        use('Explore.init "t1" "Main"; Explore.step "lemma True by simp"; '
-            'Explore.step "lemma True by auto"; Explore.truncate 0;'))
+        use('Ir.init "t1" "Main"; Ir.step "lemma True by simp"; '
+            'Ir.step "lemma True by auto"; Ir.truncate 0;'))
 
     run("fork + focus + merge",
-        use('Explore.init "t1" "Main"; Explore.step "lemma True by simp"; '
-            'Explore.fork "t2" 0; Explore.focus "t2"; '
-            'Explore.step "lemma True by auto"; Explore.merge ();'))
+        use('Ir.init "t1" "Main"; Ir.step "lemma True by simp"; '
+            'Ir.fork "t2" 0; Ir.focus "t2"; '
+            'Ir.step "lemma True by auto"; Ir.merge ();'))
 
     run("repls + remove",
-        use('Explore.init "t1" "Main"; Explore.init "t2" "Main"; '
-            'Explore.repls (); Explore.remove "t2";'))
+        use('Ir.init "t1" "Main"; Ir.init "t2" "Main"; '
+            'Ir.repls (); Ir.remove "t2";'))
 
     if has_source:
         run_test("source (missing theory)", args.isabelle, args.session, args.dir,
-                 use('(Explore.source "Main" 0 0 handle ERROR msg => '
+                 use('(Ir.source "Main" 0 0 handle ERROR msg => '
                      'if String.isSubstring "No stored segments" msg '
                      'then writeln "OK: expected error" '
                      'else raise (ERROR msg));'))
         if avail_thy:
             run_test("source", args.isabelle, args.session, args.dir,
-                     use(f'Explore.source "{avail_thy}" 0 3;'))
+                     use(f'Ir.source "{avail_thy}" 0 3;'))
         else:
             print(f"  {_SYM_SKIP} source listing {_DIM}(no stored theories){_RESET}")
     else:
         run_test("source (graceful error without segments)",
                  args.isabelle, args.session, args.dir,
-                 use('(Explore.source "Main" 0 3 handle ERROR _ => ());'))
+                 use('(Ir.source "Main" 0 3 handle ERROR _ => ());'))
 
     run("config",
-        use('Explore.config (fn c => {color = false, show_ignored = #show_ignored c, '
+        use('Ir.config (fn c => {color = false, show_ignored = #show_ignored c, '
             'full_spans = #full_spans c, show_theory_in_source = #show_theory_in_source c, '
             'auto_replay = #auto_replay c});'))
 

--- a/ir/test_repl.py
+++ b/ir/test_repl.py
@@ -155,76 +155,76 @@ def main():
         tests = []
 
         def test_help():
-            out = send_recv(sock, 'Explore.help ();')
-            assert "Explore.init" in out, f"Expected help text, got:\n{out}"
+            out = send_recv(sock, 'Ir.help ();')
+            assert "Ir.init" in out, f"Expected help text, got:\n{out}"
 
         tests.append(test_help)
 
         def test_theories():
-            out = send_recv(sock, 'Explore.theories ();')
+            out = send_recv(sock, 'Ir.theories ();')
             assert "Main" in out, f"Expected Main theory, got:\n{out}"
 
         tests.append(test_theories)
 
         def test_init_show():
-            send_recv(sock, 'Explore.init "t1" ["Main"];')
-            out = send_recv(sock, 'Explore.show ();')
+            send_recv(sock, 'Ir.init "t1" ["Main"];')
+            out = send_recv(sock, 'Ir.show ();')
             assert "t1" in out, f"Expected REPL t1, got:\n{out}"
 
         tests.append(test_init_show)
 
         def test_step():
-            out = send_recv(sock, 'Explore.step "lemma dummy: True by simp";')
+            out = send_recv(sock, 'Ir.step "lemma dummy: True by simp";')
             assert "theorem dummy: True" in out, f"Unexpected output: \n{out}"
 
         tests.append(test_step)
 
         def test_state():
-            send_recv(sock, 'Explore.step "lemma foo: True";')
-            out = send_recv(sock, 'Explore.state ~1;')
+            send_recv(sock, 'Ir.step "lemma foo: True";')
+            out = send_recv(sock, 'Ir.state ~1;')
             assert "goal (1 subgoal):", f"Unexpected state:\n{out}"
 
         tests.append(test_state)
 
         def test_text():
-            out = send_recv(sock, 'Explore.text ();')
+            out = send_recv(sock, 'Ir.text ();')
             assert "lemma" in out, f"Expected lemma text, got:\n{out}"
 
         tests.append(test_text)
 
         def test_edit_replay():
-            send_recv(sock, 'Explore.edit 0 "lemma True by auto";')
-            send_recv(sock, 'Explore.replay ();')
+            send_recv(sock, 'Ir.edit 0 "lemma True by auto";')
+            send_recv(sock, 'Ir.replay ();')
 
         tests.append(test_edit_replay)
 
         def test_fork_focus_merge():
-            send_recv(sock, 'Explore.fork "t2" 0;')
-            send_recv(sock, 'Explore.focus "t2";')
-            send_recv(sock, 'Explore.step "lemma True by auto";')
-            send_recv(sock, 'Explore.merge ();')
+            send_recv(sock, 'Ir.fork "t2" 0;')
+            send_recv(sock, 'Ir.focus "t2";')
+            send_recv(sock, 'Ir.step "lemma True by auto";')
+            send_recv(sock, 'Ir.merge ();')
 
         tests.append(test_fork_focus_merge)
 
         def test_repls():
-            out = send_recv(sock, 'Explore.repls ();')
+            out = send_recv(sock, 'Ir.repls ();')
             assert "t1" in out, f"Expected t1 in repls, got:\n{out}"
 
         tests.append(test_repls)
 
         def test_source():
-            send_recv(sock, 'Explore.source "Main" 0 3 handle ERROR _ => ();')
+            send_recv(sock, 'Ir.source "Main" 0 3 handle ERROR _ => ();')
 
         tests.append(test_source)
 
         def test_remove():
-            send_recv(sock, 'Explore.init "tmp" ["Main"];')
-            send_recv(sock, 'Explore.remove "tmp";')
+            send_recv(sock, 'Ir.init "tmp" ["Main"];')
+            send_recv(sock, 'Ir.remove "tmp";')
 
         tests.append(test_remove)
 
         def test_config():
-            send_recv(sock, 'Explore.config (fn c => '
+            send_recv(sock, 'Ir.config (fn c => '
                       '{color = false, show_ignored = #show_ignored c, '
                       'full_spans = #full_spans c, '
                       'show_theory_in_source = #show_theory_in_source c, '
@@ -234,65 +234,65 @@ def main():
 
         def test_multiline_step():
             """Multi-line Isar text sent as escaped ML string (via MCP path)."""
-            send_recv(sock, 'Explore.init "ml1" ["Main"];')
+            send_recv(sock, 'Ir.init "ml1" ["Main"];')
             # Multi-line: lemma + proof on separate lines, escaped as ML string
-            out = send_recv(sock, 'Explore.step "lemma ml_test: True\\nby simp";')
+            out = send_recv(sock, 'Ir.step "lemma ml_test: True\\nby simp";')
             assert "ml_test" in out, f"Expected ml_test theorem, got:\n{out}"
-            send_recv(sock, 'Explore.remove "ml1";')
+            send_recv(sock, 'Ir.remove "ml1";')
 
         tests.append(test_multiline_step)
 
         def test_multiline_step_raw_newline():
             """Multi-line Isar text with raw newline (TCP multi-line accumulation)."""
-            send_recv(sock, 'Explore.init "ml2" ["Main"];')
+            send_recv(sock, 'Ir.init "ml2" ["Main"];')
             # Raw newline: TCP handler accumulates lines until ;
-            out = send_recv(sock, 'Explore.step "lemma ml_raw: True\nby simp";')
+            out = send_recv(sock, 'Ir.step "lemma ml_raw: True\nby simp";')
             assert "ml_raw" in out, f"Expected ml_raw theorem, got:\n{out}"
-            send_recv(sock, 'Explore.remove "ml2";')
+            send_recv(sock, 'Ir.remove "ml2";')
 
         tests.append(test_multiline_step_raw_newline)
 
         # -- find_theorems tests --
         def test_ft_single_theory_immediate_library():
-            send_recv(sock, 'Explore.init "ft1" ["Main"];')
-            out = send_recv(sock, 'Explore.find_theorems 3 "name: conjI";')
+            send_recv(sock, 'Ir.init "ft1" ["Main"];')
+            out = send_recv(sock, 'Ir.find_theorems 3 "name: conjI";')
             assert "conjI" in out, f"Expected conjI, got:\n{out}"
-            send_recv(sock, 'Explore.remove "ft1";')
+            send_recv(sock, 'Ir.remove "ft1";')
 
         tests.append(test_ft_single_theory_immediate_library)
 
         def test_ft_single_theory_after_lemma_library():
-            send_recv(sock, 'Explore.init "ft2" ["Main"];')
-            send_recv(sock, 'Explore.step "lemma ft2_lem: True by simp";')
-            out = send_recv(sock, 'Explore.find_theorems 3 "name: conjI";')
+            send_recv(sock, 'Ir.init "ft2" ["Main"];')
+            send_recv(sock, 'Ir.step "lemma ft2_lem: True by simp";')
+            out = send_recv(sock, 'Ir.find_theorems 3 "name: conjI";')
             assert "conjI" in out, f"Expected conjI, got:\n{out}"
-            send_recv(sock, 'Explore.remove "ft2";')
+            send_recv(sock, 'Ir.remove "ft2";')
 
         tests.append(test_ft_single_theory_after_lemma_library)
 
         def test_ft_single_theory_after_lemma_repl_fact():
-            send_recv(sock, 'Explore.init "ft3" ["Main"];')
-            send_recv(sock, 'Explore.step "lemma ft3_lem: True by simp";')
-            out = send_recv(sock, 'Explore.find_theorems 3 "name: ft3_lem";')
+            send_recv(sock, 'Ir.init "ft3" ["Main"];')
+            send_recv(sock, 'Ir.step "lemma ft3_lem: True by simp";')
+            out = send_recv(sock, 'Ir.find_theorems 3 "name: ft3_lem";')
             assert "ft3_lem" in out, f"Expected ft3_lem, got:\n{out}"
-            send_recv(sock, 'Explore.remove "ft3";')
+            send_recv(sock, 'Ir.remove "ft3";')
 
         tests.append(test_ft_single_theory_after_lemma_repl_fact)
 
         def test_ft_multi_theory_immediate_library():
-            send_recv(sock, 'Explore.init "ft4" ["Main", "Complex_Main"];')
-            out = send_recv(sock, 'Explore.find_theorems 3 "name: conjI";')
+            send_recv(sock, 'Ir.init "ft4" ["Main", "Complex_Main"];')
+            out = send_recv(sock, 'Ir.find_theorems 3 "name: conjI";')
             assert "conjI" in out, f"Expected conjI, got:\n{out}"
-            send_recv(sock, 'Explore.remove "ft4";')
+            send_recv(sock, 'Ir.remove "ft4";')
 
         tests.append(test_ft_multi_theory_immediate_library)
 
         def test_ft_multi_theory_after_lemma_repl_fact():
-            send_recv(sock, 'Explore.init "ft5" ["Main", "Complex_Main"];')
-            send_recv(sock, 'Explore.step "lemma ft5_lem: True by simp";')
-            out = send_recv(sock, 'Explore.find_theorems 3 "name: ft5_lem";')
+            send_recv(sock, 'Ir.init "ft5" ["Main", "Complex_Main"];')
+            send_recv(sock, 'Ir.step "lemma ft5_lem: True by simp";')
+            out = send_recv(sock, 'Ir.find_theorems 3 "name: ft5_lem";')
             assert "ft5_lem" in out, f"Expected ft5_lem, got:\n{out}"
-            send_recv(sock, 'Explore.remove "ft5";')
+            send_recv(sock, 'Ir.remove "ft5";')
 
         tests.append(test_ft_multi_theory_after_lemma_repl_fact)
 
@@ -303,7 +303,7 @@ def main():
 
         # Cleanup from single-client tests
         cleanup_sock = connect(port)
-        send_recv(cleanup_sock, 'Explore.remove "t1";')
+        send_recv(cleanup_sock, 'Ir.remove "t1";')
         cleanup_sock.close()
 
         # -- Multi-client tests --
@@ -322,13 +322,13 @@ def main():
                 except Exception as e:
                     errors[idx] = e
 
-            send_recv(s1, 'Explore.init "mc1" ["Main"];')
-            send_recv(s1, 'Explore.init "mc2" ["Main"];')
+            send_recv(s1, 'Ir.init "mc1" ["Main"];')
+            send_recv(s1, 'Ir.init "mc2" ["Main"];')
 
             t1 = threading.Thread(target=client,
-                                  args=(0, s1, 'Explore.focus "mc1"; Explore.theories ();'))
+                                  args=(0, s1, 'Ir.focus "mc1"; Ir.theories ();'))
             t2 = threading.Thread(target=client,
-                                  args=(1, s2, 'Explore.focus "mc2"; Explore.theories ();'))
+                                  args=(1, s2, 'Ir.focus "mc2"; Ir.theories ();'))
             t1.start()
             t2.start()
             t1.join(timeout=60)
@@ -339,20 +339,20 @@ def main():
                     raise errors[i]
                 assert results[i] is not None, f"Client {i} got no result"
 
-            send_recv(s1, 'Explore.remove "mc1";')
-            send_recv(s1, 'Explore.remove "mc2";')
+            send_recv(s1, 'Ir.remove "mc1";')
+            send_recv(s1, 'Ir.remove "mc2";')
             s1.close()
             s2.close()
 
         def test_client_disconnect():
             """A client disconnects; server stays alive for new clients."""
             s1 = connect(port)
-            send_recv(s1, 'Explore.help ();')
+            send_recv(s1, 'Ir.help ();')
             s1.close()
             time.sleep(0.5)
             s2 = connect(port)
-            out = send_recv(s2, 'Explore.help ();')
-            assert "Explore.init" in out
+            out = send_recv(s2, 'Ir.help ();')
+            assert "Ir.init" in out
             s2.close()
 
         for t in [test_concurrent_clients, test_client_disconnect]:


### PR DESCRIPTION
* Based on #146 

Renames 'explore' -> 'ir' everywhere.