### PR TITLE
[fix] I/P: Fix connection failure during some remote builds

### DIFF
--- a/ip/ml_proxy.py
+++ b/ip/ml_proxy.py
@@ -426,8 +426,10 @@ def rewrite_bash_process_in_chunk(chunk, remote_bash_addr, remote_bash_pw):
             rb"bash_process_address([\x05\x06:]+)string([\x05\x06:]+)(127\.0\.0\.1:\d+)",
             chunk)
         if m:
-            chunk = chunk.replace(m.group(3), remote_bash_addr.encode(), 1)
-            logger.debug(f"Rewrote bash_process_address: {m.group(3).decode()} -> {remote_bash_addr}")
+            old_addr = m.group(3)
+            new_addr = remote_bash_addr.encode()
+            chunk = chunk.replace(old_addr, new_addr)
+            logger.debug(f"Rewrote bash_process_address: {old_addr.decode()} -> {remote_bash_addr}")
             modified = True
     if remote_bash_pw:
         m = re.search(
@@ -435,7 +437,7 @@ def rewrite_bash_process_in_chunk(chunk, remote_bash_addr, remote_bash_pw):
             rb"([0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})",
             chunk)
         if m:
-            chunk = chunk.replace(m.group(2), remote_bash_pw.encode(), 1)
+            chunk = chunk.replace(m.group(2), remote_bash_pw.encode())
             modified = True
     return chunk, modified
 

--- a/iq/Makefile
+++ b/iq/Makefile
@@ -64,6 +64,10 @@ test: build $(TEST_CLASSES_DIR)/.compiled
 	JAVA_HOME="$(JAVA_HOME)" PATH="$(JAVA_HOME)/bin:$$PATH" $(SCALA) \
 		-classpath "$(TEST_RUN_CLASSPATH)" \
 		IQSecurityTest
+	echo "Running I/Q normalization tests..."
+	$(ISABELLE) scala \
+		-classpath "$(CLASSES_DIR):$(TEST_CLASSES_DIR)" \
+		IQNormalizationTest
 	echo "Running I/Q server auth/authorization tests..."
 	JAVA_HOME="$(JAVA_HOME)" PATH="$(JAVA_HOME)/bin:$$PATH" $(SCALA) \
 		-classpath "$(TEST_RUN_CLASSPATH)" \

--- a/iq/README.md
+++ b/iq/README.md
@@ -190,7 +190,7 @@ Authentication with the I/R daemon is managed internally: I/Q reads the daemon's
 - **repl_list**: List all REPLs with step counts and origins
 - **repl_sledgehammer**: Run sledgehammer on the current proof goal
 - **repl_find_theorems**: Search for theorems
-- **repl_timeout**: Set step timeout
+- **repl_timeout**: Set step timeout for a specific REPL
 - **repl_raw**: Send a raw ML expression to the REPL
 
 ### Tool Classification

--- a/iq/src/IQNormalization.scala
+++ b/iq/src/IQNormalization.scala
@@ -1,0 +1,260 @@
+/* Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+   SPDX-License-Identifier: MIT */
+
+/**
+ * Standalone text normalization for Isabelle symbol matching with original-offset tracking.
+ *
+ * Normalizes text to a canonical Unicode form (Symbol.decode + NFC + whitespace compression)
+ * so that Isabelle escape sequences (\<Rightarrow>) match their Unicode equivalents (⇒).
+ * When normalization changes the text, an offset map tracks the correspondence between
+ * positions in the canonical string and positions in the original.
+ *
+ * Only depends on isabelle._ (Symbol, from isabelle.jar). No jEdit or PIDE dependency.
+ */
+
+import isabelle._
+
+object IQNormalization {
+
+  /** Result of normalizing text with offset tracking. */
+  final case class NormalizedText(
+    /** The canonical (normalized) string. */
+    canonical: String,
+    /**
+     * offsetMap(i) = position in the original text corresponding to canonical position i.
+     * Length = canonical.length + 1 (the sentinel at the end maps to original text length).
+     */
+    offsetMap: Array[Int]
+  )
+
+  sealed trait SubstringSearchError
+  case object SubstringNotFound extends SubstringSearchError
+  case object SubstringNotUnique extends SubstringSearchError
+  case object SubstringEmpty extends SubstringSearchError
+
+  // --- Normalization pipeline ---
+
+  /**
+   * Normalize text to canonical Unicode form (string only, no offset tracking).
+   * Pipeline: NFC → Symbol.decode → whitespace compression.
+   */
+  def normalize(text: String): String = {
+    if (text.isEmpty) return text
+    val afterNfc = java.text.Normalizer.normalize(text, java.text.Normalizer.Form.NFC)
+    val afterDecode = Symbol.decode(afterNfc)
+    compressWhitespace(afterDecode)
+  }
+
+  /**
+   * Normalize text with offset map tracking original positions.
+   * Pipeline: NFC → Symbol.decode → whitespace compression.
+   * offsetMap(i) = position in the original text for canonical position i.
+   */
+  def normalizeWithOffsets(text: String): NormalizedText = {
+    if (text.isEmpty) return NormalizedText("", Array(0))
+
+    // Step 1: NFC normalization with offset tracking
+    val (afterNfc, nfcOffsets) = nfcWithOffsets(text)
+
+    // Step 2: Symbol.decode with offset tracking
+    val (afterDecode, decodeOffsets) = symbolDecodeWithOffsets(afterNfc, nfcOffsets)
+
+    // Step 3: Whitespace compression with offset tracking
+    val (compressed, compressedOffsets) = compressWhitespaceWithOffsets(afterDecode, decodeOffsets)
+
+    NormalizedText(compressed, compressedOffsets)
+  }
+
+  /**
+   * Find a unique substring match after normalization, returning (startOffset, endOffset)
+   * in the original text. endOffset is exclusive (points one past the last matched char).
+   *
+   * Tier 1: direct indexOf (no normalization).
+   * Tier 2: full normalization pipeline with offset mapping.
+   */
+  def findUniqueMatch(text: String, substring: String): Either[SubstringSearchError, (Int, Int)] = {
+    if (substring.isEmpty) return Left(SubstringEmpty)
+
+    // Tier 1: direct match
+    val directFirst = text.indexOf(substring)
+    if (directFirst != -1) {
+      val directSecond = text.indexOf(substring, directFirst + 1)
+      if (directSecond == -1) return Right((directFirst, directFirst + substring.length))
+      else return Left(SubstringNotUnique)
+    }
+
+    // Tier 2: normalized match
+    val normalizedPattern = normalize(substring)
+    if (normalizedPattern.isEmpty) return Left(SubstringEmpty)
+
+    val normalizedText = normalize(text)
+    val normFirst = normalizedText.indexOf(normalizedPattern)
+    if (normFirst == -1) return Left(SubstringNotFound)
+
+    val normSecond = normalizedText.indexOf(normalizedPattern, normFirst + 1)
+    if (normSecond != -1) return Left(SubstringNotUnique)
+
+    // Map the match position back to the original text
+    if (normalizedText == text) {
+      // Text didn't change under normalization — offsets are identity
+      Right((normFirst, normFirst + normalizedPattern.length))
+    } else {
+      // Text changed — build the offset map
+      val normalized = normalizeWithOffsets(text)
+      val startOffset = normalized.offsetMap(normFirst)
+      val endIdx = normFirst + normalizedPattern.length
+      val endOffset =
+        if (endIdx < normalized.offsetMap.length) normalized.offsetMap(endIdx)
+        else text.length
+      Right((startOffset, endOffset))
+    }
+  }
+
+  // --- Internal pipeline steps ---
+
+  /**
+   * Apply NFC normalization with offset tracking.
+   * For each position in the NFC output, records the corresponding position in the original.
+   */
+  private[this] def nfcWithOffsets(text: String): (String, Array[Int]) = {
+    val nfc = java.text.Normalizer.normalize(text, java.text.Normalizer.Form.NFC)
+    if (nfc == text) {
+      // No change — identity mapping
+      val offsets = Array.tabulate(text.length + 1)(i => i)
+      (text, offsets)
+    } else {
+      // NFC changed the text. Build offset map character by character.
+      // This handles the (rare) case of combining characters being composed.
+      val offsets = new Array[Int](nfc.length + 1)
+      var origPos = 0
+      var nfcPos = 0
+      while (origPos < text.length && nfcPos < nfc.length) {
+        val origChar = text.charAt(origPos)
+        val origCharNfc = java.text.Normalizer.normalize(origChar.toString, java.text.Normalizer.Form.NFC)
+        for (j <- 0 until origCharNfc.length if nfcPos + j < nfc.length) {
+          offsets(nfcPos + j) = origPos
+        }
+        origPos += 1
+        nfcPos += origCharNfc.length
+      }
+      offsets(nfc.length) = text.length
+      (nfc, offsets)
+    }
+  }
+
+  /**
+   * Apply Symbol.decode with offset tracking.
+   * Walks the input using Symbol.Matcher, decodes each Isabelle symbol to Unicode,
+   * and maps each output character back through the base offset map.
+   */
+  private[this] def symbolDecodeWithOffsets(text: String, baseOffsets: Array[Int]): (String, Array[Int]) = {
+    val decoded = Symbol.decode(text)
+    if (decoded == text) {
+      // No change — pass through base offsets
+      (text, baseOffsets)
+    } else {
+      // Build offset map by iterating over Isabelle symbols
+      val result = new java.lang.StringBuilder(text.length)
+      val offsets = new java.util.ArrayList[Int](text.length + 1)
+      val matcher = new Symbol.Matcher(text)
+      var i = 0
+      while (i < text.length) {
+        val sym = matcher.match_symbol(i)
+        val symDecoded = Symbol.decode(sym)
+        val origPos = if (i < baseOffsets.length) baseOffsets(i) else baseOffsets(baseOffsets.length - 1)
+        var j = 0
+        while (j < symDecoded.length) {
+          result.append(symDecoded.charAt(j))
+          offsets.add(origPos)
+          j += 1
+        }
+        i += sym.length
+      }
+      // Sentinel: maps end of canonical to end of original
+      offsets.add(baseOffsets(baseOffsets.length - 1))
+
+      val offsetArray = new Array[Int](offsets.size)
+      var k = 0
+      while (k < offsets.size) { offsetArray(k) = offsets.get(k); k += 1 }
+      (result.toString, offsetArray)
+    }
+  }
+
+  /**
+   * Normalize whitespace: convert any whitespace character to a space,
+   * then compress consecutive spaces into a single space.
+   */
+  private[this] def compressWhitespace(text: String): String = {
+    val n = text.length
+    // Fast check: any non-space whitespace or consecutive whitespace?
+    var needsWork = false
+    var i = 0
+    while (i < n && !needsWork) {
+      val c = text.charAt(i)
+      if (c == '\t' || c == '\n' || c == '\r') needsWork = true
+      else if (c == ' ' && i + 1 < n && isWhitespace(text.charAt(i + 1))) needsWork = true
+      i += 1
+    }
+    if (!needsWork) return text
+
+    val sb = new java.lang.StringBuilder(n)
+    i = 0
+    while (i < n) {
+      val c = text.charAt(i)
+      if (isWhitespace(c)) {
+        sb.append(' ')
+        i += 1
+        while (i < n && isWhitespace(text.charAt(i))) i += 1
+      } else {
+        sb.append(c)
+        i += 1
+      }
+    }
+    sb.toString
+  }
+
+  /**
+   * Compress whitespace with offset tracking.
+   * Runs of whitespace characters collapse to a single space.
+   * The space maps to the original position of the first whitespace character in the run.
+   */
+  private[this] def compressWhitespaceWithOffsets(text: String, baseOffsets: Array[Int]): (String, Array[Int]) = {
+    val n = text.length
+    // Fast check: any non-space whitespace or consecutive whitespace?
+    var needsWork = false
+    var i = 0
+    while (i < n && !needsWork) {
+      val c = text.charAt(i)
+      if (c == '\t' || c == '\n' || c == '\r') needsWork = true
+      else if (c == ' ' && i + 1 < n && isWhitespace(text.charAt(i + 1))) needsWork = true
+      i += 1
+    }
+    if (!needsWork) return (text, baseOffsets)
+
+    val sb = new java.lang.StringBuilder(n)
+    val offsets = new java.util.ArrayList[Int](n + 1)
+    i = 0
+    while (i < n) {
+      val c = text.charAt(i)
+      if (isWhitespace(c)) {
+        sb.append(' ')
+        offsets.add(baseOffsets(i))
+        i += 1
+        while (i < n && isWhitespace(text.charAt(i))) i += 1
+      } else {
+        sb.append(c)
+        offsets.add(baseOffsets(i))
+        i += 1
+      }
+    }
+    offsets.add(baseOffsets(baseOffsets.length - 1))
+
+    val offsetArray = new Array[Int](offsets.size)
+    var k = 0
+    while (k < offsets.size) { offsetArray(k) = offsets.get(k); k += 1 }
+    (sb.toString, offsetArray)
+  }
+
+  private[this] def isWhitespace(c: Char): Boolean =
+    c == ' ' || c == '\t' || c == '\n' || c == '\r'
+}

--- a/iq/src/IQServer.scala
+++ b/iq/src/IQServer.scala
@@ -1211,7 +1211,7 @@ class IQServer(
         }
       }
 
-      val params = IQToolParams.fromMap(extractArguments(toolCall.arguments))
+      val params = IQToolParams.fromMap(decodeIsabelleTextParams(extractArguments(toolCall.arguments)))
       safeOutput(
         s"I/Q Server: Extracted tool='${toolCall.toolName.wire}', params=${params.toMap}"
       )
