### PR TITLE
fix: Auto-select free port for I/Q MCP server

### DIFF
--- a/iq/src/IQPlugin.scala
+++ b/iq/src/IQPlugin.scala
@@ -7,6 +7,14 @@ import isabelle.jedit._
 import org.gjt.sp.jedit.{EBMessage, EBPlugin, jEdit}
 
 object IQPlugin {
+  /** System property key used to communicate the actual bound port to other
+    * plugins (e.g. Isabelle Assistant) running in the same JVM. Non-persistent:
+    * cleared on JVM exit and on plugin stop. */
+  val PORT_PROPERTY = "iq.mcp.port"
+
+  private val DEFAULT_PORT = 8765
+  private val MAX_PORT_SCAN = 100
+
   @volatile private var instance: Option[IQPlugin] = None
 
   /** Port reported by ML_Repl via PIDE protocol message. */
@@ -14,6 +22,9 @@ object IQPlugin {
 
   /** Port of the I/R REPL (repl.py), set by IQExploreDockable on connect. */
   @volatile var irReplPort: Option[Int] = None
+
+  /** Actual bound port of the I/Q MCP server, set after successful start. */
+  @volatile var mcpPort: Option[Int] = None
 
   private def register(plugin: IQPlugin): Unit = {
     instance = Some(plugin)
@@ -83,18 +94,34 @@ class IQPlugin extends EBPlugin {
   }
 
   private def startServer(): Unit = {
-    // Start MCP server
-    try {
-      val securityConfig = buildSecurityConfig()
-      iqServer = Some(new IQServer(port = 8765, securityConfig = securityConfig))
-      iqServer.foreach(_.start())
-      Output.writeln("Isabelle/Q Server started successfully on port 8765")
-      IQPlugin.activateWidget("iq-mcp-status")
-    } catch {
-      case ex: Exception =>
-        iqServer = None
-        Output.writeln(s"Failed to start Isabelle/Q Server: ${ex.getMessage}")
-        ex.printStackTrace()
+    val securityConfig = buildSecurityConfig()
+    var tryPort = IQPlugin.DEFAULT_PORT
+    val maxPort = tryPort + IQPlugin.MAX_PORT_SCAN
+    var started = false
+    while (!started && tryPort < maxPort) {
+      try {
+        iqServer = Some(new IQServer(port = tryPort, securityConfig = securityConfig))
+        iqServer.foreach(_.start())
+        System.setProperty(IQPlugin.PORT_PROPERTY, tryPort.toString)
+        started = true
+        IQPlugin.mcpPort = Some(tryPort)
+        Output.writeln(s"Isabelle/Q Server started successfully on port $tryPort")
+        IQPlugin.activateWidget("iq-mcp-status")
+      } catch {
+        case _: java.net.BindException =>
+          iqServer = None
+          tryPort += 1
+        case ex: Exception =>
+          iqServer = None
+          Output.writeln(s"Failed to start Isabelle/Q Server: ${ex.getMessage}")
+          ex.printStackTrace()
+          return
+      }
+    }
+    if (!started) {
+      Output.writeln(
+        s"Failed to start Isabelle/Q Server: no free port in range ${IQPlugin.DEFAULT_PORT}–${maxPort - 1}"
+      )
     }
   }
 
@@ -112,6 +139,8 @@ class IQPlugin extends EBPlugin {
     // Stop MCP server
     iqServer.foreach(_.stop())
     iqServer = None
+    IQPlugin.mcpPort = None
+    System.clearProperty(IQPlugin.PORT_PROPERTY)
 
     // Stop I/R daemon
     IQExploreDockable.shutdown()

--- a/isabelle-assistant/src/IQMcpClient.scala
+++ b/isabelle-assistant/src/IQMcpClient.scala
@@ -29,6 +29,12 @@ object IQMcpClient {
   private val connectTimeoutMs = 250
   private val minSocketTimeoutMs = 1000
 
+  /** Read the I/Q MCP port from the system property set by the I/Q plugin,
+    * falling back to the default if the property is absent or malformed. */
+  private def currentPort: Int =
+    try { System.getProperty("iq.mcp.port", "8765").trim.toInt }
+    catch { case _: NumberFormatException => AssistantConstants.DEFAULT_MCP_PORT }
+
   /** Connection pool for persistent TCP connection to I/Q MCP server.
     * Reuses connections to avoid per-call socket overhead (250ms per connect).
     * Falls back to fresh connection on any I/O error.
@@ -39,12 +45,23 @@ object IQMcpClient {
     @volatile private var connection: Option[(Socket, BufferedReader, PrintWriter)] = None
     @volatile private var lastUsedMs = 0L
     private val keepaliveIntervalMs = 30000L // 30 seconds
+
+    private def connectTo(port: Int, socketTimeout: Int): (Socket, BufferedReader, PrintWriter) = {
+      val s = new Socket()
+      s.connect(new InetSocketAddress(host, port), connectTimeoutMs)
+      s.setSoTimeout(socketTimeout)
+      val r = new BufferedReader(new InputStreamReader(s.getInputStream, StandardCharsets.UTF_8))
+      val w = new PrintWriter(new OutputStreamWriter(s.getOutputStream, StandardCharsets.UTF_8), true)
+      (s, r, w)
+    }
     
     def withConnection[T](timeoutMs: Long)(f: (BufferedReader, PrintWriter) => T): T = {
       lock.lock()
       try {
-        // Check if connection is stale or needs keepalive
+        val port = currentPort
         val now = System.currentTimeMillis()
+
+        // Check if connection is stale or needs keepalive
         if (connection.isDefined && now - lastUsedMs > keepaliveIntervalMs) {
           // Send keepalive ping
           if (!pingExistingConnection()) {
@@ -57,20 +74,7 @@ object IQMcpClient {
         val (socket, reader, writer) = connection match {
           case Some(conn) => conn
           case None =>
-            val newSocket = new Socket()
-            newSocket.connect(
-              new InetSocketAddress(host, AssistantConstants.DEFAULT_MCP_PORT),
-              connectTimeoutMs
-            )
-            newSocket.setSoTimeout(minSocketTimeoutMs)
-            val newReader = new BufferedReader(
-              new InputStreamReader(newSocket.getInputStream, StandardCharsets.UTF_8)
-            )
-            val newWriter = new PrintWriter(
-              new OutputStreamWriter(newSocket.getOutputStream, StandardCharsets.UTF_8),
-              true
-            )
-            val conn = (newSocket, newReader, newWriter)
+            val conn = connectTo(port, minSocketTimeoutMs)
             connection = Some(conn)
             conn
         }
@@ -89,20 +93,7 @@ object IQMcpClient {
             closeQuietly()
             connection = None
             
-            val freshSocket = new Socket()
-            freshSocket.connect(
-              new InetSocketAddress(host, AssistantConstants.DEFAULT_MCP_PORT),
-              connectTimeoutMs
-            )
-            // Apply per-call timeout to retry connection as well
-            freshSocket.setSoTimeout(bounded)
-            val freshReader = new BufferedReader(
-              new InputStreamReader(freshSocket.getInputStream, StandardCharsets.UTF_8)
-            )
-            val freshWriter = new PrintWriter(
-              new OutputStreamWriter(freshSocket.getOutputStream, StandardCharsets.UTF_8),
-              true
-            )
+            val (freshSocket, freshReader, freshWriter) = connectTo(port, bounded)
             connection = Some((freshSocket, freshReader, freshWriter))
             lastUsedMs = System.currentTimeMillis()
             


### PR DESCRIPTION
*Description of changes:*

Scan ports starting from 8765 to avoid conflicts when multiple Isabelle/jEdit sessions run concurrently. The actual bound port is published via a JVM system property so the Isabelle Assistant in the same process connects to the correct instance.

- IQPlugin: scan ports 8765–8864, set/clear system property iq.mcp.port
- IQMcpClient: read port from system property, deduplicate socket creation


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
