### PR TITLE
I/Q: Fix stdio buffering causing delayed MCP responses

### DIFF
--- a/ir/mcp_server.py
+++ b/ir/mcp_server.py
@@ -39,6 +39,9 @@ MCP configuration for communication via streaming-http
 
 """
 
+import sys
+sys.stdout.reconfigure(line_buffering=True)
+
 import socket
 from mcp.server.fastmcp import FastMCP
 


### PR DESCRIPTION
Python uses block buffering on stdout when connected to a pipe, which caused JSON-RPC responses to accumulate in the 4-8KB pipe buffer instead of being flushed immediately. This shifted responses by ~4-5 calls, making the I/Q REPL appear broken.

Force line-buffered stdout before any I/O occurs.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
