### PR TITLE
ir: Allow Ir.init to reference active REPLs by name

### DIFF
--- a/ir/ir.ML
+++ b/ir/ir.ML
@@ -273,8 +273,15 @@ fun parse_spec spec =
   | [thy] => (thy, NONE)
   | _ => error ("Bad spec: " ^ quote spec);
 
-(* Create a new REPL.  The theory must already be loaded — either present
-   in the initial heap or previously loaded via Ir.load_theory. *)
+(* Resolve a theory name: check active REPLs first (extracting their final
+   theory), then fall back to Thy_Info.get_theory for heap/loaded theories. *)
+fun get_theory_or_repl name =
+  case Symtab.lookup (Synchronized.value repl_tab) name of
+    SOME r => Toplevel.theory_of (last_state r)
+  | NONE => Thy_Info.get_theory name;
+
+(* Create a new REPL.  Theory specs can refer to loaded theories (in the
+   heap or via Ir.load_theory) or to active REPLs by name. *)
 fun init id specs =
   let val _ = if Symtab.defined (Synchronized.value repl_tab) id
               then error ("REPL " ^ quote id ^ " already exists")
@@ -294,7 +301,7 @@ fun init id specs =
                         then error "Cannot mix theory and segment specs in multi-theory init"
                         else ()
                 val thy_names = map #1 parsed
-                val thys = map Thy_Info.get_theory thy_names
+                val thys = map get_theory_or_repl thy_names
                 val thy = Theory.begin_theory (id, Position.none) thys
             in (From_Theory (String.concatWith "+" thy_names),
                 Toplevel.make_state (SOME thy)) end

--- a/ir/test_repl.py
+++ b/ir/test_repl.py
@@ -346,6 +346,42 @@ def core_tests(sock, prefix):
         send_recv(sock, f'Ir.remove {q(t)};')
     tests.append(("ft_negation", test_ft_negation))
 
+    def test_init_from_repl():
+        """Init a new REPL using an active REPL as theory source."""
+        src = f"{prefix}_irsrc"
+        dst = f"{prefix}_irdst"
+        send_recv(sock, f'Ir.init {q(src)} ["Main"];')
+        send_recv(sock, f'Ir.step {q(src)} "lemma {prefix}_repl_lem: True by simp";')
+        # Create dst from src — should inherit src's theory with the lemma
+        send_recv(sock, f'Ir.init {q(dst)} [{q(src)}];')
+        out = send_recv(sock, f'Ir.find_theorems {q(dst)} 3 "name: {prefix}_repl_lem";')
+        assert f"{prefix}_repl_lem" in out, \
+            f"Expected {prefix}_repl_lem visible in dst, got:\n{out}"
+        send_recv(sock, f'Ir.remove {q(dst)};')
+        send_recv(sock, f'Ir.remove {q(src)};')
+    tests.append(("init_from_repl", test_init_from_repl))
+
+    def test_init_from_repl_chain():
+        """Chain: A → B → C, lemmas from A and B visible in C."""
+        a = f"{prefix}_irca"
+        b = f"{prefix}_ircb"
+        c = f"{prefix}_ircc"
+        send_recv(sock, f'Ir.init {q(a)} ["Main"];')
+        send_recv(sock, f'Ir.step {q(a)} "lemma {prefix}_chain_a: True by simp";')
+        send_recv(sock, f'Ir.init {q(b)} [{q(a)}];')
+        send_recv(sock, f'Ir.step {q(b)} "lemma {prefix}_chain_b: True by simp";')
+        send_recv(sock, f'Ir.init {q(c)} [{q(b)}];')
+        out_a = send_recv(sock, f'Ir.find_theorems {q(c)} 3 "name: {prefix}_chain_a";')
+        assert f"{prefix}_chain_a" in out_a, \
+            f"Expected {prefix}_chain_a visible in C, got:\n{out_a}"
+        out_b = send_recv(sock, f'Ir.find_theorems {q(c)} 3 "name: {prefix}_chain_b";')
+        assert f"{prefix}_chain_b" in out_b, \
+            f"Expected {prefix}_chain_b visible in C, got:\n{out_b}"
+        send_recv(sock, f'Ir.remove {q(c)};')
+        send_recv(sock, f'Ir.remove {q(b)};')
+        send_recv(sock, f'Ir.remove {q(a)};')
+    tests.append(("init_from_repl_chain", test_init_from_repl_chain))
+
     # Cleanup: remove the shared REPL
     def cleanup():
         send_recv(sock, f'Ir.remove {q(r)};')


### PR DESCRIPTION
Add get_theory_or_repl that checks the REPL table first (extracting the final theory state) before falling back to Thy_Info.get_theory. This lets Ir.init create REPLs whose parent theories come from other active REPLs, not just heap/loaded theories.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
