### PR TITLE
I/R + I/Q: dynamic port allocation for ML_Repl TCP server

### DIFF
--- a/iq/src/IQExploreDockable.scala
+++ b/iq/src/IQExploreDockable.scala
@@ -53,12 +53,33 @@ object IQExploreDockable {
         onStatus("ir/repl.py not found at " + replPy)
         started = false
       case Some(replPy) =>
-        // Start ML_Repl
-        PIDE.session.protocol_command("IR_Repl.start", XML.string("9146"))
-        onStatus("Sent IR_Repl.start (port 9146)")
+        // Register protocol handler to receive ML_Repl port
+        PIDE.session.init_protocol_handler(new IQPlugin.IR_Repl_Handler)
+        // Start ML_Repl (port 0 = pick any free port)
+        PIDE.session.protocol_command("IR_Repl.start")
+        onStatus("Sent IR_Repl.start")
+        // Wait for ML_Repl to report its port (max 10s)
+        val mlPort = {
+          var attempts = 0
+          while (IQPlugin.mlReplPort.isEmpty && attempts < 20) {
+            Thread.sleep(500)
+            attempts += 1
+            onStatus("Waiting for ML_Repl port... (" + (attempts * 500) + "ms)")
+          }
+          IQPlugin.mlReplPort match {
+            case Some(p) =>
+              onStatus("ML_Repl reported port " + p)
+              p
+            case None =>
+              onStatus("ML_Repl did not report port within 10s — cannot start repl.py")
+              started = false
+              return
+          }
+        }
         // Launch repl.py --daemon with current Isabelle home
         val isabellePath = Isabelle_System.getenv("ISABELLE_HOME")
         val pb = new ProcessBuilder("python3", replPy, "--daemon", "--mcp", "--expect-ml",
+          "--poly-ml-port", mlPort.toString,
           "--isabelle", isabellePath)
         pb.redirectErrorStream(true)
         val cmdLine = pb.command().toArray.mkString(" ")

--- a/iq/src/IQPlugin.scala
+++ b/iq/src/IQPlugin.scala
@@ -9,6 +9,9 @@ import org.gjt.sp.jedit.{EBMessage, EBPlugin, jEdit}
 object IQPlugin {
   @volatile private var instance: Option[IQPlugin] = None
 
+  /** Port reported by ML_Repl via PIDE protocol message. */
+  @volatile var mlReplPort: Option[Int] = None
+
   private def register(plugin: IQPlugin): Unit = {
     instance = Some(plugin)
   }
@@ -19,6 +22,22 @@ object IQPlugin {
 
   def restartServerFromSettings(): Unit = {
     instance.foreach(_.restartServerFromSettings())
+  }
+
+  /** PIDE protocol handler: receives IR_Repl.port messages from ML. */
+  class IR_Repl_Handler extends Session.Protocol_Handler {
+    private def handle_port(msg: Prover.Protocol_Output): Boolean = {
+      msg.properties match {
+        case List(_, ("port", isabelle.Value.Int(port))) =>
+          mlReplPort = Some(port)
+          Output.writeln("IQPlugin: ML_Repl port = " + port)
+          true
+        case _ => false
+      }
+    }
+
+    override val functions: Session.Protocol_Functions =
+      List("IR_Repl.port" -> handle_port)
   }
 }
 

--- a/ir/ml_repl.ML
+++ b/ir/ml_repl.ML
@@ -187,16 +187,16 @@ val ir_pri = ~1;
 
 fun start port =
   if Tcp_Handler.is_running () then
-    (Output.information ("IR_Repl: server already running on port " ^ string_of_int port);
+    (Output.information ("IR_Repl: server already running");
      NONE)
   else
   let
-    val accept_loop = Tcp_Handler.start port
+    val (actual_port, accept_loop) = Tcp_Handler.start port
     val ir_group = Future.new_group NONE
     val _ = Synchronized.change server_group_id (K (Task_Queue.group_id ir_group))
     val _ = Synchronized.change Tcp_Handler.handler (K eval_handler)
   in
-    SOME ((singleton o Future.forks)
+    SOME (actual_port, (singleton o Future.forks)
       {name = "ml_repl_accept", group = SOME ir_group,
        deps = [], pri = ir_pri, interrupts = true}
       accept_loop)
@@ -209,19 +209,27 @@ fun stop () =
 end;
 
 (* PIDE protocol command for starting I/R from jEdit *)
+
+fun report_port port =
+  Output.protocol_message
+    [Markup.function "IR_Repl.port", ("port", Value.print_int port)] [];
+
 val _ =
   Protocol_Command.define "IR_Repl.start"
     (fn args =>
       let
         val port =
           (case args of
-            [] => 9146
-          | [p] => the_default 9146 (Int.fromString p)
+            [] => 0
+          | [p] => the_default 0 (Int.fromString p)
           | _ => error "IR_Repl.start: expected at most one argument (port)")
       in
         case ML_Repl.start port of
-          SOME _ => Output.writeln ("IR_Repl: started on port " ^ string_of_int port)
-        | NONE => Output.writeln ("IR_Repl: already running on port " ^ string_of_int port)
+          SOME (actual_port, _) =>
+            (report_port actual_port;
+             Output.writeln ("IR_Repl: started on port " ^ string_of_int actual_port))
+        | NONE =>
+            Output.writeln "IR_Repl: already running"
       end);
 
 val _ =

--- a/ir/repl.py
+++ b/ir/repl.py
@@ -497,7 +497,8 @@ class PolyMLProcess:
 
     def __init__(self, isabelle, session, directory, ml_dir, port,
                  bash_server=None, no_build=False, redirect=True):
-        self.port = port
+        self.requested_port = port
+        self.port = port  # updated to actual port after start
         self.cmd = self._build_cmd(isabelle, session, directory, ml_dir, port,
                                    bash_server=bash_server, redirect=redirect)
         self.proc = subprocess.Popen(
@@ -508,6 +509,20 @@ class PolyMLProcess:
             bufsize=0,
             start_new_session=True,
         )
+
+    def read_actual_port(self, timeout=60):
+        """Read stdout until Tcp_Handler reports its port. Updates self.port."""
+        import re
+        deadline = time.monotonic() + timeout
+        while time.monotonic() < deadline and self.alive():
+            line = self.proc.stdout.readline().decode("utf-8", errors="replace")
+            if not line:
+                break
+            m = re.search(r"Tcp_Handler: listening on 127\.0\.0\.1:(\d+)", line)
+            if m:
+                self.port = int(m.group(1))
+                return self.port
+        return None
 
     @staticmethod
     def _build_cmd(isabelle, session, directory, ml_dir, port,
@@ -525,7 +540,7 @@ class PolyMLProcess:
         cmd += ["-f", os.path.join(ml_dir, "tcp_handler.ML"),
                 "-f", os.path.join(ml_dir, "ir.ML"),
                 "-f", os.path.join(ml_dir, "ml_repl.ML"),
-                "-e", f"case ML_Repl.start {port} of SOME f => Future.join f | NONE => ();"]
+                "-e", f"case ML_Repl.start {port} of SOME (_, f) => Future.join f | NONE => ();"]
         return cmd
 
     def alive(self):
@@ -1315,8 +1330,8 @@ def find_isabelle_installation(isabelle_arg):
 def main():
     p = argparse.ArgumentParser(description="I/R REPL TCP server")
     p.add_argument("--port", type=int, default=9147)
-    p.add_argument("--poly-ml-port", type=int, default=9146,
-                   help="Port for ML_Repl inside Poly/ML (default: 9146)")
+    p.add_argument("--poly-ml-port", type=int, default=0,
+                   help="Port for ML_Repl inside Poly/ML (default: 0 = OS picks a free port)")
     p.add_argument("--isabelle", default=None,
                    help="Path to Isabelle executable (auto-detected if not provided)")
     p.add_argument("--session", default="AutoCorrode")
@@ -1442,6 +1457,10 @@ def main():
         os.execvp(cmd[0], cmd)
 
     # Try connecting to an already-running ML_Repl
+    if args.poly_ml_port == 0 and args.expect_ml:
+        print(f"{RED}--expect-ml requires a specific --poly-ml-port{RST}",
+              file=sys.stderr)
+        sys.exit(1)
     conn = PolyMLConnection(port=args.poly_ml_port)
     poly = None  # PolyMLProcess, only if we need to start one
     bash_server = None
@@ -1500,6 +1519,16 @@ def main():
         poly = PolyMLProcess(args.isabelle, args.session, args.dir, ml_dir,
                              args.poly_ml_port, bash_server=bash_server)
 
+        # Learn the actual port (important when --poly-ml-port 0)
+        actual_port = poly.read_actual_port()
+        if actual_port is None:
+            if done: done.set(); t.join()
+            print(f"{RED}Poly/ML process exited or timed out before "
+                  f"reporting port{RST}", file=sys.stderr)
+            poly.close()
+            sys.exit(1)
+        conn = PolyMLConnection(port=actual_port)
+
         # Wait for ML_Repl TCP port to become available
         for attempt in range(300):  # up to 60s
             if not poly.alive():
@@ -1527,9 +1556,9 @@ def main():
             sys.exit(1)
 
         if done: done.set(); t.join()
-        _log(f"ML_Repl ready on 127.0.0.1:{args.poly_ml_port}" if quiet else
+        _log(f"ML_Repl ready on 127.0.0.1:{poly.port}" if quiet else
              f"{GREEN}● ML_Repl ready on "
-             f"127.0.0.1:{args.poly_ml_port}{RST}")
+             f"127.0.0.1:{poly.port}{RST}")
 
     def _signal_cleanup(signum, frame):
         if poly:

--- a/ir/tcp_handler.ML
+++ b/ir/tcp_handler.ML
@@ -17,7 +17,7 @@ signature TCP_HANDLER =
 sig
   val handler : (string -> BinIO.outstream -> unit) Synchronized.var
   val is_running : unit -> bool
-  val start : int -> (unit -> unit)
+  val start : int -> int * (unit -> unit)
   val stop : unit -> unit
 end;
 
@@ -98,15 +98,19 @@ fun accept_loop () =
       end;
 
 fun start port =
-  let val SOME me = NetHostDB.getByName "127.0.0.1"
+  let (* port = 0: OS picks any free ephemeral port;
+         port > 0: binds to that specific port.
+         In both cases, actual_port is read back via getSockName. *)
+      val SOME me = NetHostDB.getByName "127.0.0.1"
       val addr = INetSock.toAddr (NetHostDB.addr me, port)
       val ssock : Socket.passive INetSock.stream_sock = INetSock.TCP.socket ()
       val _ = Socket.Ctl.setREUSEADDR (ssock, true)
       val _ = Socket.bind (ssock, addr)
       val _ = Socket.listen (ssock, 1)
+      val (_, actual_port) = INetSock.fromAddr (Socket.Ctl.getSockName ssock)
       val _ = Synchronized.change server_socket (K (SOME ssock))
-      val _ = writeln ("Tcp_Handler: listening on 127.0.0.1:" ^ string_of_int port)
-  in accept_loop end;
+      val _ = writeln ("Tcp_Handler: listening on 127.0.0.1:" ^ string_of_int actual_port)
+  in (actual_port, accept_loop) end;
 
 fun stop () =
   Synchronized.change server_socket (fn old =>


### PR DESCRIPTION
ML_Repl now picks a free port when started with port 0 (the new default) and reports the actual port back to Scala via a PIDE protocol message. I/Q waits for this message before launching repl.py, eliminating all hardcoded port assumptions.

First step towards allowing multiple Isabelle/jEdit + I/Q + I/R sessions in parallel.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