@@ -1251,6 +1251,21 @@ class IQServer(
   def extractArguments(jsonMap: Map[String, JSON.T]): Map[String, Any] = {
     IQArgumentUtils.extractArguments(jsonMap)
   }
+
+  /** Parameters that contain Isabelle text and should be Symbol.decode'd on input. */
+  private val isabelleTextParamNames: Set[String] =
+    Set("old_str", "new_str", "pattern", "content")
+
+  /**
+   * Decode Isabelle escape sequences in text parameters.
+   * Converts \<Rightarrow> → ⇒ etc. so that MCP callers can use either representation.
+   * Only applies to parameters known to contain Isabelle text (old_str, new_str, pattern, content).
+   */
+  private def decodeIsabelleTextParams(params: Map[String, Any]): Map[String, Any] =
+    params.map {
+      case (k, v: String) if isabelleTextParamNames.contains(k) => k -> Symbol.decode(v)
+      case other => other
+    }
 
   /**
    * Formats a successful JSON-RPC response.
@@ -3400,8 +3415,8 @@ class IQServer(
           case _ => return Left("new_str parameter is required for command 'str_replace'")
         }
 
-        val startOffset = IQUtils.findUniqueSubstringOffset(content, old_str) match {
-          case Right(offset) => offset
+        val (startOffset, endOffset) = IQUtils.findUniqueSubstringMatch(content, old_str) match {
+          case Right(offsets) => offsets
           case Left(IQUtils.SubstringNotFound) =>
             return Left(s"Substring not found: '$old_str'")
           case Left(IQUtils.SubstringNotUnique) =>
@@ -3409,8 +3424,6 @@ class IQServer(
           case Left(IQUtils.SubstringEmpty) =>
             return Left("old_str parameter cannot be empty")
         }
-
-        val endOffset = startOffset + old_str.length
 
         (startOffset, endOffset, new_str)
 
@@ -3682,11 +3695,11 @@ end"""
     val totalLines = lines.length
     val safeContextLines = math.max(0, contextLines)
 
-    val normalizedPattern = pattern.toLowerCase(Locale.ROOT)
+    val normalizedPattern = IQNormalization.normalize(pattern).toLowerCase(Locale.ROOT)
 
-    // Find matching lines
+    // Find matching lines (normalize each line for Isabelle symbol + whitespace tolerance)
     val matchingLineIndices = lines.zipWithIndex.collect {
-      case (line, idx) if line.toLowerCase(Locale.ROOT).contains(normalizedPattern) => idx
+      case (line, idx) if IQNormalization.normalize(line).toLowerCase(Locale.ROOT).contains(normalizedPattern) => idx
     }
 
     // Create an array of match objects with context

--- a/iq/src/IQServer.scala
+++ b/iq/src/IQServer.scala
@@ -804,9 +804,11 @@ class IQServer(
       for { repl <- strParam(p, "repl"); q <- strParam(p, "query"); r <- withIR(_.findTheorems(repl, p.get("max_results").collect { case n: Long => n.toInt }.getOrElse(40), q)) }
       yield IQToolResult.fromMap(r)
     }),
-    IQToolName.ReplTimeout -> (params =>
-      intParam(params.toMap, "secs").flatMap(s => withIR(_.timeout(s))).map(IQToolResult.fromMap)
-    ),
+    IQToolName.ReplTimeout -> (params => {
+      val p = params.toMap
+      for { repl <- strParam(p, "repl"); s <- intParam(p, "secs"); r <- withIR(_.timeout(repl, s)) }
+      yield IQToolResult.fromMap(r)
+    }),
     IQToolName.ReplRaw -> (params =>
       strParam(params.toMap, "ml_code").flatMap(c => withIR(_.send(c))).map(IQToolResult.fromMap)
     )
@@ -2057,11 +2059,11 @@ class IQServer(
           "max_results" -> int("Maximum results (default 40)")),
           List("repl", "query"))),
       Map("name" -> "repl_timeout",
-        "description" -> (replPrefix + "Set step timeout in seconds (0=unlimited, default 10s). NOTE: DO NOT set this to values >10s unless you have " +
+        "description" -> (replPrefix + "Set step timeout in seconds for a specific REPL (0=unlimited, default 10s). NOTE: DO NOT set this to values >10s unless you have " +
           "a specific reason to. Calls like `metis`, `auto`, `blast`, `force`, should NOT take longer than 5s. Even if they do, and the call " +
           "ultimately succeeds, it points at a proof that ought to be broken down further. ONLY use a large timeout if you work with very large " +
           "scripts or in special circumstances where, exceptionally, a large timeout is expected / tolerated."),
-        "inputSchema" -> schema(Map("secs" -> int("Timeout in seconds")), List("secs"))),
+        "inputSchema" -> schema(Map(replParam, "secs" -> int("Timeout in seconds")), List("repl", "secs"))),
       Map("name" -> "repl_raw",
         "description" -> (replPrefix + "Send a raw ML expression to the REPL."),
         "inputSchema" -> schema(Map("ml_code" -> str("ML expression")), List("ml_code")))

--- a/iq/src/IQUtils.scala
+++ b/iq/src/IQUtils.scala
@@ -195,69 +195,65 @@ object IQUtils {
       }
     }
 
-    // If direct matching failed or found multiple matches, try Unicode normalization
-    import java.text.Normalizer
-    val normalizedText = Normalizer.normalize(searchText, Normalizer.Form.NFC)
-    val normalizedSubstring = Normalizer.normalize(searchSubstring, Normalizer.Form.NFC)
-
-    val firstIndex = normalizedText.indexOf(normalizedSubstring)
-    if (firstIndex == -1) {
-      Output.writeln(s"I/Q Server: Substring not found in text")
-      Output.writeln(s"I/Q Server: Original text length: ${text.length}")
-      Output.writeln(s"I/Q Server: Original substring length: ${substring.length}")
-      Output.writeln(s"I/Q Server: Search text length: ${searchText.length}")
-      Output.writeln(s"I/Q Server: Search substring length: ${searchSubstring.length}")
-      if (offsetAdjustment > 0) {
-        Output.writeln(s"I/Q Server: Applied leading space relaxation: trimmed $offsetAdjustment spaces")
-      }
-      return Left(SubstringNotFound)
+    // If direct matching failed, try full normalization (NFC + Symbol.decode + whitespace compression)
+    IQNormalization.findUniqueMatch(searchText, searchSubstring) match {
+      case Right((startOffset, _)) =>
+        Right(startOffset + offsetAdjustment)
+      case Left(IQNormalization.SubstringNotFound) =>
+        Output.writeln(s"I/Q Server: Substring not found in text (after normalization)")
+        Output.writeln(s"I/Q Server: Original text length: ${text.length}")
+        Output.writeln(s"I/Q Server: Original substring length: ${substring.length}")
+        if (offsetAdjustment > 0) {
+          Output.writeln(s"I/Q Server: Applied leading space relaxation: trimmed $offsetAdjustment spaces")
+        }
+        Left(SubstringNotFound)
+      case Left(IQNormalization.SubstringNotUnique) =>
+        Output.writeln(s"I/Q Server: Substring found multiple times after normalization")
+        Left(SubstringNotUnique)
+      case Left(IQNormalization.SubstringEmpty) =>
+        Left(SubstringEmpty)
     }
-
-    val secondIndex = normalizedText.indexOf(normalizedSubstring, firstIndex + 1)
-    if (secondIndex != -1) {
-      Output.writeln(s"I/Q Server: Substring found multiple times at normalized positions $firstIndex and $secondIndex")
-      return Left(SubstringNotUnique)
-    }
-
-    // Convert the normalized offset back to search text offset, then add space adjustment
-    val searchTextOffset = mapNormalizedOffsetToOriginal(searchText, normalizedText, firstIndex)
-    Right(searchTextOffset + offsetAdjustment)
   }
 
   /**
-   * Maps an offset in a normalized string back to the corresponding offset in the original string.
-   * This handles cases where Unicode normalization changes character positions.
+   * Finds a unique substring match, returning both start and end offsets in the original text.
+   * The end offset is exclusive. Same relaxation and normalization as findUniqueSubstringOffset.
    */
-  private def mapNormalizedOffsetToOriginal(originalText: String, normalizedText: String, normalizedOffset: Int): Int = {
-    import java.text.Normalizer
+  def findUniqueSubstringMatch(text: String, substring: String): Either[SubstringSearchError, (Int, Int)] = {
+    if (substring.isEmpty) return Left(SubstringEmpty)
 
-    // If no normalization occurred, offsets are the same
-    if (originalText == normalizedText) return normalizedOffset
+    val textLeadingSpaces = countLeadingSpaces(text)
+    val substringLeadingSpaces = countLeadingSpaces(substring)
 
-    // Build a mapping by processing character by character
-    var originalPos = 0
-    var normalizedPos = 0
+    val (searchText, searchSubstring, offsetAdjustment) =
+      if (textLeadingSpaces > 0 && textLeadingSpaces == substringLeadingSpaces) {
+        val trimmedText = text.substring(textLeadingSpaces)
+        val trimmedSubstring = substring.substring(substringLeadingSpaces)
+        (trimmedText, trimmedSubstring, textLeadingSpaces)
+      } else {
+        (text, substring, 0)
+      }
 
-    while (normalizedPos < normalizedOffset && originalPos < originalText.length) {
-      // Get the next character from original text
-      val originalChar = originalText.charAt(originalPos)
-
-      // Normalize just this character to see how many normalized characters it produces
-      val normalizedChar = Normalizer.normalize(originalChar.toString, Normalizer.Form.NFC)
-
-      // Advance positions
-      originalPos += 1
-      normalizedPos += normalizedChar.length
-
-      // If we've gone past the target offset, we need to back up
-      if (normalizedPos > normalizedOffset) {
-        // The target offset falls within this character's normalization
-        // Return the position of the start of this character in the original text
-        return originalPos - 1
+    // Tier 1: direct match
+    val directFirstIndex = searchText.indexOf(searchSubstring)
+    if (directFirstIndex != -1) {
+      val directSecondIndex = searchText.indexOf(searchSubstring, directFirstIndex + 1)
+      if (directSecondIndex == -1) {
+        val start = directFirstIndex + offsetAdjustment
+        return Right((start, start + searchSubstring.length))
+      } else {
+        return Left(SubstringNotUnique)
       }
     }
 
-    originalPos
+    // Tier 2: normalized match
+    IQNormalization.findUniqueMatch(searchText, searchSubstring) match {
+      case Right((startOffset, endOffset)) =>
+        Right((startOffset + offsetAdjustment, endOffset + offsetAdjustment))
+      case Left(IQNormalization.SubstringNotFound) => Left(SubstringNotFound)
+      case Left(IQNormalization.SubstringNotUnique) => Left(SubstringNotUnique)
+      case Left(IQNormalization.SubstringEmpty) => Left(SubstringEmpty)
+    }
   }
 
   /**

--- a/iq/src/IRClient.scala
+++ b/iq/src/IRClient.scala
@@ -166,8 +166,8 @@ class IRClient(host: String = "127.0.0.1", port: Int = 9147, token: String = "")
   def sledgehammer(repl: String, secs: Int): String =
     send(s"Ir.sledgehammer ${q(repl)} ${mlInt(secs)}")
 
-  /** Set step timeout (0=unlimited). */
-  def timeout(secs: Int): String = send(s"Ir.timeout ${mlInt(secs)}")
+  /** Set step timeout for a specific REPL (0=unlimited). */
+  def timeout(repl: String, secs: Int): String = send(s"Ir.timeout ${q(repl)} ${mlInt(secs)}")
 
   /** Search theorems (n=max results, 0=unlimited). */
   def findTheorems(repl: String, n: Int, query: String): String =
@@ -223,7 +223,7 @@ class IRClient(host: String = "127.0.0.1", port: Int = 9147, token: String = "")
       |Proof tools:
       |  sledgehammer("r", 30)              Run sledgehammer (timeout in secs)
       |  findTheorems("r", 10, "name: *")   Search theorems
-      |  timeout(10)                        Set step timeout (0 = unlimited)
+      |  timeout("r", 10)                   Set step timeout for REPL (0 = unlimited)
       |
       |Config:
       |  config("(fn c => ...)")            Update ML config record

--- a/iq/src/test/scala/IQNormalizationTest.scala
+++ b/iq/src/test/scala/IQNormalizationTest.scala
@@ -1,0 +1,817 @@
+/* Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+   SPDX-License-Identifier: MIT */
+
+/**
+ * Standalone tests for IQNormalization.
+ * No jEdit or PIDE dependency — only requires isabelle.jar on the classpath.
+ */
+object IQNormalizationTest {
+  private var passed = 0
+  private var failed = 0
+
+  private def assert(condition: Boolean, message: String): Unit = {
+    if (!condition) {
+      failed += 1
+      System.err.println(s"  FAIL: $message")
+    } else {
+      passed += 1
+    }
+  }
+
+  private def assertEquals[A](actual: A, expected: A, label: String): Unit = {
+    if (actual != expected) {
+      failed += 1
+      System.err.println(s"  FAIL: $label")
+      System.err.println(s"    expected: $expected")
+      System.err.println(s"    actual:   $actual")
+    } else {
+      passed += 1
+    }
+  }
+
+  private def assertRight[L, R](result: Either[L, R], label: String): R = {
+    result match {
+      case Right(v) =>
+        passed += 1
+        v
+      case Left(err) =>
+        failed += 1
+        System.err.println(s"  FAIL: $label — expected Right, got Left($err)")
+        throw new RuntimeException(s"assertRight failed: $label")
+    }
+  }
+
+  private def assertLeft[L, R](result: Either[L, R], expectedLeft: L, label: String): Unit = {
+    result match {
+      case Left(v) =>
+        if (v == expectedLeft) passed += 1
+        else {
+          failed += 1
+          System.err.println(s"  FAIL: $label — expected Left($expectedLeft), got Left($v)")
+        }
+      case Right(v) =>
+        failed += 1
+        System.err.println(s"  FAIL: $label — expected Left($expectedLeft), got Right($v)")
+    }
+  }
+
+  // ---- Test groups ----
+
+  private def testNormalize(): Unit = {
+    println("  normalize() — canonical form correctness")
+
+    // Identity: already-Unicode text
+    assertEquals(
+      IQNormalization.normalize("foo \u21d2 bar"),
+      "foo \u21d2 bar",
+      "identity: Unicode text unchanged")
+
+    // Isabelle decode
+    assertEquals(
+      IQNormalization.normalize("foo \\<Rightarrow> bar"),
+      "foo \u21d2 bar",
+      "decode: \\<Rightarrow> to \u21d2")
+
+    // Multiple symbols
+    assertEquals(
+      IQNormalization.normalize("\\<forall>x. x \\<Rightarrow> x"),
+      "\u2200x. x \u21d2 x",
+      "decode: multiple symbols")
+
+    // Cartouches
+    assertEquals(
+      IQNormalization.normalize("\\<open>hello\\<close>"),
+      "\u2039hello\u203a",
+      "decode: cartouches \\<open>/\\<close>")
+
+    // Whitespace compression
+    assertEquals(
+      IQNormalization.normalize("A   B"),
+      "A B",
+      "whitespace: multiple spaces compressed")
+
+    assertEquals(
+      IQNormalization.normalize("A \t\n B"),
+      "A B",
+      "whitespace: mixed whitespace compressed")
+
+    // Combined: symbol + whitespace
+    assertEquals(
+      IQNormalization.normalize("A  \\<Rightarrow>  B"),
+      "A \u21d2 B",
+      "combined: symbol decode + whitespace compression")
+
+    // No symbols: pure ASCII
+    assertEquals(
+      IQNormalization.normalize("hello world"),
+      "hello world",
+      "identity: pure ASCII unchanged")
+
+    // Empty string
+    assertEquals(
+      IQNormalization.normalize(""),
+      "",
+      "identity: empty string")
+
+    // Single whitespace
+    assertEquals(
+      IQNormalization.normalize(" "),
+      " ",
+      "identity: single space unchanged")
+
+    // Logic symbols
+    assertEquals(
+      IQNormalization.normalize("\\<and>"),
+      "\u2227",
+      "decode: \\<and> to \u2227")
+
+    assertEquals(
+      IQNormalization.normalize("\\<or>"),
+      "\u2228",
+      "decode: \\<or> to \u2228")
+
+    assertEquals(
+      IQNormalization.normalize("\\<forall>"),
+      "\u2200",
+      "decode: \\<forall> to \u2200")
+
+    assertEquals(
+      IQNormalization.normalize("\\<exists>"),
+      "\u2203",
+      "decode: \\<exists> to \u2203")
+
+    // Arrow symbols
+    assertEquals(
+      IQNormalization.normalize("\\<rightarrow>"),
+      "\u2192",
+      "decode: \\<rightarrow> to \u2192")
+
+    assertEquals(
+      IQNormalization.normalize("\\<Longrightarrow>"),
+      "\u27f9",
+      "decode: \\<Longrightarrow> to \u27f9")
+
+    // Text with no Isabelle symbols but with backslashes
+    assertEquals(
+      IQNormalization.normalize("a \\ b"),
+      "a \\ b",
+      "identity: backslash that is not an Isabelle symbol")
+
+    // Trailing/leading whitespace compression
+    assertEquals(
+      IQNormalization.normalize("  hello  "),
+      " hello ",
+      "whitespace: leading/trailing compressed to single spaces")
+  }
+
+  private def testNormalizeWithOffsets(): Unit = {
+    println("  normalizeWithOffsets() — offset map correctness")
+
+    // Identity: no change
+    locally {
+      val result = IQNormalization.normalizeWithOffsets("abc")
+      assertEquals(result.canonical, "abc", "offsets identity: canonical unchanged")
+      assertEquals(result.offsetMap.toList, List(0, 1, 2, 3), "offsets identity: identity map")
+    }
+
+    // Single Isabelle symbol: \<Rightarrow> (14 chars) → ⇒ (1 char)
+    locally {
+      val input = "\\<Rightarrow>"
+      val result = IQNormalization.normalizeWithOffsets(input)
+      assertEquals(result.canonical, "\u21d2", "offsets single symbol: canonical")
+      assertEquals(result.offsetMap.length, 2, "offsets single symbol: map length (1 char + sentinel)")
+      assertEquals(result.offsetMap(0), 0, "offsets single symbol: char maps to 0")
+      assertEquals(result.offsetMap(1), input.length, "offsets single symbol: sentinel maps to end")
+    }
+
+    // Symbol in context: "ab\<Rightarrow>cd" → "ab⇒cd"
+    // \<Rightarrow> is 13 chars, so: a=0, b=1, \<Rightarrow>=2..14, c=15, d=16, length=17
+    locally {
+      val input = "ab\\<Rightarrow>cd"
+      val result = IQNormalization.normalizeWithOffsets(input)
+      assertEquals(result.canonical, "ab\u21d2cd", "offsets in context: canonical")
+      assertEquals(result.offsetMap(0), 0, "offsets in context: 'a' at 0")
+      assertEquals(result.offsetMap(1), 1, "offsets in context: 'b' at 1")
+      assertEquals(result.offsetMap(2), 2, "offsets in context: '⇒' maps to original 2")
+      assertEquals(result.offsetMap(3), 15, "offsets in context: 'c' maps to original 15")
+      assertEquals(result.offsetMap(4), 16, "offsets in context: 'd' maps to original 16")
+      assertEquals(result.offsetMap(5), 17, "offsets in context: sentinel maps to end")
+    }
+
+    // Whitespace compression: "a  b" → "a b"
+    locally {
+      val result = IQNormalization.normalizeWithOffsets("a  b")
+      assertEquals(result.canonical, "a b", "offsets ws: canonical")
+      assertEquals(result.offsetMap(0), 0, "offsets ws: 'a' at 0")
+      assertEquals(result.offsetMap(1), 1, "offsets ws: space maps to first ws at 1")
+      assertEquals(result.offsetMap(2), 3, "offsets ws: 'b' at 3")
+      assertEquals(result.offsetMap(3), 4, "offsets ws: sentinel")
+    }
+
+    // Combined: "a  \<Rightarrow>  b" → "a ⇒ b"
+    // a=0, sp=1, sp=2, \<Rightarrow>=3..15 (13 chars), sp=16, sp=17, b=18, length=19
+    locally {
+      val input = "a  \\<Rightarrow>  b"
+      val result = IQNormalization.normalizeWithOffsets(input)
+      assertEquals(result.canonical, "a \u21d2 b", "offsets combined: canonical")
+      assertEquals(result.offsetMap(0), 0, "offsets combined: 'a' at 0")
+      assertEquals(result.offsetMap(1), 1, "offsets combined: first compressed space at 1")
+      assertEquals(result.offsetMap(2), 3, "offsets combined: '⇒' maps to original 3")
+      assertEquals(result.offsetMap(3), 16, "offsets combined: second compressed space at 16")
+      assertEquals(result.offsetMap(4), 18, "offsets combined: 'b' at 18")
+      assertEquals(result.offsetMap(5), 19, "offsets combined: sentinel")
+    }
+
+    // Empty string
+    locally {
+      val result = IQNormalization.normalizeWithOffsets("")
+      assertEquals(result.canonical, "", "offsets empty: canonical empty")
+      assertEquals(result.offsetMap.toList, List(0), "offsets empty: just sentinel")
+    }
+
+    // Multiple consecutive symbols
+    // \<forall> is 9 chars, \<exists> is 9 chars
+    locally {
+      val input = "\\<forall>\\<exists>"
+      val result = IQNormalization.normalizeWithOffsets(input)
+      assertEquals(result.canonical, "\u2200\u2203", "offsets multi-symbol: canonical")
+      assertEquals(result.offsetMap(0), 0, "offsets multi-symbol: ∀ maps to 0")
+      assertEquals(result.offsetMap(1), 9, "offsets multi-symbol: ∃ maps to 9")
+      assertEquals(result.offsetMap(2), input.length, "offsets multi-symbol: sentinel")
+    }
+  }
+
+  private def testFindUniqueMatch(): Unit = {
+    println("  findUniqueMatch() — matching with offset tracking")
+
+    // Exact match, no normalization needed
+    locally {
+      val (start, end) = assertRight(
+        IQNormalization.findUniqueMatch("foo bar", "bar"),
+        "exact match")
+      assertEquals(start, 4, "exact match: start")
+      assertEquals(end, 7, "exact match: end")
+    }
+
+    // Pattern has Isabelle escapes, text is Unicode
+    // text "foo ⇒ bar": ⇒ is at position 4, length 1
+    locally {
+      val (start, end) = assertRight(
+        IQNormalization.findUniqueMatch("foo \u21d2 bar", "\\<Rightarrow>"),
+        "pattern Isabelle, text Unicode")
+      assertEquals(start, 4, "pattern Isabelle, text Unicode: start")
+      assertEquals(end, 5, "pattern Isabelle, text Unicode: end")
+    }
+
+    // Text has Isabelle escapes, pattern is Unicode
+    // text "foo \<Rightarrow> bar": \<Rightarrow> starts at 4, next char (space) at 17
+    locally {
+      val (start, end) = assertRight(
+        IQNormalization.findUniqueMatch("foo \\<Rightarrow> bar", "\u21d2"),
+        "text Isabelle, pattern Unicode")
+      assertEquals(start, 4, "text Isabelle, pattern Unicode: start")
+      assertEquals(end, 17, "text Isabelle, pattern Unicode: end")
+    }
+
+    // Both have Isabelle escapes (direct match — Tier 1)
+    // \<Rightarrow> is 13 chars
+    locally {
+      val (start, end) = assertRight(
+        IQNormalization.findUniqueMatch("\\<Rightarrow>", "\\<Rightarrow>"),
+        "both Isabelle")
+      assertEquals(start, 0, "both Isabelle: start")
+      assertEquals(end, 13, "both Isabelle: end")
+    }
+
+    // Both Unicode (direct match — Tier 1)
+    locally {
+      val (start, end) = assertRight(
+        IQNormalization.findUniqueMatch("\u21d2", "\u21d2"),
+        "both Unicode")
+      assertEquals(start, 0, "both Unicode: start")
+      assertEquals(end, 1, "both Unicode: end")
+    }
+
+    // Whitespace mismatch
+    locally {
+      val (start, end) = assertRight(
+        IQNormalization.findUniqueMatch("A   B", "A B"),
+        "whitespace mismatch")
+      assertEquals(start, 0, "whitespace mismatch: start")
+      assertEquals(end, 5, "whitespace mismatch: end")
+    }
+
+    // Combined: text has Isabelle + extra whitespace, pattern has Unicode + single space
+    // "P  \<Rightarrow>  Q" = P(0) sp(1) sp(2) \<Rightarrow>(3..15) sp(16) sp(17) Q(18) len=19
+    locally {
+      val (start, end) = assertRight(
+        IQNormalization.findUniqueMatch("P  \\<Rightarrow>  Q", "P \u21d2 Q"),
+        "combined: Isabelle+ws text, Unicode+single-space pattern")
+      assertEquals(start, 0, "combined: start")
+      assertEquals(end, 19, "combined: end")
+    }
+
+    // Not found
+    assertLeft(
+      IQNormalization.findUniqueMatch("foo bar", "baz"),
+      IQNormalization.SubstringNotFound,
+      "not found")
+
+    // Not unique (direct match)
+    assertLeft(
+      IQNormalization.findUniqueMatch("foo bar foo", "foo"),
+      IQNormalization.SubstringNotUnique,
+      "not unique (direct)")
+
+    // Not unique (normalized match)
+    assertLeft(
+      IQNormalization.findUniqueMatch("A \\<Rightarrow> B \\<Rightarrow> C", "\u21d2"),
+      IQNormalization.SubstringNotUnique,
+      "not unique (normalized)")
+
+    // Empty substring
+    assertLeft(
+      IQNormalization.findUniqueMatch("foo", ""),
+      IQNormalization.SubstringEmpty,
+      "empty substring")
+
+    // Mixed encoding in pattern
+    // text "∀x. x ⇒ x" is 9 chars, pattern decodes to same → full match
+    locally {
+      val (start, end) = assertRight(
+        IQNormalization.findUniqueMatch(
+          "\u2200x. x \u21d2 x",
+          "\\<forall>x. x \\<Rightarrow> x"),
+        "mixed encoding pattern")
+      assertEquals(start, 0, "mixed encoding: start")
+      assertEquals(end, 9, "mixed encoding: end")
+    }
+
+    // Match at end of text
+    // "hello \<Rightarrow>" = h(0)e(1)l(2)l(3)o(4)sp(5)\<Rightarrow>(6..18) len=19
+    locally {
+      val (start, end) = assertRight(
+        IQNormalization.findUniqueMatch("hello \\<Rightarrow>", "\u21d2"),
+        "match at end")
+      assertEquals(start, 6, "match at end: start")
+      assertEquals(end, 19, "match at end: end")
+    }
+
+    // Match at start of text
+    // "\<Rightarrow> hello" = \<Rightarrow>(0..12) sp(13) h(14)... len=19
+    locally {
+      val (start, end) = assertRight(
+        IQNormalization.findUniqueMatch("\\<Rightarrow> hello", "\u21d2"),
+        "match at start")
+      assertEquals(start, 0, "match at start: start")
+      assertEquals(end, 13, "match at start: end")
+    }
+
+    // Multi-symbol pattern
+    // "x \<and> y \<Rightarrow> z": x(0)sp(1)\<and>(2..7)sp(8)y(9)sp(10)\<Rightarrow>(11..23)sp(24)z(25)
+    // decoded: "x ∧ y ⇒ z" (9 chars), pattern "∧ y ⇒" matches at pos 2, len 5, endIdx=7
+    // offsetMap(7) = 24
+    locally {
+      val (start, end) = assertRight(
+        IQNormalization.findUniqueMatch(
+          "x \\<and> y \\<Rightarrow> z",
+          "\u2227 y \u21d2"),
+        "multi-symbol pattern")
+      assertEquals(start, 2, "multi-symbol pattern: start")
+      assertEquals(end, 24, "multi-symbol pattern: end")
+    }
+
+    // Pattern with only whitespace difference
+    locally {
+      val (start, end) = assertRight(
+        IQNormalization.findUniqueMatch("a\t\n b", "a b"),
+        "tab+newline compressed")
+      assertEquals(start, 0, "tab+newline: start")
+      assertEquals(end, 5, "tab+newline: end")
+    }
+  }
+
+  private def testEdgeCases(): Unit = {
+    println("  Edge cases and regression tests")
+
+    // Literal backslash that is NOT an Isabelle symbol
+    locally {
+      val text = "path\\to\\file"
+      assertEquals(
+        IQNormalization.normalize(text),
+        text,
+        "literal backslash: not an Isabelle symbol, unchanged")
+    }
+
+    // Malformed symbols: \<> and \<^>
+    locally {
+      val text1 = "hello \\<> world"
+      // Should not crash — malformed symbols pass through
+      val norm1 = IQNormalization.normalize(text1)
+      assert(norm1.nonEmpty, "malformed \\<>: did not crash")
+
+      val text2 = "hello \\<^> world"
+      val norm2 = IQNormalization.normalize(text2)
+      assert(norm2.nonEmpty, "malformed \\<^>: did not crash")
+    }
+
+    // Single character text
+    assertEquals(
+      IQNormalization.normalize("x"),
+      "x",
+      "single char: unchanged")
+
+    // Text that is all whitespace
+    assertEquals(
+      IQNormalization.normalize("   "),
+      " ",
+      "all whitespace: compressed to single space")
+
+    // Newlines as whitespace
+    assertEquals(
+      IQNormalization.normalize("a\n\n\nb"),
+      "a b",
+      "multiple newlines: compressed")
+
+    // Carriage returns
+    assertEquals(
+      IQNormalization.normalize("a\r\n\r\nb"),
+      "a b",
+      "CRLF: compressed")
+
+    // No whitespace compression for single whitespace chars
+    assertEquals(
+      IQNormalization.normalize("a b"),
+      "a b",
+      "single space: unchanged")
+
+    assertEquals(
+      IQNormalization.normalize("a\tb"),
+      "a b",
+      "single tab: normalized to space")
+
+    assertEquals(
+      IQNormalization.normalize("a\nb"),
+      "a b",
+      "single newline: normalized to space")
+
+    // Symbol followed immediately by another symbol (no space)
+    locally {
+      val input = "\\<forall>\\<forall>"
+      val norm = IQNormalization.normalize(input)
+      assertEquals(norm, "\u2200\u2200", "adjacent symbols: both decoded")
+    }
+
+    // findUniqueMatch with text that has no match even after normalization
+    assertLeft(
+      IQNormalization.findUniqueMatch("\\<Rightarrow>", "\\<Longrightarrow>"),
+      IQNormalization.SubstringNotFound,
+      "different symbols: not found")
+
+    // findUniqueMatch where direct match exists but is not unique,
+    // while normalized form is also not unique
+    assertLeft(
+      IQNormalization.findUniqueMatch("x x", "x"),
+      IQNormalization.SubstringNotUnique,
+      "non-unique single char")
+
+    // Performance sanity: normalize a moderately large string
+    locally {
+      val largeText = "hello \\<Rightarrow> world " * 1000
+      val t0 = System.nanoTime()
+      val _ = IQNormalization.normalize(largeText)
+      val elapsed = (System.nanoTime() - t0) / 1000000
+      assert(elapsed < 5000, s"performance: normalize 20KB in <5s (took ${elapsed}ms)")
+    }
+
+    // Performance: normalizeWithOffsets on moderately large string
+    locally {
+      val largeText = "hello \\<Rightarrow> world " * 1000
+      val t0 = System.nanoTime()
+      val _ = IQNormalization.normalizeWithOffsets(largeText)
+      val elapsed = (System.nanoTime() - t0) / 1000000
+      assert(elapsed < 5000, s"performance: normalizeWithOffsets 20KB in <5s (took ${elapsed}ms)")
+    }
+  }
+
+  /**
+   * Systematic tests of findUniqueMatch covering:
+   *   encoding: {Isabelle sequences, Unicode, mixed}
+   *   whitespace: {exact, extra spaces, tabs, mixed ws}
+   *   match result: {no match, unique via Tier 1, unique via Tier 2, multiple}
+   *
+   * Every (startOffset, endOffset) is hardcoded against the ORIGINAL text.
+   */
+  private def testEncodingWhitespaceMatrix(): Unit = {
+    println("  findUniqueMatch() — encoding × whitespace × match-result matrix")
+
+    // ================================================================
+    // 1. ENCODING VARIATIONS — unique match, exact whitespace
+    // ================================================================
+
+    // 1a. Text=Isabelle, Pattern=Unicode (Tier 2)
+    // text: "A \<Rightarrow> B" = A(0) sp(1) \<Rightarrow>(2..14) sp(15) B(16) = 17 chars
+    locally {
+      val (s, e) = assertRight(
+        IQNormalization.findUniqueMatch("A \\<Rightarrow> B", "A \u21d2 B"),
+        "1a: text=Isabelle pattern=Unicode")
+      assertEquals(s, 0, "1a: start")
+      assertEquals(e, 17, "1a: end")
+    }
+
+    // 1b. Text=Unicode, Pattern=Isabelle (Tier 2)
+    // text: "A ⇒ B" = 5 chars
+    locally {
+      val (s, e) = assertRight(
+        IQNormalization.findUniqueMatch("A \u21d2 B", "A \\<Rightarrow> B"),
+        "1b: text=Unicode pattern=Isabelle")
+      assertEquals(s, 0, "1b: start")
+      assertEquals(e, 5, "1b: end")
+    }
+
+    // 1c. Both Isabelle (Tier 1 — direct match)
+    locally {
+      val (s, e) = assertRight(
+        IQNormalization.findUniqueMatch("A \\<Rightarrow> B", "A \\<Rightarrow> B"),
+        "1c: both Isabelle")
+      assertEquals(s, 0, "1c: start")
+      assertEquals(e, 17, "1c: end")
+    }
+
+    // 1d. Both Unicode (Tier 1 — direct match)
+    locally {
+      val (s, e) = assertRight(
+        IQNormalization.findUniqueMatch("A \u21d2 B", "A \u21d2 B"),
+        "1d: both Unicode")
+      assertEquals(s, 0, "1d: start")
+      assertEquals(e, 5, "1d: end")
+    }
+
+    // 1e. Text=Isabelle cartouches, Pattern=Unicode cartouches
+    // \<open> = 7 chars, \<close> = 8 chars
+    // text: "f \<open>x\<close>" = f(0) sp(1) \<open>(2..8) x(9) \<close>(10..17) = 18 chars
+    locally {
+      val (s, e) = assertRight(
+        IQNormalization.findUniqueMatch("f \\<open>x\\<close>", "f \u2039x\u203a"),
+        "1e: Isabelle cartouches vs Unicode cartouches")
+      assertEquals(s, 0, "1e: start")
+      assertEquals(e, 18, "1e: end")
+    }
+
+    // 1f. Reversed: Text=Unicode cartouches, Pattern=Isabelle cartouches
+    locally {
+      val (s, e) = assertRight(
+        IQNormalization.findUniqueMatch("f \u2039x\u203a", "f \\<open>x\\<close>"),
+        "1f: Unicode cartouches vs Isabelle cartouches")
+      assertEquals(s, 0, "1f: start")
+      assertEquals(e, 5, "1f: end")
+    }
+
+    // 1g. Cross-mixed: text=Isabelle-open + Unicode-close, pattern=Unicode-open + Isabelle-close
+    // text: "\<open>x›" = \<open>(0..6) x(7) ›(8) = 9 chars
+    locally {
+      val (s, e) = assertRight(
+        IQNormalization.findUniqueMatch("\\<open>x\u203a", "\u2039x\\<close>"),
+        "1g: cross-mixed cartouche encodings")
+      assertEquals(s, 0, "1g: start")
+      assertEquals(e, 9, "1g: end")
+    }
+
+    // ================================================================
+    // 2. WHITESPACE VARIATIONS — same encoding (Unicode), unique match
+    // ================================================================
+
+    // 2a. Pattern has extra spaces, text has single spaces
+    // text: "A ⇒ B" = 5 chars
+    // endOffset must be 5 (actual match end), NOT 0 + patternLen
+    locally {
+      val (s, e) = assertRight(
+        IQNormalization.findUniqueMatch("A \u21d2 B", "A  \u21d2  B"),
+        "2a: pattern extra spaces, text single")
+      assertEquals(s, 0, "2a: start")
+      assertEquals(e, 5, "2a: end=5, not pattern.length=7")
+    }
+
+    // 2b. Text has extra spaces, pattern has single spaces
+    // text: "A  ⇒  B" = A(0) sp(1) sp(2) ⇒(3) sp(4) sp(5) B(6) = 7 chars
+    locally {
+      val (s, e) = assertRight(
+        IQNormalization.findUniqueMatch("A  \u21d2  B", "A \u21d2 B"),
+        "2b: text extra spaces, pattern single")
+      assertEquals(s, 0, "2b: start")
+      assertEquals(e, 7, "2b: end=7, not pattern.length=5")
+    }
+
+    // 2c. Tabs in pattern, spaces in text (1:1 char replacement)
+    locally {
+      val (s, e) = assertRight(
+        IQNormalization.findUniqueMatch("A \u21d2 B", "A\t\u21d2\tB"),
+        "2c: tabs in pattern, spaces in text")
+      assertEquals(s, 0, "2c: start")
+      assertEquals(e, 5, "2c: end")
+    }
+
+    // 2d. Tabs in text, spaces in pattern
+    locally {
+      val (s, e) = assertRight(
+        IQNormalization.findUniqueMatch("A\t\u21d2\tB", "A \u21d2 B"),
+        "2d: tabs in text, spaces in pattern")
+      assertEquals(s, 0, "2d: start")
+      assertEquals(e, 5, "2d: end")
+    }
+
+    // 2e. Mixed whitespace in pattern (tab + spaces), single space in text
+    locally {
+      val (s, e) = assertRight(
+        IQNormalization.findUniqueMatch("A \u21d2 B", "A \t \u21d2 \t B"),
+        "2e: mixed ws in pattern")
+      assertEquals(s, 0, "2e: start")
+      assertEquals(e, 5, "2e: end=5, not pattern.length=11")
+    }
+
+    // 2f. Heavily padded pattern
+    locally {
+      val (s, e) = assertRight(
+        IQNormalization.findUniqueMatch("A \u21d2 B", "A     \u21d2     B"),
+        "2f: heavily padded pattern")
+      assertEquals(s, 0, "2f: start")
+      assertEquals(e, 5, "2f: end=5, not pattern.length=15")
+    }
+
+    // ================================================================
+    // 3. COMBINED encoding + whitespace, unique match
+    // ================================================================
+
+    // 3a. Text=Isabelle+extra ws, Pattern=Unicode+single ws
+    // text: "A  \<Rightarrow>  B" = A(0) sp(1) sp(2) \<Rightarrow>(3..15) sp(16) sp(17) B(18) = 19 chars
+    locally {
+      val (s, e) = assertRight(
+        IQNormalization.findUniqueMatch("A  \\<Rightarrow>  B", "A \u21d2 B"),
+        "3a: text=Isabelle+extra-ws, pattern=Unicode+single-ws")
+      assertEquals(s, 0, "3a: start")
+      assertEquals(e, 19, "3a: end")
+    }
+
+    // 3b. Text=Unicode+single ws, Pattern=Isabelle+extra ws
+    // text: "A ⇒ B" = 5 chars
+    locally {
+      val (s, e) = assertRight(
+        IQNormalization.findUniqueMatch("A \u21d2 B", "A  \\<Rightarrow>  B"),
+        "3b: text=Unicode+single-ws, pattern=Isabelle+extra-ws")
+      assertEquals(s, 0, "3b: start")
+      assertEquals(e, 5, "3b: end=5, not pattern.length=19")
+    }
+
+    // 3c. Substring in context — Isabelle text, Unicode pattern
+    // text: "hello A \<Rightarrow> B world"
+    //   h(0)e(1)l(2)l(3)o(4) (5)A(6) (7)\<Rightarrow>(8..20) (21)B(22) (23)w(24)o(25)r(26)l(27)d(28) = 29
+    locally {
+      val (s, e) = assertRight(
+        IQNormalization.findUniqueMatch("hello A \\<Rightarrow> B world", "A \u21d2 B"),
+        "3c: Isabelle in context, Unicode pattern")
+      assertEquals(s, 6, "3c: start")
+      assertEquals(e, 23, "3c: end")
+    }
+
+    // 3d. Substring in context — Isabelle+extra ws text, Unicode pattern
+    // text: "hello A  \<Rightarrow>  B world"
+    //   h(0)e(1)l(2)l(3)o(4) (5)A(6) (7) (8)\<Rightarrow>(9..21) (22) (23)B(24) (25)w(26)o(27)r(28)l(29)d(30) = 31
+    locally {
+      val (s, e) = assertRight(
+        IQNormalization.findUniqueMatch("hello A  \\<Rightarrow>  B world", "A \u21d2 B"),
+        "3d: Isabelle+extra-ws in context, Unicode pattern")
+      assertEquals(s, 6, "3d: start")
+      assertEquals(e, 25, "3d: end")
+    }
+
+    // 3e. Same text as 3d, but pattern also has extra whitespace
+    // Offsets in original text must be identical to 3d
+    locally {
+      val (s, e) = assertRight(
+        IQNormalization.findUniqueMatch("hello A  \\<Rightarrow>  B world", "A   \u21d2   B"),
+        "3e: both extra-ws + encoding mismatch")
+      assertEquals(s, 6, "3e: start — same as 3d")
+      assertEquals(e, 25, "3e: end — same as 3d, not shifted by pattern ws")
+    }
+
+    // ================================================================
+    // 4. NO MATCH
+    // ================================================================
+
+    assertLeft(
+      IQNormalization.findUniqueMatch("A \\<Rightarrow> B", "A \\<Longrightarrow> B"),
+      IQNormalization.SubstringNotFound,
+      "4a: different Isabelle symbols")
+
+    assertLeft(
+      IQNormalization.findUniqueMatch("A \u21d2 B", "A \\<Longrightarrow> B"),
+      IQNormalization.SubstringNotFound,
+      "4b: ⇒ text vs ⟹ pattern, cross-encoding")
+
+    assertLeft(
+      IQNormalization.findUniqueMatch("hello world", "\\<Rightarrow>"),
+      IQNormalization.SubstringNotFound,
+      "4c: no symbol in text")
+
+    assertLeft(
+      IQNormalization.findUniqueMatch("AB", "A B"),
+      IQNormalization.SubstringNotFound,
+      "4d: ws in pattern but not in text — no match")
+
+    // ================================================================
+    // 5. MULTIPLE MATCHES — not unique
+    // ================================================================
+
+    assertLeft(
+      IQNormalization.findUniqueMatch("\u21d2 x \u21d2", "\u21d2"),
+      IQNormalization.SubstringNotUnique,
+      "5a: two ⇒, direct duplicates")
+
+    assertLeft(
+      IQNormalization.findUniqueMatch("A \\<Rightarrow> B \\<Rightarrow> C", "\u21d2"),
+      IQNormalization.SubstringNotUnique,
+      "5b: two Isabelle arrows, Unicode pattern")
+
+    // ws compression creates duplicates: "A  B  A  B" → "A B A B", pattern "A B" × 2
+    assertLeft(
+      IQNormalization.findUniqueMatch("A  B  A  B", "A B"),
+      IQNormalization.SubstringNotUnique,
+      "5c: ws compression creates duplicate matches")
+
+    assertLeft(
+      IQNormalization.findUniqueMatch("\\<Rightarrow>  x  \\<Rightarrow>", "\u21d2"),
+      IQNormalization.SubstringNotUnique,
+      "5d: encoding + ws normalization, two matches")
+
+    // ================================================================
+    // 6. OFFSET CONTRACT — endOffset tracks original text, not pattern length
+    //    These are the cases that expose the findCommandByPattern bug.
+    // ================================================================
+
+    // 6a. Pattern=15 chars (padded), text match=5 chars
+    locally {
+      val (s, e) = assertRight(
+        IQNormalization.findUniqueMatch("A \u21d2 B", "A     \u21d2     B"),
+        "6a: long pattern, short text")
+      assertEquals(s, 0, "6a: start")
+      assertEquals(e, 5, "6a: end=5, NOT pattern.length=15")
+    }
+
+    // 6b. Pattern=19 chars (Isabelle+ws), text match=5 chars (Unicode)
+    locally {
+      val (s, e) = assertRight(
+        IQNormalization.findUniqueMatch("A \u21d2 B", "A  \\<Rightarrow>  B"),
+        "6b: Isabelle+ws pattern, Unicode text")
+      assertEquals(s, 0, "6b: start")
+      assertEquals(e, 5, "6b: end=5, NOT pattern.length=19")
+    }
+
+    // 6c. Pattern=5 chars (Unicode), text match=19 chars (Isabelle+ws), in context
+    // text: "X A  \<Rightarrow>  B Y"
+    //   X(0) (1)A(2) (3) (4)\<Rightarrow>(5..17) (18) (19)B(20) (21)Y(22) = 23 chars
+    locally {
+      val (s, e) = assertRight(
+        IQNormalization.findUniqueMatch("X A  \\<Rightarrow>  B Y", "A \u21d2 B"),
+        "6c: Unicode pattern, Isabelle+ws text in context")
+      assertEquals(s, 2, "6c: start=2")
+      assertEquals(e, 21, "6c: end=21, NOT start+pattern.length=7")
+    }
+
+    // 6d. The file_pattern scenario: pattern overshoots into "by simp"
+    // text: "lemma foo: \<open>True\<close>\nby simp"
+    //   l(0)e(1)m(2)m(3)a(4) (5)f(6)o(7)o(8):(9) (10)\<open>(11..17)T(18)r(19)u(20)e(21)\<close>(22..29)\n(30)b(31)y(32) (33)s(34)i(35)m(36)p(37) = 38 chars
+    // pattern (Unicode+extra ws): "lemma  foo:  ‹True›" (20 chars)
+    // normalized text: "lemma foo: ‹True› by simp" (25 chars)
+    // normalized pattern: "lemma foo: ‹True›" (17 chars)
+    // match at norm 0, endIdx=17 → offsetMap(17)=30 (the \n)
+    // lastCharOffset should be 30-1=29 (the '>' of \<close>) — within lemma command
+    // bug version: 0+20-1=19 — happens to be inside too, but wrong principle
+    locally {
+      val text = "lemma foo: \\<open>True\\<close>\nby simp"
+      val pattern = "lemma  foo:  \u2039True\u203a"
+      val (s, e) = assertRight(
+        IQNormalization.findUniqueMatch(text, pattern),
+        "6d: file_pattern scenario — endOffset at command boundary")
+      assertEquals(s, 0, "6d: start=0")
+      assertEquals(e, 30, "6d: end=30 (the \\n), NOT 0+pattern.length=20")
+    }
+  }
+
+  def main(args: Array[String]): Unit = {
+    println("IQNormalizationTest")
+
+    testNormalize()
+    testNormalizeWithOffsets()
+    testFindUniqueMatch()
+    testEdgeCases()
+    testEncodingWhitespaceMatrix()
+
+    println()
+    if (failed > 0) {
+      println(s"FAILED: $failed failures, $passed passed")
+      sys.exit(1)
+    } else {
+      println(s"OK: $passed tests passed")
+    }
+  }
+}

--- a/ir/ir.ML
+++ b/ir/ir.ML
@@ -42,7 +42,7 @@ sig
   val sledgehammer_state : (Proof.state * int) option Synchronized.var
   val sledgehammer_result : string Synchronized.var
   val find_theorems : string -> int -> string -> unit
-  val timeout : int -> unit
+  val timeout : string -> int -> unit
   val is_interactive_session : unit -> bool
   val help : unit -> unit
 end;
@@ -62,12 +62,9 @@ val cfg : config Synchronized.var =
 fun config f = Synchronized.change cfg f;
 fun get_cfg () = Synchronized.value cfg;
 
-(** Step timeout (seconds, 0 = no limit) **)
+(** Default step timeout (seconds, 0 = no limit) **)
 
-val step_timeout : int Synchronized.var = Synchronized.var "Ir.timeout" 10;
-fun timeout secs =
-  (Synchronized.change step_timeout (K secs);
-   TextIO.print ("Timeout set to " ^ (if secs = 0 then "unlimited" else string_of_int secs ^ "s") ^ "\n"));
+val default_timeout : int = 10;
 
 (** Markup-based token rendering **)
 
@@ -208,7 +205,8 @@ type repl_step = {
 type repl = {
   origin: origin,
   base_state: Toplevel.state,
-  steps: repl_step list
+  steps: repl_step list,
+  timeout: int
 };
 
 (* Sledgehammer bridge: structure-qualified vars survive heap save/load,
@@ -229,8 +227,17 @@ fun the_repl id =
 fun update_repl id r =
   Synchronized.change repl_tab (Symtab.update (id, r));
 
+fun timeout id secs =
+  let val _ = the_repl id
+      val _ = Synchronized.change repl_tab (Symtab.map_entry id
+        (fn r : repl => {origin = #origin r, base_state = #base_state r,
+                         steps = #steps r, timeout = secs}))
+  in out ("Timeout for " ^ quote id ^ " set to " ^
+          (if secs = 0 then "unlimited" else string_of_int secs ^ "s"))
+  end;
+
 (* Execute Isar text against a state *)
-fun exec_text text st =
+fun exec_text timeout_secs text st =
   let val thy = Toplevel.theory_of st
       val transitions = Outer_Syntax.parse_text thy (fn () => thy) Position.none text
       fun run (tr, s) =
@@ -239,12 +246,11 @@ fun exec_text text st =
             val s' = Toplevel.command_exception false tr s
             val _ = Multithreading.parallel_proofs := old
         in s' end
-      val secs = Synchronized.value step_timeout
       fun go () = List.foldl (fn (tr, s) => run (tr, s)) st transitions
-  in if secs > 0
-     then Timeout.apply (Time.fromSeconds (Int.toLarge secs)) go ()
+  in if timeout_secs > 0
+     then Timeout.apply (Time.fromSeconds (Int.toLarge timeout_secs)) go ()
        handle Timeout.TIMEOUT _ =>
-         error ("Step timed out after " ^ string_of_int secs ^ "s")
+         error ("Step timed out after " ^ string_of_int timeout_secs ^ "s")
      else go ()
   end;
 
@@ -292,7 +298,7 @@ fun init id specs =
                 val thy = Theory.begin_theory (id, Position.none) thys
             in (From_Theory (String.concatWith "+" thy_names),
                 Toplevel.make_state (SOME thy)) end
-      val r : repl = {origin = origin, base_state = st, steps = []}
+      val r : repl = {origin = origin, base_state = st, steps = [], timeout = default_timeout}
   in update_repl id r;
      out ("Created REPL " ^ quote id)
   end;
@@ -318,7 +324,7 @@ fun init_from_document id node_name command_id =
             else ()
     val toplevel_st = Command.eval_result_state eval
     val r : repl = {origin = From_Document (node_name, command_id),
-                    base_state = toplevel_st, steps = []}
+                    base_state = toplevel_st, steps = [], timeout = default_timeout}
   in update_repl id r;
      out ("Created REPL " ^ quote id ^ " from document " ^ quote node_name ^
           " command " ^ string_of_int command_id ^
@@ -338,7 +344,8 @@ fun fork parent_id new_id state_idx =
                else if i >= 1 andalso i <= n then #post_state (nth steps (i - 1))
                else error ("State " ^ string_of_int state_idx ^ " out of range (0.." ^
                            string_of_int n ^ ")")
-      val r : repl = {origin = From_REPL (parent_id, i), base_state = st, steps = []}
+      val r : repl = {origin = From_REPL (parent_id, i), base_state = st, steps = [],
+                      timeout = #timeout parent}
   in update_repl new_id r;
      out ("Forked REPL " ^ quote new_id ^ " from " ^ quote parent_id ^
           " at state " ^ string_of_int i)
@@ -347,10 +354,10 @@ fun fork parent_id new_id state_idx =
 fun step id text =
   let val r = the_repl id
       val pre = last_state r
-      val post = exec_text text pre
+      val post = exec_text (#timeout r) text pre
       val s : repl_step = {text = text, pre_state = pre, post_state = post, stale = false}
       val r' : repl = {origin = #origin r, base_state = #base_state r,
-                        steps = #steps r @ [s]}
+                        steps = #steps r @ [s], timeout = #timeout r}
   in update_repl id r';
      out (pretty_state post)
   end;
@@ -374,8 +381,11 @@ fun show id =
         | From_REPL (p, i) => "REPL " ^ quote p ^ " state " ^ string_of_int i
         | From_Document (n, i) => "document " ^ quote n ^ " cmd " ^ string_of_int i
       val n = length (#steps r)
+      val tmo = if #timeout r = 0 then "unlimited"
+                 else string_of_int (#timeout r) ^ "s"
       val _ = out ("REPL " ^ quote id ^
-                   " (" ^ string_of_int n ^ " steps, from " ^ orig ^ ")")
+                   " (" ^ string_of_int n ^ " steps, from " ^ orig ^
+                   ", timeout=" ^ tmo ^ ")")
       val _ = out ("  base  level=" ^ string_of_int (Toplevel.level (#base_state r)))
       val thy = Toplevel.theory_of (#base_state r)
       fun pr _ [] = ()
@@ -399,13 +409,14 @@ fun replay id =
       fun go _ [] acc = rev acc
         | go prev_post (s :: rest) acc =
             if #stale (s : repl_step) then
-              let val post = exec_text (#text s) prev_post
+              let val post = exec_text (#timeout r) (#text s) prev_post
                   val s' : repl_step = {text = #text s, pre_state = prev_post,
                                          post_state = post, stale = false}
               in go post rest (s' :: acc) end
             else go (#post_state s) rest (s :: acc)
       val steps' = go (#base_state r) (#steps r) []
-      val r' : repl = {origin = #origin r, base_state = #base_state r, steps = steps'}
+      val r' : repl = {origin = #origin r, base_state = #base_state r, steps = steps',
+                        timeout = #timeout r}
   in update_repl id r';
      out ("Replayed " ^ string_of_int (length (filter #stale (#steps r))) ^ " stale steps")
   end;
@@ -417,14 +428,15 @@ fun edit id idx new_text =
               then error ("Step " ^ string_of_int idx ^ " out of range") else ()
       val pre = if idx = 0 then #base_state r
                 else #post_state (nth steps (idx - 1))
-      val post = exec_text new_text pre
+      val post = exec_text (#timeout r) new_text pre
       val edited : repl_step = {text = new_text, pre_state = pre, post_state = post, stale = false}
       val before_steps = List.take (steps, idx)
       val after_steps = List.drop (steps, idx + 1)
         |> map (fn s : repl_step => {text = #text s, pre_state = #pre_state s,
                                       post_state = #post_state s, stale = true})
       val r' : repl = {origin = #origin r, base_state = #base_state r,
-                        steps = before_steps @ [edited] @ after_steps}
+                        steps = before_steps @ [edited] @ after_steps,
+                        timeout = #timeout r}
   in update_repl id r';
      out ("Edited step " ^ string_of_int idx ^ ", " ^
           string_of_int (length after_steps) ^ " subsequent steps marked stale");
@@ -448,7 +460,8 @@ fun truncate id raw_idx =
               if pid = id andalso si > idx then Symtab.delete rid else I
           | _ => I) tab tab)
       val r' : repl = {origin = #origin r, base_state = #base_state r,
-                        steps = if idx < 0 then [] else List.take (steps, idx + 1)}
+                        steps = if idx < 0 then [] else List.take (steps, idx + 1),
+                        timeout = #timeout r}
   in update_repl id r';
      out ("Truncated to step " ^ string_of_int idx ^ ", dropped " ^
           string_of_int dropped ^ " steps")
@@ -594,7 +607,7 @@ fun help () = out
   \  merge id               inline sub-REPL into parent\n\
   \  sledgehammer id secs   run sledgehammer on proof state\n\
   \  find_theorems id n q   search theorems (n=max, 0=unlimited)\n\
-  \  timeout secs           set step timeout (0=unlimited, default 5s)\n\
+  \  timeout id secs        set step timeout for REPL (0=unlimited, default 10s)\n\
   \  remove id              remove REPL and its sub-REPLs\n\
   \  repls ()               list all REPLs\n\
   \  theories ()            list loaded theories\n\

--- a/ir/mcp_server.py
+++ b/ir/mcp_server.py
@@ -383,12 +383,12 @@ async def find_theorems(repl: str, query: str, max_results: int = 40, ctx: Conte
             parts.append(criterion.strip())
     return await _send(ctx, f"Ir.find_theorems {ml_str(repl)} {ml_int(max_results)} {ml_str(' '.join(parts))};")
 
-@mcp.tool(description="Set step timeout in seconds (0=unlimited, default 10s). NOTE: DO NOT set this to values >10s unless you have "
+@mcp.tool(description="Set step timeout in seconds for a specific REPL (0=unlimited, default 10s). NOTE: DO NOT set this to values >10s unless you have "
           "a specific reason to. Calls like `metis`, `auto`, `blast`, `force`, should NOT take longer than 5s. Even if they do, and the call "
           "ultimately succeeds, it points at a proof that ought to be broken down further. ONLY use a large timeout if you work with very large "
           "scripts or in special circumstances where, exceptionally, a large timeout is expected / tolerated.")
-async def timeout(secs: int, ctx: Context = None) -> str:
-    return await _send(ctx, f"Ir.timeout {ml_int(secs)};")
+async def timeout(repl: str, secs: int, ctx: Context = None) -> str:
+    return await _send(ctx, f"Ir.timeout {ml_str(repl)} {ml_int(secs)};")
 
 @mcp.tool(description="Remove a REPL and all its sub-REPLs.")
 async def remove(repl: str, ctx: Context = None) -> str:

--- a/ir/mcp_server.py
+++ b/ir/mcp_server.py
@@ -495,20 +495,32 @@ def main():
     import argparse
     p = argparse.ArgumentParser(description="I/R MCP server")
     p.add_argument("--transport", choices=["stdio", "sse", "streamable-http"],
-                   default="stdio")
-    p.add_argument("--port", type=int, default=9148,
+                   default=None)
+    p.add_argument("--port", type=int, default=None,
                    help="Port for SSE/streamable-http transport (default: 9148)")
     p.add_argument("--repl-port", type=int, default=9147,
                    help="Port of the I/R REPL to connect to (default: 9147)")
     args = p.parse_args()
 
+    port_explicit = args.port is not None
+    transport = args.transport
+
+    if port_explicit and transport == "stdio":
+        p.error("--port cannot be used with --transport stdio")
+
+    if transport is None:
+        transport = "streamable-http" if port_explicit else "stdio"
+
+    if args.port is None:
+        args.port = 9148
+
     global _repl_port
     _repl_port = args.repl_port
 
-    if args.transport in ("sse", "streamable-http"):
+    if transport in ("sse", "streamable-http"):
         mcp.settings.host = "127.0.0.1"
         mcp.settings.port = args.port
-        mcp.run(transport=args.transport)
+        mcp.run(transport=transport)
     else:
         mcp.run(transport="stdio")
 

--- a/ir/mcp_server.py
+++ b/ir/mcp_server.py
@@ -39,6 +39,7 @@ MCP configuration for communication via streaming-http
 
 """
 
+import asyncio
 import sys
 if hasattr(sys.stdout, "reconfigure"):
     sys.stdout.reconfigure(line_buffering=True)
@@ -55,70 +56,88 @@ SENTINEL = "<<DONE>>"
 # ---------------------------------------------------------------------------
 
 class ReplClient:
-    """Synchronous TCP client for the I/R REPL server."""
+    """Ephemeral TCP client for the I/R REPL server.
 
-    def __init__(self, host: str = "127.0.0.1", port: int = 9147):
+    Opens a fresh TCP connection per send() call — desync is structurally
+    impossible since there is no persistent pipe for stale responses.
+    """
+
+    def __init__(self, host: str = "127.0.0.1", port: int = 9147,
+                 token: str = ""):
         self.host = host
         self.port = port
-        self.sock: socket.socket | None = None
+        self.token = token
 
     def connect(self, host: str | None = None, port: int | None = None,
                 token: str | None = None):
-        self.disconnect()
         if host is not None:
             self.host = host
         if port is not None:
             self.port = port
-        self.sock = socket.create_connection((self.host, self.port))
-        if token:
-            self.sock.sendall((token + "\n").encode())
-            response = b""
-            while b"\n" not in response:
-                chunk = self.sock.recv(1024)
-                if not chunk:
-                    raise RuntimeError("Connection closed during auth handshake")
-                response += chunk
-            if not response.startswith(b"OK"):
-                self.sock.close()
-                self.sock = None
-                raise RuntimeError("REPL authentication failed")
+        if token is not None:
+            self.token = token
+        # Probe reachability
+        sock = socket.create_connection((self.host, self.port))
+        sock.close()
 
     def disconnect(self):
-        if self.sock is not None:
-            try:
-                self.sock.close()
-            except OSError:
-                pass
-            self.sock = None
+        pass
 
     @property
     def connected(self) -> bool:
-        return self.sock is not None
+        if not self.token:
+            return False
+        try:
+            sock = socket.create_connection((self.host, self.port), timeout=2)
+            sock.close()
+            return True
+        except Exception:
+            return False
 
     def send(self, ml_command: str) -> str:
-        """Send an ML command and return the transformed output.
+        """Send an ML command on a fresh connection and return the output.
 
-        Raises RuntimeError if the ML command produced an error (the REPL
-        server prefixes error responses with 'ERR\\n').  FastMCP catches this
-        and returns it to the MCP client with isError=true.
+        Opens a new TCP socket, authenticates, sends the command, reads
+        until the sentinel, and closes.  Raises RuntimeError if the ML
+        command produced an error (the REPL server prefixes error responses
+        with 'ERR\\n').  FastMCP catches this and returns it to the MCP
+        client with isError=true.
         """
-        if self.sock is None:
+        if not self.token:
             raise RuntimeError("Not connected — call the 'connect' tool first")
-        self.sock.sendall((ml_command.strip() + "\n").encode())
-        buf = b""
-        while True:
-            chunk = self.sock.recv(4096)
-            if not chunk:
-                self.sock = None
-                raise EOFError("Connection closed by repl.py")
-            buf += chunk
-            text = buf.decode("utf-8", errors="replace")
-            if SENTINEL in text:
-                raw = text[:text.index(SENTINEL)].strip()
-                result = apply_transforms(raw)
-                if result.startswith("ERR\n"):
-                    raise RuntimeError(result[4:])
-                return result
+        sock = socket.create_connection((self.host, self.port))
+        try:
+            # Authenticate
+            sock.sendall((self.token + "\n").encode())
+            auth_buf = b""
+            while b"\n" not in auth_buf:
+                chunk = sock.recv(1024)
+                if not chunk:
+                    raise RuntimeError("Connection closed during auth handshake")
+                auth_buf += chunk
+            if not auth_buf.startswith(b"OK"):
+                raise RuntimeError("REPL authentication failed")
+            # Send command
+            cmd = ml_command.strip()
+            if not cmd.endswith(";") and not cmd.startswith("/"):
+                cmd += ";"
+            sock.sendall((cmd + "\n").encode())
+            # Read until sentinel
+            buf = b""
+            while True:
+                chunk = sock.recv(4096)
+                if not chunk:
+                    raise EOFError("Connection closed by repl.py")
+                buf += chunk
+                text = buf.decode("utf-8", errors="replace")
+                if SENTINEL in text:
+                    raw = text[:text.index(SENTINEL)].strip()
+                    result = apply_transforms(raw)
+                    if result.startswith("ERR\n"):
+                        raise RuntimeError(result[4:])
+                    return result
+        finally:
+            sock.close()
 
 # ---------------------------------------------------------------------------
 # Output transforms (applied to every response from the ML process)
@@ -211,29 +230,33 @@ def _get_client(ctx: Context) -> ReplClient:
         _repl_clients[key] = client
     return client
 
+async def _send(ctx: Context, ml_command: str) -> str:
+    """Send a command on an ephemeral connection in a background thread."""
+    return await asyncio.to_thread(_get_client(ctx).send, ml_command)
+
 @mcp.tool(description="Connect to the I/R REPL server. Call this before using any other tool. Can also reconnect after a dropped connection. If the token is not provided to you, use the IR_AUTH_TOKEN environment variable if set.")
-def connect(token: str, port: int = 0, ctx: Context = None) -> str:
+async def connect(token: str, port: int = 0, ctx: Context = None) -> str:
     if port == 0:
         port = _repl_port
     client = _get_client(ctx)
-    client.connect("127.0.0.1", port, token)
-    return f"Connected to {client.host}:{client.port}\n\n{session_info(ctx=ctx)}"
+    await asyncio.to_thread(client.connect, "127.0.0.1", port, token)
+    return f"Connected to {client.host}:{client.port}\n\n{await session_info(ctx=ctx)}"
 
 @mcp.tool(description="Disconnect from the I/R REPL server.")
-def disconnect(ctx: Context = None) -> str:
+async def disconnect(ctx: Context = None) -> str:
     client = _get_client(ctx)
-    if not client.connected:
+    if not client.token:
         return "Already disconnected"
     client.disconnect()
     _repl_clients.pop(id(ctx.session), None)
     return "Disconnected"
 
 @mcp.tool(description="Show the loaded Isabelle session name, directory, and available theories.")
-def session_info(ctx: Context = None) -> str:
+async def session_info(ctx: Context = None) -> str:
     client = _get_client(ctx)
-    if not client.connected:
+    if not client.token:
         return "Not connected. Call `connect` first."
-    info = client.send('/info')
+    info = await asyncio.to_thread(client.send, '/info')
     session = dir_ = heap_db = ""
     for line in info.splitlines():
         line = line.strip()
@@ -243,7 +266,8 @@ def session_info(ctx: Context = None) -> str:
             dir_ = line.split("=", 1)[1].strip()
         elif line.startswith("heap_db"):
             heap_db = line.split("=", 1)[1].strip()
-    theories = apply_transforms(client.send('Ir.theories ();'))
+    theories = await asyncio.to_thread(client.send, 'Ir.theories ();')
+    theories = apply_transforms(theories)
     result = f"Session name: {session}\nSession directory: {dir_}"
     if heap_db and heap_db != "(none)":
         result += f"\nHeap DB: {heap_db}"
@@ -255,11 +279,11 @@ def session_info(ctx: Context = None) -> str:
     "Show server status including the Isabelle session name, "
     "root directory, ports, uptime, and client count. "
     "Use this to find out which session and directory the REPL is running with."))
-def server_info(ctx: Context = None) -> str:
+async def server_info(ctx: Context = None) -> str:
     client = _get_client(ctx)
-    if not client.connected:
+    if not client.token:
         return "Not connected. Call `connect` first."
-    return client.send("/info")
+    return await _send(ctx, "/info")
 
 @mcp.tool(description=(
     "Create a new REPL session that imports the given Isabelle theories. "
@@ -274,20 +298,20 @@ def server_info(ctx: Context = None) -> str:
     "When multiple theories are listed, they are merged so the REPL has access to all of them. "
     "Use `theories` to see what is already loaded in the session."
 ))
-def init(repl: str, theories: list[str], ctx: Context = None) -> str:
+async def init(repl: str, theories: list[str], ctx: Context = None) -> str:
     ml_list = "[" + ", ".join(ml_str(t) for t in theories) + "]"
-    return _get_client(ctx).send(f"Ir.init {ml_str(repl)} {ml_list};")
+    return await _send(ctx, f"Ir.init {ml_str(repl)} {ml_list};")
 
 @mcp.tool(description=(
     "Create a new REPL session rooted at a specific command in the PIDE document model. "
     "Requires the exact node name and command ID from the PIDE document model."
 ))
-def init_from_document(repl: str, node_name: str, command_id: int, ctx: Context = None) -> str:
-    return _get_client(ctx).send(f"Ir.init_from_document {ml_str(repl)} {ml_str(node_name)} {ml_int(command_id)};")
+async def init_from_document(repl: str, node_name: str, command_id: int, ctx: Context = None) -> str:
+    return await _send(ctx, f"Ir.init_from_document {ml_str(repl)} {ml_str(node_name)} {ml_int(command_id)};")
 
 @mcp.tool(description="Fork a sub-REPL from an existing REPL at the given state index (0=base, -1=latest).")
-def fork(repl: str, new_repl: str, state_idx: int, ctx: Context = None) -> str:
-    return _get_client(ctx).send(f"Ir.fork {ml_str(repl)} {ml_str(new_repl)} {ml_int(state_idx)};")
+async def fork(repl: str, new_repl: str, state_idx: int, ctx: Context = None) -> str:
+    return await _send(ctx, f"Ir.fork {ml_str(repl)} {ml_str(new_repl)} {ml_int(state_idx)};")
 
 @mcp.tool(description=(
     "Apply an Isar command to a REPL. "
@@ -295,47 +319,47 @@ def fork(repl: str, new_repl: str, state_idx: int, ctx: Context = None) -> str:
     "Don't use 'theory' commands — the theory context is set by 'init'. "
     "IMPORTANT: If a step FAILS (error response), the REPL state is UNCHANGED — "
     "do NOT call 'back' to undo a failed step."))
-def step(repl: str, isar_text: str, ctx: Context = None) -> str:
-    return _get_client(ctx).send(f"Ir.step {ml_str(repl)} {ml_str(isar_text)};")
+async def step(repl: str, isar_text: str, ctx: Context = None) -> str:
+    return await _send(ctx, f"Ir.step {ml_str(repl)} {ml_str(isar_text)};")
 
 @mcp.tool(description="Show a REPL: origin, steps, and staleness.")
-def show(repl: str, ctx: Context = None) -> str:
-    return _get_client(ctx).send(f"Ir.show {ml_str(repl)};")
+async def show(repl: str, ctx: Context = None) -> str:
+    return await _send(ctx, f"Ir.show {ml_str(repl)};")
 
 @mcp.tool(description="Print the Toplevel.state at the given index (0=base, 1=after step 0, -1=latest).")
-def state(repl: str, state_idx: int, ctx: Context = None) -> str:
-    return _get_client(ctx).send(f"Ir.state {ml_str(repl)} {ml_int(state_idx)};")
+async def state(repl: str, state_idx: int, ctx: Context = None) -> str:
+    return await _send(ctx, f"Ir.state {ml_str(repl)} {ml_int(state_idx)};")
 
 @mcp.tool(description="Print the concatenated Isar text of all steps in a REPL.")
-def text(repl: str, ctx: Context = None) -> str:
-    return _get_client(ctx).send(f"Ir.text {ml_str(repl)};")
+async def text(repl: str, ctx: Context = None) -> str:
+    return await _send(ctx, f"Ir.text {ml_str(repl)};")
 
 @mcp.tool(description="Replace the step at `idx` with new Isar text. Subsequent steps are replayed if auto_replay is on.")
-def edit(repl: str, idx: int, isar_text: str, ctx: Context = None) -> str:
-    return _get_client(ctx).send(f"Ir.edit {ml_str(repl)} {ml_int(idx)} {ml_str(isar_text)};")
+async def edit(repl: str, idx: int, isar_text: str, ctx: Context = None) -> str:
+    return await _send(ctx, f"Ir.edit {ml_str(repl)} {ml_int(idx)} {ml_str(isar_text)};")
 
 @mcp.tool(description="Re-execute all stale steps in a REPL.")
-def replay(repl: str, ctx: Context = None) -> str:
-    return _get_client(ctx).send(f"Ir.replay {ml_str(repl)};")
+async def replay(repl: str, ctx: Context = None) -> str:
+    return await _send(ctx, f"Ir.replay {ml_str(repl)};")
 
 @mcp.tool(description="Discard all steps after the given index. Use negative indices to count from the end: -1 reverts the last step, -2 the last two, etc.")
-def truncate(repl: str, idx: int, ctx: Context = None) -> str:
-    return _get_client(ctx).send(f"Ir.truncate {ml_str(repl)} {ml_int(idx)};")
+async def truncate(repl: str, idx: int, ctx: Context = None) -> str:
+    return await _send(ctx, f"Ir.truncate {ml_str(repl)} {ml_int(idx)};")
 
 @mcp.tool(description="Revert the last SUCCESSFUL step. Synonym for truncate(-1). Only call after a step that succeeded — failed steps don't change the REPL state.")
-def back(repl: str, ctx: Context = None) -> str:
-    return _get_client(ctx).send(f"Ir.back {ml_str(repl)};")
+async def back(repl: str, ctx: Context = None) -> str:
+    return await _send(ctx, f"Ir.back {ml_str(repl)};")
 
 @mcp.tool(description="Merge a sub-REPL back into its parent.")
-def merge(repl: str, ctx: Context = None) -> str:
-    return _get_client(ctx).send(f"Ir.merge {ml_str(repl)};")
+async def merge(repl: str, ctx: Context = None) -> str:
+    return await _send(ctx, f"Ir.merge {ml_str(repl)};")
 
 @mcp.tool(description=(
     "Run Sledgehammer on the current proof state. "
     "DO NOT set timeout_secs above 15. The default of 15s is almost always "
     "sufficient — Sledgehammer very rarely finds proofs beyond 15s."))
-def sledgehammer(repl: str, timeout_secs: int = 15, ctx: Context = None) -> str:
-    return _get_client(ctx).send(f"Ir.sledgehammer {ml_str(repl)} {ml_int(timeout_secs)};")
+async def sledgehammer(repl: str, timeout_secs: int = 15, ctx: Context = None) -> str:
+    return await _send(ctx, f"Ir.sledgehammer {ml_str(repl)} {ml_int(timeout_secs)};")
 
 @mcp.tool(description='Search for theorems. Criteria: '
     'name:foo (name pattern, unquoted), intro/elim/dest/solves (goal-based), '
@@ -344,7 +368,7 @@ def sledgehammer(repl: str, timeout_secs: int = 15, ctx: Context = None) -> str:
     'Name patterns are NOT quoted: name:append. '
     'Prefix with - to negate. '
     'Examples: name:conjI, "_ + _ = _", simp:"True", -name:foo, -"_ + _"')
-def find_theorems(repl: str, query: str, max_results: int = 40, ctx: Context = None) -> str:
+async def find_theorems(repl: str, query: str, max_results: int = 40, ctx: Context = None) -> str:
     q = query.strip()
     # Auto-quote bare term patterns that aren't already quoted or a keyword
     keywords = ("name:", "simp:", "intro", "elim", "dest", "solves")
@@ -357,26 +381,26 @@ def find_theorems(repl: str, query: str, max_results: int = 40, ctx: Context = N
             parts.append(prefix + '"' + c + '"')
         else:
             parts.append(criterion.strip())
-    return _get_client(ctx).send(f"Ir.find_theorems {ml_str(repl)} {ml_int(max_results)} {ml_str(' '.join(parts))};")
+    return await _send(ctx, f"Ir.find_theorems {ml_str(repl)} {ml_int(max_results)} {ml_str(' '.join(parts))};")
 
 @mcp.tool(description="Set step timeout in seconds (0=unlimited, default 10s). NOTE: DO NOT set this to values >10s unless you have "
           "a specific reason to. Calls like `metis`, `auto`, `blast`, `force`, should NOT take longer than 5s. Even if they do, and the call "
           "ultimately succeeds, it points at a proof that ought to be broken down further. ONLY use a large timeout if you work with very large "
           "scripts or in special circumstances where, exceptionally, a large timeout is expected / tolerated.")
-def timeout(secs: int, ctx: Context = None) -> str:
-    return _get_client(ctx).send(f"Ir.timeout {ml_int(secs)};")
+async def timeout(secs: int, ctx: Context = None) -> str:
+    return await _send(ctx, f"Ir.timeout {ml_int(secs)};")
 
 @mcp.tool(description="Remove a REPL and all its sub-REPLs.")
-def remove(repl: str, ctx: Context = None) -> str:
-    return _get_client(ctx).send(f"Ir.remove {ml_str(repl)};")
+async def remove(repl: str, ctx: Context = None) -> str:
+    return await _send(ctx, f"Ir.remove {ml_str(repl)};")
 
 @mcp.tool(description="List all REPL sessions.")
-def repls(ctx: Context = None) -> str:
-    return _get_client(ctx).send("Ir.repls ();")
+async def repls(ctx: Context = None) -> str:
+    return await _send(ctx, "Ir.repls ();")
 
 @mcp.tool(description="List all loaded Isabelle theories. This includes theories from the initial heap plus any loaded via load_theory.")
-def theories(ctx: Context = None) -> str:
-    return _get_client(ctx).send("Ir.theories ();")
+async def theories(ctx: Context = None) -> str:
+    return await _send(ctx, "Ir.theories ();")
 
 @mcp.tool(description=(
     "Load a theory (and its transitive dependencies) by fully qualified name into the Isabelle session. "
@@ -385,59 +409,59 @@ def theories(ctx: Context = None) -> str:
     "NOTE: Not available when I/R is running inside Isabelle/jEdit (PIDE mode). "
     "In PIDE mode, open theories in jEdit instead and use init_from_document."
 ))
-def load_theory(theory_name: str, verbose: bool = False, ctx: Context = None) -> str:
-    result = _get_client(ctx).send(f"Ir.load_theory {ml_str(theory_name)};")
+async def load_theory(theory_name: str, verbose: bool = False, ctx: Context = None) -> str:
+    result = await _send(ctx, f"Ir.load_theory {ml_str(theory_name)};")
     if verbose:
         return result
     return "\n".join(l for l in result.splitlines() if l.startswith("Loaded theory")) or result
 
 @mcp.tool(description="List command spans of a stored theory. Use negative indices to count from the end.")
-def source(theory_name: str, start: int, stop: int, ctx: Context = None) -> str:
-    return _get_client(ctx).send(f"Ir.source {ml_str(theory_name)} {ml_int(start)} {ml_int(stop)};")
+async def source(theory_name: str, start: int, stop: int, ctx: Context = None) -> str:
+    return await _send(ctx, f"Ir.source {ml_str(theory_name)} {ml_int(start)} {ml_int(stop)};")
 
 @mcp.tool(description="Set verbosity of theory source listings. 0 (default): abbreviated command spans. 1: full command spans.")
-def set_verbosity(level: int, ctx: Context = None) -> str:
+async def set_verbosity(level: int, ctx: Context = None) -> str:
     val = "true" if level > 0 else "false"
-    return _get_client(ctx).send(f"Ir.config (fn c => {{color = #color c, show_ignored = #show_ignored c, "
+    return await _send(ctx, f"Ir.config (fn c => {{color = #color c, show_ignored = #show_ignored c, "
                      f"full_spans = {val}, show_theory_in_source = #show_theory_in_source c, "
                      f"auto_replay = #auto_replay c}});")
 
 @mcp.tool(description="Enable or disable auto-replay after edits to REPLs. 0: disable, 1: enable (default).")
-def set_auto_replay(enabled: int, ctx: Context = None) -> str:
+async def set_auto_replay(enabled: int, ctx: Context = None) -> str:
     val = "true" if enabled > 0 else "false"
-    return _get_client(ctx).send(f"Ir.config (fn c => {{color = #color c, show_ignored = #show_ignored c, "
+    return await _send(ctx, f"Ir.config (fn c => {{color = #color c, show_ignored = #show_ignored c, "
                      f"full_spans = #full_spans c, show_theory_in_source = #show_theory_in_source c, "
                      f"auto_replay = {val}}});")
 
 @mcp.tool(description="Show the I/R help text.")
-def help(ctx: Context = None) -> str:
-    return _get_client(ctx).send("Ir.help ();")
+async def help(ctx: Context = None) -> str:
+    return await _send(ctx, "Ir.help ();")
 
 @mcp.tool(description=(
     "List source files recorded in the heap database. "
     "With check=True (default), verifies each file's SHA1 digest against the filesystem "
     "to detect files that have changed since the heap was built."))
-def source_files(check: bool = True, ctx: Context = None) -> str:
+async def source_files(check: bool = True, ctx: Context = None) -> str:
     cmd = "/sources --check" if check else "/sources"
-    return _get_client(ctx).send(cmd)
+    return await _send(ctx, cmd)
 
 @mcp.tool(description=(
     "Show the slowest commands from the heap build. "
     "Useful for identifying proof bottlenecks before starting refactoring. "
     "Returns per-command timing (with file:line) and per-file aggregation."))
-def timings(top_n: int = 20, theory: str = "", ctx: Context = None) -> str:
+async def timings(top_n: int = 20, theory: str = "", ctx: Context = None) -> str:
     cmd = f"/timings --top {top_n}"
     if theory:
         cmd += f" --theory {theory}"
-    return _get_client(ctx).send(cmd)
+    return await _send(ctx, cmd)
 
 @mcp.tool(description=(
     "Get the segment-to-line-number mapping for a theory. "
     "Shows each segment's index, source line number, command keyword, "
     "and build timing (if available from the heap DB). "
     "Use this to understand a theory's structure before using init()."))
-def source_map(theory_name: str, ctx: Context = None) -> str:
-    return _get_client(ctx).send(f'/source-map "{theory_name}"')
+async def source_map(theory_name: str, ctx: Context = None) -> str:
+    return await _send(ctx, f'/source-map "{theory_name}"')
 
 
 @mcp.tool(description=(
@@ -447,21 +471,21 @@ def source_map(theory_name: str, ctx: Context = None) -> str:
     "segment index, then creates the REPL there. "
     "The theory_or_file argument can be a theory name (e.g. 'MySession.Foo') "
     "or a file suffix (e.g. 'Foo.thy')."))
-def init_at_line(id: str, theory_or_file: str, line: int, ctx: Context = None) -> str:
+async def init_at_line(id: str, theory_or_file: str, line: int, ctx: Context = None) -> str:
     client = _get_client(ctx)
-    resolution = client.send(f'/resolve "{theory_or_file}" {line}')
+    resolution = await asyncio.to_thread(client.send, f'/resolve "{theory_or_file}" {line}')
     spec = resolution.strip()
     if not spec or spec.startswith("ERR") or spec.startswith("No ") or \
        spec.startswith("Cannot") or spec.startswith("Usage"):
         return spec
-    return client.send(f"Ir.init {ml_str(id)} [{ml_str(spec)}];")
+    return await asyncio.to_thread(client.send, f"Ir.init {ml_str(id)} [{ml_str(spec)}];")
 
 @mcp.tool(description="Send a raw ML expression to the Poly/ML console. Use for anything not covered by other tools. The expression must end with a semicolon.")
-def raw_ml(ml_code: str, ctx: Context = None) -> str:
+async def raw_ml(ml_code: str, ctx: Context = None) -> str:
     code = ml_code.rstrip()
     if not code.endswith(";"):
         code += ";"
-    return _get_client(ctx).send(code)
+    return await _send(ctx, code)
 
 # ---------------------------------------------------------------------------
 # Main

--- a/ir/ml_repl.ML
+++ b/ir/ml_repl.ML
@@ -44,6 +44,13 @@ fun find_connection_message () =
               then SOME msg else lookup rest
       in lookup table end;
 
+(* WARNING: only returns true on Future worker threads whose group
+   ancestry includes a registered connection group.  Returns false on
+   Isabelle_Threads (accept loop, connection handlers) because
+   Future.worker_group() returns NONE there.  Code running on connection
+   threads must use the direct `message` function (Path A), NOT
+   writeln/warning/Private_Output (Path B) — those silently fall through
+   to jEdit's output channel instead of the TCP client. *)
 fun is_server_context () = is_some (find_connection_message ());
 
 
@@ -131,14 +138,21 @@ val ir_pri = ~1;
 val ir_group_var : Future.group option Synchronized.var =
   Synchronized.var "ML_Repl.ir_group" NONE;
 
+(* Accept loop thread handle (for cleanup on stop). *)
+val accept_thread_var : Isabelle_Thread.T option Synchronized.var =
+  Synchronized.var "ML_Repl.accept_thread" NONE;
+
 
 (** Per-connection handler **)
 
 (* Evaluate a single ML command within a command sub-group.
    The sub-group is a child of conn_group, so worker threads spawned
    during eval will find the connection's message function via
-   find_connection_message(). After eval, we join all pending tasks
-   in the command group to ensure all output is flushed before "done". *)
+   find_connection_message().  After eval, we join all pending tasks
+   in the command group to ensure all output is flushed before "done".
+   NOTE: pre-fork code (semicolon check, auto-correct warning) runs on
+   the connection Isabelle_Thread — must use `message` directly, not
+   writeln/Private_Output (see is_server_context warning). *)
 fun eval_in_group conn_group message line =
   let
     val cmd_group = Future.new_group (SOME conn_group)
@@ -200,7 +214,13 @@ fun eval_in_group conn_group message line =
 (* Per-connection handler registered as Tcp_Handler.connection_handler.
    Creates a persistent Message_Channel and group for the connection,
    registers in the routing table, runs a sequential read-eval loop,
-   and cleans up on disconnect. *)
+   and cleans up on disconnect.
+   NOTE: This handler runs on an Isabelle_Thread (outside the Future
+   worker pool) so that it does not consume worker slots needed by PIDE.
+   Consequence: Private_Output wrappers (writeln, warning, etc.) do NOT
+   route to this connection's TCP client from this thread.  All output
+   on this thread must go through `message` directly.  Eval output is
+   fine — eval futures run in the worker pool with correct group context. *)
 fun connection_serve in_stream out_stream =
   let
     val _ = install_wrappers ()
@@ -242,15 +262,23 @@ fun start port =
     val _ = Synchronized.change ir_group_var (K (SOME ir_group))
     val _ = Synchronized.change Tcp_Handler.connection_handler
               (K (SOME connection_serve))
+    (* Accept loop runs on an Isabelle_Thread (outside the Future worker
+       pool) so it does not consume a worker slot while blocked on
+       Socket.accept or await_connection_slot. *)
+    val accept_thread = Isabelle_Thread.fork
+      (Isabelle_Thread.interrupts (Isabelle_Thread.params "ml_repl_accept"))
+      accept_loop
+    val _ = Synchronized.change accept_thread_var (K (SOME accept_thread))
   in
-    SOME (actual_port, (singleton o Future.forks)
-      {name = "ml_repl_accept", group = SOME ir_group,
-       deps = [], pri = ir_pri, interrupts = true}
-      accept_loop)
+    SOME (actual_port, accept_thread)
   end;
 
 fun stop () =
   (Tcp_Handler.stop ();
+   (case Synchronized.value accept_thread_var of
+      SOME t => (Isabelle_Thread.interrupt_thread t handle Thread.Thread _ => ())
+    | NONE => ());
+   Synchronized.change accept_thread_var (K NONE);
    Synchronized.change ir_group_var (K NONE);
    Synchronized.change connection_messages (K []));
 

--- a/ir/ml_repl.ML
+++ b/ir/ml_repl.ML
@@ -168,6 +168,8 @@ fun eval_in_group conn_group message line =
              ML_Compiler.eval (ML_Compiler.verbose true ML_Compiler.flags)
                Position.none (ML_Lex.tokenize line)) ()
 
+    val timing_start = Timing.start ()
+
     (* Fork eval into cmd_group so output routing works.
        Workers in cmd_group are descendants of conn_group, so
        find_connection_message() finds the right channel. *)
@@ -187,6 +189,10 @@ fun eval_in_group conn_group message line =
        Toplevel.command_exception joins parallel proofs, so this
        suffices to ensure all output is flushed before "done". *)
     val _ = ignore (Future.join_result eval_future)
+    val timing = Timing.result timing_start
+    val elapsed_str = Time.fmt 3 (#elapsed timing) ^ "s"
+    val _ = message Markup.tracingN (Markup.serial_properties 0)
+              [XML.blob ["[timing] " ^ elapsed_str]]
   in
     message "done" [] []
   end;

--- a/ir/repl.py
+++ b/ir/repl.py
@@ -94,7 +94,7 @@ IR_CMDS = {
     'Ir.source':         'thy start stop  — list theory commands (start/stop 0-based, ~N from end)',
     'Ir.source_map':     'thy start stop  — segment-to-position map (start/stop 0-based, ~N from end)',
     'Ir.sledgehammer':   'id secs  — run sledgehammer on proof state with timeout',
-    'Ir.timeout':        'secs  — set step timeout (0=unlimited, default 5s)',
+    'Ir.timeout':        'id secs  — set step timeout for REPL (0=unlimited, default 10s)',
     'Ir.find_theorems':  'id n "query"  — search theorems (n=max results, 0=unlimited)',
     'Ir.back':           'id  — revert last step (synonym for truncate ~1)',
     'Ir.config':         'f  — update config (color, show_ignored, full_spans, auto_replay)',
@@ -131,7 +131,7 @@ IR_SIGS = {
     'Ir.source':        (['thy', 'start', 'stop'], 'list theory commands (start/stop 0-based, ~N from end)'),
     'Ir.source_map':    (['thy', 'start', 'stop'], 'segment-to-position map (start/stop 0-based, ~N from end)'),
     'Ir.sledgehammer':  (['id', 'secs'], 'run sledgehammer on proof state with timeout'),
-    'Ir.timeout':       (['secs'], 'set step timeout (0=unlimited, default 5s)'),
+    'Ir.timeout':       (['id', 'secs'], 'set step timeout for REPL (0=unlimited, default 10s)'),
     'Ir.find_theorems': (['id', 'n', '"query"'], 'search theorems (n=max results, 0=unlimited)'),
     'Ir.back':          (['id'], 'revert last step (synonym for truncate ~1)'),
     'Ir.config':        (['f'], 'update config (color, show_ignored, full_spans, auto_replay)'),
@@ -234,7 +234,7 @@ class IrCompleter(Completer if _HAVE_PROMPT_TOOLKIT else object):
                 |
                     (?P<cmd>Ir\.back)    \s+ (?P<rid>"[^"]*")
                 |
-                    (?P<cmd>Ir\.timeout) \s+ (?P<num>[^\s]+)
+                    (?P<cmd>Ir\.timeout) \s+ (?P<rid>"[^"]*") \s+ (?P<num>[^\s]+)
                 |
                     # /-commands with quoted arguments
                     (?P<cmd>/source-map) \s+ (?P<thy>"[^"]*")

--- a/ir/repl.py
+++ b/ir/repl.py
@@ -644,7 +644,7 @@ class PolyMLProcess:
         cmd += ["-f", os.path.join(ml_dir, "tcp_handler.ML"),
                 "-f", os.path.join(ml_dir, "ir.ML"),
                 "-f", os.path.join(ml_dir, "ml_repl.ML"),
-                "-e", f"case ML_Repl.start {port} of SOME (_, f) => Future.join f | NONE => ();"]
+                "-e", f"case ML_Repl.start {port} of SOME (_, t) => Isabelle_Thread.join t | NONE => ();"]
         return cmd
 
     def alive(self):

--- a/ir/repl.py
+++ b/ir/repl.py
@@ -2331,14 +2331,32 @@ def main():
                 missing_vars = heap_info.unresolved_env_vars()
                 if missing_vars:
                     for var in sorted(missing_vars):
-                        _log(f"WARNING: ${var} is not set — "
-                             f"source files using it cannot be resolved. "
-                             f"Set it with: export {var}=/path/to/sources"
-                             if quiet else
-                             f"{YELLOW}WARNING: ${var} is not set — "
-                             f"source files using it cannot be resolved. "
-                             f"Set it with: export {var}=/path/to/sources{RST}")
-                else:
+                        if var == "ISABELLE_PROJECT_BASE":
+                            default = (os.path.realpath(args.dir)
+                                       if args.dir else os.getcwd())
+                            _log(f"WARNING: ${var} is not set — "
+                                 f"defaulting to {default}. "
+                                 f"Set it with: export {var}=/path/to/sources"
+                                 if quiet else
+                                 f"{YELLOW}WARNING: ${var} is not set — "
+                                 f"defaulting to {default}. "
+                                 f"Set it with: "
+                                 f"export {var}=/path/to/sources{RST}")
+                            os.environ[var] = default
+                            from heap_info import _isabelle_env_cache
+                            _isabelle_env_cache.pop(
+                                (var, args.isabelle), None)
+                        else:
+                            _log(f"WARNING: ${var} is not set — "
+                                 f"source files using it cannot be "
+                                 f"resolved. Set it with: "
+                                 f"export {var}=/path/to/sources"
+                                 if quiet else
+                                 f"{YELLOW}WARNING: ${var} is not set — "
+                                 f"source files using it cannot be "
+                                 f"resolved. Set it with: "
+                                 f"export {var}=/path/to/sources{RST}")
+                if not heap_info.unresolved_env_vars():
                     sources = heap_info.source_files()
                     verified = sum(1 for s in sources
                                    if s["status"] == "verified")

--- a/ir/repl.py
+++ b/ir/repl.py
@@ -478,6 +478,37 @@ console_transforms = [isabelle_to_unicode, yxml_to_ansi]
 tcp_transforms = [isabelle_to_unicode, strip_yxml]
 mcp_transforms = [isabelle_to_unicode, strip_yxml]
 
+# ---------------------------------------------------------------------------
+# Noise filter — drop known-noisy output lines
+# ---------------------------------------------------------------------------
+# Each rule is either:
+#   ("drop", pattern)        — drop lines containing `pattern`
+#   ("drop+next", pattern)   — drop lines containing `pattern` AND the next line
+NOISE_RULES = [
+    ("drop+next", "Ignoring duplicate rewrite rule:"),
+    ("drop", "val it = (): unit"),
+]
+
+def noise_filter(text):
+    """Remove noisy lines from transformed output text."""
+    lines = text.split("\n")
+    result = []
+    skip_next = 0
+    for line in lines:
+        if skip_next > 0:
+            skip_next -= 1
+            continue
+        matched = False
+        for rule_type, pattern in NOISE_RULES:
+            if pattern in line:
+                matched = True
+                if rule_type == "drop+next":
+                    skip_next = 1
+                break
+        if not matched:
+            result.append(line)
+    return "\n".join(result)
+
 # ANSI colors
 RST = "\033[0m"
 BOLD = "\033[1m"
@@ -1365,8 +1396,9 @@ class Server:
                             ml_conn = None
                         raise
                     err_prefix = "ERR\n" if had_error else ""
-                    response = (err_prefix +
-                                apply_transforms(tcp_transforms, raw_output) +
+                    transformed = noise_filter(
+                        apply_transforms(tcp_transforms, raw_output))
+                    response = (err_prefix + transformed +
                                 "\n" + SENTINEL + "\n").encode("utf-8")
                     client.sendall(response)
                     with self.clients_lock:
@@ -1646,7 +1678,9 @@ def process_mgmt_console_input(line, server, cmd_lines, output_fn=None,
         return True
     def on_msg(kind, props, body):
         if body and strip_yxml(body).strip():
-            out(apply_transforms(console_transforms, body))
+            plain = noise_filter(isabelle_to_unicode(strip_yxml(body)))
+            if plain.strip():
+                out(apply_transforms(console_transforms, body))
         server.log_output("[this]", kind, props, body)
     server.log_input("[this]", command)
     try:

--- a/ir/tcp_handler.ML
+++ b/ir/tcp_handler.ML
@@ -3,10 +3,13 @@
 
 (* Generic TCP line server with PIDE-compatible message framing.
 
-   Listens on a localhost port, accepts concurrent connections (one
-   Future.fork per connection).  For each connection, wraps the socket
-   into BinIO streams (following Socket_IO) and passes them to a
-   configurable handler.
+   Listens on a localhost port, accepts concurrent connections.  Each
+   connection runs on its own Isabelle_Thread (outside the Future worker
+   pool) so that I/O-bound connection handlers never consume worker
+   slots needed by PIDE or evaluation futures.
+
+   For each connection, wraps the socket into BinIO streams (following
+   Socket_IO) and passes them to a configurable handler.
 
    Two handler modes:
    - connection_handler (preferred): receives (in_stream, out_stream),
@@ -45,8 +48,8 @@ val connection_handler :
     (BinIO.instream -> BinIO.outstream -> unit) option Synchronized.var =
   Synchronized.var "Tcp_Handler.connection_handler" NONE;
 
-(* Connection limit: each connection blocks a Future worker thread on I/O,
-   so we cap at max_threads - 2 to leave headroom for accept_loop + evals.
+(* Connection limit: each connection runs on its own Isabelle_Thread.
+   We still cap connections to bound OS thread count.
    accept_loop blocks (via guarded_access) when the limit is reached. *)
 val active_connections : int Synchronized.var =
   Synchronized.var "Tcp_Handler.active_connections" 0;
@@ -54,6 +57,10 @@ val active_connections : int Synchronized.var =
 val max_connections : int Synchronized.var =
   Synchronized.var "Tcp_Handler.max_connections"
     (Int.max (2, Multithreading.max_threads () - 2));
+
+(* Tracked Isabelle_Threads for connection handlers (for cleanup on stop). *)
+val connection_threads : Isabelle_Thread.T list Synchronized.var =
+  Synchronized.var "Tcp_Handler.connection_threads" [];
 
 val server_socket : Socket.passive INetSock.stream_sock option Synchronized.var =
   Synchronized.var "Tcp_Handler.socket" NONE;
@@ -170,8 +177,8 @@ fun await_connection_slot () =
 fun release_connection_slot () =
   Synchronized.change active_connections (fn n => Int.max (0, n - 1));
 
-(* Accept loop: fork a Future per connection, with a connection limit
-   to avoid exhausting the worker thread pool. *)
+(* Accept loop: fork an Isabelle_Thread per connection (outside the Future
+   worker pool) with a connection limit to bound OS thread count. *)
 fun accept_loop () =
   case Synchronized.value server_socket of
     NONE => ()
@@ -181,14 +188,20 @@ fun accept_loop () =
         val (client, _) = Socket.accept ssock
             handle OS.SysErr msg =>
               (release_connection_slot (); raise OS.SysErr msg)
-      in ignore (Future.fork (fn () =>
-           ((serve_client client
-               handle OS.SysErr _ => ()
-                    | IO.Io _ => ()
-                    | Fail _ => ());
-            Socket.close client handle OS.SysErr _ => ();
-            release_connection_slot ())));
-         accept_loop ()
+        val thread = Isabelle_Thread.fork
+          (Isabelle_Thread.interrupts (Isabelle_Thread.params "ir_connection"))
+          (fn () =>
+            ((serve_client client
+                handle OS.SysErr _ => ()
+                     | IO.Io _ => ()
+                     | Fail _ => ());
+             Socket.close client handle OS.SysErr _ => ();
+             release_connection_slot ();
+             Synchronized.change connection_threads
+               (filter Isabelle_Thread.is_active)))
+      in
+        Synchronized.change connection_threads (cons thread);
+        accept_loop ()
       end
       handle Fail "stopped" => ()
            | OS.SysErr _ => ();
@@ -225,6 +238,10 @@ fun stop () =
   (Synchronized.change server_socket (fn old =>
     (case old of SOME s => (Socket.close s handle OS.SysErr _ => ()) | NONE => ();
      NONE));
+   (* Interrupt connection threads so they exit blocking reads *)
+   List.app (fn t => Isabelle_Thread.interrupt_thread t handle Thread.Thread _ => ())
+     (Synchronized.value connection_threads);
+   Synchronized.change connection_threads (K []);
    Synchronized.change server_token (K NONE);
    Synchronized.change active_connections (K 0));
 


### PR DESCRIPTION
**Symptom:** Sessions with multiple `theories` blocks in ROOT failed when built remotely via I/P, with repeated "Connection refused: failed to open socket 127.0.0.1:<port>" errors. The build completed all theory loading but exited with rc=1.

**Issue:** When proxying a build to a remote machine, the proxy rewrites bash_process_address in PIDE messages so that the remote ML process connects to a remote Bash.Server instead of the local one. The build_session message carries a separate Options object per theory group, each containing bash_process_address. The rewrite only replaced the first occurrence (count=1), leaving subsequent groups with the unrewritten local address.

**Fix:** Remove the count limit from replace() for both bash_process_address and bash_process_password, so all theory groups are rewritten.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
