### PR TITLE
Micro_Rust_Parsing_Frontend: tweak the handling of dereference places

### DIFF
--- a/Micro_Rust_Parsing_Frontend/Micro_Rust_Syntax.thy
+++ b/Micro_Rust_Parsing_Frontend/Micro_Rust_Syntax.thy
@@ -177,7 +177,7 @@ syntax
     ("_" [0]1000)
   "_urust_lhs_parens" :: "urust_lhs \<Rightarrow> urust_lhs"
     ("'(_')" [0]999)
-  "_urust_lhs_deref" :: \<open>urust_lhs \<Rightarrow> urust_lhs\<close>
+  "_urust_lhs_deref" :: \<open>urust \<Rightarrow> urust_lhs\<close>
     ("*_" [200]100)
   "_urust_lhs_field_access" :: \<open>urust_lhs \<Rightarrow> urust_identifier \<Rightarrow> urust_lhs\<close>
     ("_._" [99,1000]100)
@@ -575,7 +575,7 @@ syntax
 translations
   "_urust_lhs_as_urust (_urust_lhs_identifier id)" => "_urust_identifier id"
   "_urust_lhs_as_urust (_urust_lhs_parens lhs)" => "_urust_parens (_urust_lhs_as_urust lhs)"
-  "_urust_lhs_as_urust (_urust_lhs_deref lhs)" => "_urust_deref (_urust_lhs_as_urust lhs)"
+  "_urust_lhs_as_urust (_urust_lhs_deref ex)" => "ex" (* Deref is basically a no-op on a LHS *)
   "_urust_lhs_as_urust (_urust_lhs_field_access lhs fld)" =>
     "_urust_field_access (_urust_lhs_as_urust lhs) fld"
   "_urust_lhs_as_urust (_urust_lhs_index lhs idx)" =>


### PR DESCRIPTION
Allow the `* _` syntax production of `_urust_lhs` to take an arbitrary `_urust` expression instead of restricting it to `_urust_lhs`. This allows the grammar to parse more syntax, and seems a closer match to the behavior of the Rust compiler. The documentation regarding place expressions [1] is rather imprecise, but this seems like a valid interpretation.

Also, tweak the handling of the `_urust_lhs_deref` synax form. When it appears in an assignment, the dereference syntax is essentially a no-op.

[1]: https://doc.rust-lang.org/reference/expressions.html#r-expr.place-value

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
