### PR TITLE
Reduce use of event-dispatch thread (EDT) from I/Q

### DIFF
--- a/iq/src/IQServer.scala
+++ b/iq/src/IQServer.scala
@@ -426,87 +426,86 @@ class IQServer(
 
     Output.writeln(s"I/Q Server: Waiting for theory completion: $node_name (timeout: ${timeout_ms}, timeout_per_command: ${timeoutPerCommandMs}ms)")
 
-    // Save the original required state
+    // Save the original required state and mark node as required (single-shot EDT calls)
     val originalRequiredState = GUI_Thread.now {
       model.node_required
     }
-
     GUI_Thread.now {
       Document_Model.node_required(node_name, set = true)
     }
 
-    // Get initial status to ensure we always have a valid status object
-    var currentStatus: Document_Status.Node_Status = GUI_Thread.now {
-      val snapshot = Document_Model.snapshot(model)
+    def getNodeStatus(): Document_Status.Node_Status = {
+      val snapshot = PIDE.session.snapshot(node_name = node_name)
       val state = snapshot.state
       val version = snapshot.version
       Document_Status.Node_Status.make(Date.now(), state, version, node_name)
     }
 
-    var completed = false
-    var iterations = 0
-    var perCommandTimerStart: Option[Long] = None
+    def isCompleted(status: Document_Status.Node_Status): Boolean =
+      status.terminated &&
+        (status.consolidated ||
+         (status.unprocessed == 0 && status.running == 0))
 
-    def is_timeout() : Boolean = {
-      timeout_ms match {
-        case Some(t) => (System.currentTimeMillis() - startTime) >= t
-        case _ => false
-      }
-    }
+    // Get initial status
+    @volatile var currentStatus = getNodeStatus()
+    var completed = isCompleted(currentStatus)
 
-    while (!completed && !is_timeout()) {
-      currentStatus = GUI_Thread.now {
-        val snapshot = Document_Model.snapshot(model)
-        val state = snapshot.state
-        val version = snapshot.version
-        Document_Status.Node_Status.make(Date.now(), state, version, node_name)
-      }
+    if (!completed) {
+      val latch = new CountDownLatch(1)
+      var checkCount = 0
+      var perCommandTimerStart: Option[Long] = None
 
-      // Check completion status
-      completed = currentStatus.terminated &&
-                  (currentStatus.consolidated ||
-                   (currentStatus.unprocessed == 0 && currentStatus.running == 0))
+      val consumer = Session.Consumer[Session.Commands_Changed](
+        "IQServer.waitForTheoryCompletion"
+      ) {
+        case Session.Commands_Changed(_, nodes, _) if nodes.contains(node_name) =>
+          checkCount += 1
+          currentStatus = getNodeStatus()
 
-      // Per-command timeout logic
-      if (currentStatus.unprocessed == 0 && perCommandTimerStart.isEmpty) {
-        // First time we see unprocessed == 0, start the timer
-        perCommandTimerStart = Some(System.currentTimeMillis())
-        Output.writeln(s"I/Q Server: All commands processed, starting per-command timer for running commands")
-      }
+          if (isCompleted(currentStatus)) {
+            Output.writeln(s"I/Q Server: Theory completion achieved after $checkCount checks")
+            latch.countDown()
+          } else {
+            // Per-command timeout logic
+            if (currentStatus.unprocessed == 0 && perCommandTimerStart.isEmpty) {
+              perCommandTimerStart = Some(System.currentTimeMillis())
+              Output.writeln(s"I/Q Server: All commands processed, starting per-command timer for running commands")
+            }
 
-      // Check per-command timeout abort conditions
-      if (currentStatus.unprocessed == 0) {
-        if (currentStatus.running == 0) {
-          // No commands running, we're done
-          completed = true
-          Output.writeln(s"I/Q Server: No commands running, completion achieved")
-        } else {
-          // Check if per-command timer has fired
-          timeoutPerCommandMs match {
-            case Some(perCmdTimeout) =>
-              perCommandTimerStart match {
-                case Some(timerStart) =>
-                  val perCommandElapsed = System.currentTimeMillis() - timerStart
-                  if (perCommandElapsed >= perCmdTimeout) {
-                    Output.writeln(s"I/Q Server: Per-command timeout of ${perCmdTimeout}ms exceeded (${perCommandElapsed}ms elapsed), aborting")
-                    completed = true
-                  }
-                case None =>
-              }
-            case None => // No per-command timeout set
+            timeoutPerCommandMs match {
+              case Some(perCmdTimeout) =>
+                perCommandTimerStart match {
+                  case Some(timerStart) =>
+                    val perCommandElapsed = System.currentTimeMillis() - timerStart
+                    if (perCommandElapsed >= perCmdTimeout) {
+                      Output.writeln(s"I/Q Server: Per-command timeout of ${perCmdTimeout}ms exceeded (${perCommandElapsed}ms elapsed), aborting")
+                      latch.countDown()
+                    }
+                  case None =>
+                }
+              case None =>
+            }
+
+            // Log progress every 50 checks (~5 seconds at 100ms event interval)
+            if (checkCount % 50 == 0) {
+              Output.writeln(s"I/Q Server: Theory completion progress - unprocessed: ${currentStatus.unprocessed}, running: ${currentStatus.running}, finished: ${currentStatus.finished}, failed: ${currentStatus.failed}, terminated: ${currentStatus.terminated}, consolidated: ${currentStatus.consolidated}")
+            }
           }
+        case _ =>
+      }
+
+      PIDE.session.commands_changed += consumer
+      try {
+        // Re-check after subscribing to avoid TOCTOU race
+        currentStatus = getNodeStatus()
+        if (isCompleted(currentStatus)) {
+          latch.countDown()
         }
-      }
-
-      iterations += 1
-
-      // Log progress every 5 iterations (5 seconds)
-      if (iterations % 5 == 0) {
-        Output.writeln(s"I/Q Server: Theory completion progress - unprocessed: ${currentStatus.unprocessed}, running: ${currentStatus.running}, finished: ${currentStatus.finished}, failed: ${currentStatus.failed}, terminated: ${currentStatus.terminated}, consolidated: ${currentStatus.consolidated}")
-      }
-
-      if (!completed) {
-        Thread.sleep(1000)
+        val timeoutVal = timeout_ms.getOrElse(30000).toLong
+        val awaitResult = latch.await(timeoutVal, TimeUnit.MILLISECONDS)
+        completed = awaitResult || isCompleted(currentStatus)
+      } finally {
+        PIDE.session.commands_changed -= consumer
       }
     }
 
@@ -522,7 +521,6 @@ class IQServer(
       Document_Model.node_required(node_name, set = originalRequiredState)
     }
 
-    // Ensure we always return a valid status object
     (completed, currentStatus)
   }
 
@@ -2422,107 +2420,113 @@ class IQServer(
 
     Output.writeln(s"I/Q Server: Parameters - mode: $mode, startLine: $startLineOpt, endLine: $endLineOpt, startOffset: $startOffsetOpt, endOffset: $endOffsetOpt, filePath: $filePath, waitUntilProcessed: $waitUntilProcessed, timeout: $timeoutMs, timeout_per_command: ${timeoutPerCommandMs}ms")
 
-    // Determine mode and execute (with optional waiting loop)
+    // Determine mode and execute (with optional waiting)
     val startTime = System.currentTimeMillis()
-    val pollIntervalMs = 500L  // 500ms
-    var commandInfos: List[CommandInfo] = List.empty
-    var shouldContinue = true
-    var loopCount = 0
-    var perCommandTimerStart: Option[Long] = None
+    val node_name = model.node_name
+    @volatile var commandInfos: List[CommandInfo] = List.empty
 
-    if (waitUntilProcessed) {
-      Output.writeln(s"I/Q Server: wait_until_processed=true detected - entering polling loop with ${timeoutMs.getOrElse(0L)}ms timeout")
-    } else {
-      Output.writeln(s"I/Q Server: wait_until_processed=false - single retrieval mode")
+    def retrieveCommands(): List[CommandInfo] = {
+      val snapshot = PIDE.session.snapshot(node_name = node_name)
+      getCommandsInOffsetRange(snapshot, node_name, content, startOffset, endOffset)
     }
 
-    while (shouldContinue) {
-      loopCount += 1
-      if (waitUntilProcessed) {
-        Output.writeln(s"I/Q Server: Polling loop iteration $loopCount - retrieving commands...")
+    def allProcessed(infos: List[CommandInfo]): Boolean =
+      infos.forall { info =>
+        info.status.summary match {
+          case CommandStatusSummary.Finished |
+              CommandStatusSummary.Canceled |
+              CommandStatusSummary.Failed => true
+          case _ => false
+        }
       }
 
-      // Get commands using the same logic regardless of waiting
-      commandInfos = GUI_Thread.now {
-        getCommandsInOffsetRange(model, content, startOffset, endOffset)
+    def allProcessedOrRunning(infos: List[CommandInfo]): Boolean =
+      infos.forall { info =>
+        info.status.summary match {
+          case CommandStatusSummary.Finished |
+              CommandStatusSummary.Canceled |
+              CommandStatusSummary.Failed |
+              CommandStatusSummary.Running => true
+          case _ => false
+        }
       }
 
-      if (waitUntilProcessed) {
-        Output.writeln(s"I/Q Server: Retrieved ${commandInfos.length} commands in iteration $loopCount")
-      }
+    if (!waitUntilProcessed) {
+      Output.writeln(s"I/Q Server: wait_until_processed=false - single retrieval mode")
+      commandInfos = retrieveCommands()
+    } else {
+      Output.writeln(s"I/Q Server: wait_until_processed=true - entering event-driven wait with ${timeoutMs.getOrElse(0L)}ms timeout")
 
-      // Check if we should continue waiting
-      if (!waitUntilProcessed || commandInfos.isEmpty) {
-        // Not waiting or no commands found - exit loop
-        if (waitUntilProcessed && commandInfos.isEmpty) {
-          Output.writeln(s"I/Q Server: No commands found - exiting wait loop")
-        }
-        shouldContinue = false
-      } else {
-        // Check if all commands are processed OR running too long
-        val allCommandsProcessedOrRunning = commandInfos.forall { info =>
-          info.status.summary match {
-            case CommandStatusSummary.Finished |
-                CommandStatusSummary.Canceled |
-                CommandStatusSummary.Failed |
-                CommandStatusSummary.Running => true
-            case _ => false
-          }
-        }
+      // Initial retrieval
+      commandInfos = retrieveCommands()
 
-        if (allCommandsProcessedOrRunning && perCommandTimerStart.isEmpty) {
-          perCommandTimerStart = Some(System.currentTimeMillis())
-          Output.writeln(s"I/Q Server: All commands processed or running, starting per-command timer")
-        }
+      if (commandInfos.nonEmpty && !allProcessed(commandInfos)) {
+        val latch = new CountDownLatch(1)
+        var checkCount = 0
+        var perCommandTimerStart: Option[Long] = None
 
-        val allProcessed = commandInfos.forall { info =>
-          info.status.summary match {
-            case CommandStatusSummary.Finished |
-                CommandStatusSummary.Canceled |
-                CommandStatusSummary.Failed => true
-            case _ => false
-          }
-        }
+        val consumer = Session.Consumer[Session.Commands_Changed](
+          "IQServer.handleGetCommandCore"
+        ) {
+          case Session.Commands_Changed(_, nodes, _) if nodes.contains(node_name) =>
+            checkCount += 1
+            commandInfos = retrieveCommands()
+            Output.writeln(s"I/Q Server: Event-driven check $checkCount - retrieved ${commandInfos.length} commands")
 
-        if (allProcessed) {
-          shouldContinue = false
-        } else {
-          // Check per-command timeout
-          timeoutPerCommandMs match {
-            case Some(perCmdTimeout) =>
-              perCommandTimerStart match {
-                case Some(timerStart) =>
-                  val perCommandElapsed = System.currentTimeMillis() - timerStart
-                  if (perCommandElapsed >= perCmdTimeout) {
-                    Output.writeln(s"I/Q Server: Per-command timeout of ${perCmdTimeout}ms exceeded, aborting")
-                    shouldContinue = false
-                  }
-                case None => // Timer not started yet
+            if (commandInfos.isEmpty || allProcessed(commandInfos)) {
+              latch.countDown()
+            } else {
+              // Per-command timeout: start timer once all commands are at least running
+              if (allProcessedOrRunning(commandInfos) && perCommandTimerStart.isEmpty) {
+                perCommandTimerStart = Some(System.currentTimeMillis())
+                Output.writeln(s"I/Q Server: All commands processed or running, starting per-command timer")
               }
-            case None => // No per-command timeout set
-          }
 
-          // Check global timeout
-          val timedOut = System.currentTimeMillis() - startTime >= timeoutMs.getOrElse(0L)
+              // Check per-command timeout
+              timeoutPerCommandMs match {
+                case Some(perCmdTimeout) =>
+                  perCommandTimerStart match {
+                    case Some(timerStart) =>
+                      val perCommandElapsed = System.currentTimeMillis() - timerStart
+                      if (perCommandElapsed >= perCmdTimeout) {
+                        Output.writeln(s"I/Q Server: Per-command timeout of ${perCmdTimeout}ms exceeded, aborting")
+                        latch.countDown()
+                      }
+                    case None =>
+                  }
+                case None =>
+              }
 
-          if (timedOut) {
-            Output.writeln(s"I/Q Server: Wait timeout reached after ${timeoutMs.getOrElse(0L)}ms and $loopCount iterations")
-            shouldContinue = false
-          } else {
-            // Log status and wait before next poll
-            val statusCounts = commandInfos.groupBy { info =>
-              info.status.summary.asWire
-            }.view.mapValues(_.size).toMap
-            Output.writeln(s"I/Q Server: Iteration $loopCount - Status: ${statusCounts.map { case (k, v) => s"$k: $v" }.mkString(", ")} - waiting ${pollIntervalMs}ms...")
-            Thread.sleep(pollIntervalMs)
+              // Log status
+              val statusCounts = commandInfos.groupBy(_.status.summary.asWire).view.mapValues(_.size).toMap
+              Output.writeln(s"I/Q Server: Check $checkCount - Status: ${statusCounts.map { case (k, v) => s"$k: $v" }.mkString(", ")}")
+            }
+          case _ =>
+        }
+
+        PIDE.session.commands_changed += consumer
+        try {
+          // Re-check after subscribing to avoid TOCTOU race
+          commandInfos = retrieveCommands()
+          if (commandInfos.isEmpty || allProcessed(commandInfos)) {
+            latch.countDown()
           }
+          val timeoutVal = timeoutMs.getOrElse(5000L)
+          val completed = latch.await(timeoutVal, TimeUnit.MILLISECONDS)
+          if (!completed) {
+            Output.writeln(s"I/Q Server: Wait timeout reached after ${timeoutVal}ms and $checkCount checks")
+            // Do a final retrieval so we return the latest state
+            commandInfos = retrieveCommands()
+          }
+        } finally {
+          PIDE.session.commands_changed -= consumer
         }
       }
     }
 
     val totalElapsed = System.currentTimeMillis() - startTime
     if (waitUntilProcessed) {
-      Output.writeln(s"I/Q Server: Wait loop completed after $loopCount iterations in ${totalElapsed}ms")
+      Output.writeln(s"I/Q Server: Wait completed in ${totalElapsed}ms")
     }
 
     // Optionally dump XML results to file for all commands
@@ -3458,7 +3462,7 @@ class IQServer(
 
     Output.writeln(s"I/Q Server: Writing to theory file: $filePath (waitUntilProcessed: $waitUntilProcessed, timeout: ${timeoutMs.getOrElse(0)}ms, range: $startOffset-$endOffset)")
 
-    // Delegate to existing resource write logic
+    // Delegate to existing resource write logic.
     GUI_Thread.now {
       IQUtils.replaceTextInBuffer(buffer_model, text, startOffset, endOffset)
     }

--- a/iq/src/IQServer.scala
+++ b/iq/src/IQServer.scala
@@ -540,9 +540,20 @@ class IQServer(
   /** Flag indicating whether the server is running */
   @volatile private var isRunning = false
 
-  /** Thread pool for handling client connections */
+  /** Thread pool for handling client connections.
+   *  Threads run at MIN_PRIORITY so the OS scheduler prefers the EDT
+   *  (and other jEdit threads) when CPU is contended. */
+  private val workerCounter = new AtomicInteger(0)
   private val executor: ExecutorService =
-    Executors.newFixedThreadPool(securityConfig.maxClientThreads)
+    Executors.newFixedThreadPool(
+      securityConfig.maxClientThreads,
+      (r: Runnable) => {
+        val t = new Thread(r, s"iq-worker-${workerCounter.incrementAndGet()}")
+        t.setDaemon(true)
+        t.setPriority(Thread.MIN_PRIORITY)
+        t
+      }
+    )
 
   // Timestamp formatter for socket logging
   private val timeFormatter = DateTimeFormatter.ofPattern("HH:mm:ss.SSS")
@@ -2658,11 +2669,9 @@ class IQServer(
     }
   }
 
-  private def getCommandsInOffsetRange(model: Document_Model, content: String, startOffset: Int, endOffset: Int): List[CommandInfo] = {
-    val node_name = model.node_name
+  private def getCommandsInOffsetRange(snapshot: Document.Snapshot, node_name: Document.Node.Name, content: String, startOffset: Int, endOffset: Int): List[CommandInfo] = {
     Output.writeln(s"I/Q Server: Getting commands in offset range $startOffset-$endOffset for node: $node_name")
 
-    val snapshot = Document_Model.snapshot(model)
     val node = snapshot.get_node(node_name)
 
     val targetRange = Text.Range(startOffset, endOffset)
@@ -3154,12 +3163,10 @@ class IQServer(
     var tracked = false
 
     while (!tracked && System.currentTimeMillis() < deadline) {
-      tracked = GUI_Thread.now {
-        Document_Model.get_model(nodeName).nonEmpty
-      }
+      tracked = Document_Model.get_model(nodeName).nonEmpty
       if (!tracked) {
         try {
-          Thread.sleep(25)
+          Thread.sleep(200)
         } catch {
           case _: InterruptedException =>
             Thread.currentThread().interrupt()
@@ -4505,7 +4512,7 @@ end"""
 
         getFileContentAndModel(filePath) match {
           case (Some(content), Some(model)) =>
-            val snapshot = GUI_Thread.now { Document_Model.snapshot(model) }
+            val snapshot = PIDE.session.snapshot(node_name = model.node_name)
             val node = snapshot.get_node(model.node_name)
             if (node == null || node.commands.isEmpty) {
               Right(
@@ -5214,21 +5221,21 @@ end"""
         val lines = IQLineOffsetUtils.splitLines(content)
         val lineCount = lines.length
         
-        GUI_Thread.now {
+        {
           // Entity count from PIDE commands
-          val snapshot = Document_Model.snapshot(model)
+          val snapshot = PIDE.session.snapshot(node_name = model.node_name)
           val node = snapshot.get_node(model.node_name)
           val entityCount = if (node != null) {
-            node.command_iterator().count { case (cmd, _) => 
+            node.command_iterator().count { case (cmd, _) =>
               EntityKeywords.contains(cmd.span.name)
             }
           } else 0
-          
+
           // Processing status and diagnostics
           val nodeStatus = Document_Status.Node_Status.make(
             Date.now(), snapshot.state, snapshot.version, model.node_name
           )
-          
+
           Right(Map(
             "path" -> filePath,
             "line_count" -> lineCount,
@@ -5263,24 +5270,22 @@ end"""
 
     getFileContentAndModel(filePath) match {
       case (_, Some(model)) =>
-        GUI_Thread.now {
-          val snapshot = Document_Model.snapshot(model)
-          val nodeStatus = Document_Status.Node_Status.make(
-            Date.now(), snapshot.state, snapshot.version, model.node_name
-          )
+        val snapshot = PIDE.session.snapshot(node_name = model.node_name)
+        val nodeStatus = Document_Status.Node_Status.make(
+          Date.now(), snapshot.state, snapshot.version, model.node_name
+        )
 
-          Right(Map(
-            "path" -> filePath,
-            "fully_processed" -> (nodeStatus.terminated && nodeStatus.unprocessed == 0 && nodeStatus.running == 0),
-            "unprocessed" -> nodeStatus.unprocessed,
-            "running" -> nodeStatus.running,
-            "finished" -> nodeStatus.finished,
-            "failed" -> nodeStatus.failed,
-            "has_errors" -> (nodeStatus.failed > 0),
-            "error_count" -> nodeStatus.failed,
-            "consolidated" -> nodeStatus.consolidated
-          ))
-        }
+        Right(Map(
+          "path" -> filePath,
+          "fully_processed" -> (nodeStatus.terminated && nodeStatus.unprocessed == 0 && nodeStatus.running == 0),
+          "unprocessed" -> nodeStatus.unprocessed,
+          "running" -> nodeStatus.running,
+          "finished" -> nodeStatus.finished,
+          "failed" -> nodeStatus.failed,
+          "has_errors" -> (nodeStatus.failed > 0),
+          "error_count" -> nodeStatus.failed,
+          "consolidated" -> nodeStatus.consolidated
+        ))
       case _ => Left(s"File not tracked: $filePath")
     }
   }
@@ -5305,47 +5310,45 @@ end"""
 
     getFileContentAndModel(filePath) match {
       case (Some(content), Some(model)) =>
-        GUI_Thread.now {
-          val snapshot = Document_Model.snapshot(model)
-          val node = snapshot.get_node(model.node_name)
-          val lineDoc = Line.Document(content)
-          
-          if (node == null || node.commands.isEmpty) {
-            Right(Map("path" -> filePath, "count" -> 0, "positions" -> List.empty[Map[String, Any]]))
-          } else {
-            // Find sorry/oops commands
-            val sorryKeywords = Set("sorry", "oops")
-            val commands = node.command_iterator().toList
-            
-            // Find enclosing proof for each sorry
-            def findEnclosingProof(sorryIndex: Int): String = {
-              val proofStarters = Set("lemma", "theorem", "corollary", "proposition", "schematic_goal")
-              commands.take(sorryIndex).reverse.collectFirst {
-                case (cmd, _) if proofStarters.contains(cmd.span.name) =>
-                  EntityNamePattern.findFirstMatchIn(cmd.source.take(200))
-                    .map(_.group(1))
-                    .getOrElse(s"${cmd.span.name} (unnamed)")
-              }.getOrElse("(unknown)")
-            }
-            
-            val positions = commands.zipWithIndex.collect {
-              case ((cmd, offset), idx) if sorryKeywords.contains(cmd.span.name) =>
-                val line = lineDoc.position(offset).line + 1
-                val enclosingProof = findEnclosingProof(idx)
-                Map(
-                  "line" -> line,
-                  "keyword" -> cmd.span.name,
-                  "offset" -> offset,
-                  "in_proof" -> enclosingProof
-                )
-            }
-            
-            Right(Map(
-              "path" -> filePath,
-              "count" -> positions.length,
-              "positions" -> positions
-            ))
+        val snapshot = PIDE.session.snapshot(node_name = model.node_name)
+        val node = snapshot.get_node(model.node_name)
+        val lineDoc = Line.Document(content)
+
+        if (node == null || node.commands.isEmpty) {
+          Right(Map("path" -> filePath, "count" -> 0, "positions" -> List.empty[Map[String, Any]]))
+        } else {
+          // Find sorry/oops commands
+          val sorryKeywords = Set("sorry", "oops")
+          val commands = node.command_iterator().toList
+
+          // Find enclosing proof for each sorry
+          def findEnclosingProof(sorryIndex: Int): String = {
+            val proofStarters = Set("lemma", "theorem", "corollary", "proposition", "schematic_goal")
+            commands.take(sorryIndex).reverse.collectFirst {
+              case (cmd, _) if proofStarters.contains(cmd.span.name) =>
+                EntityNamePattern.findFirstMatchIn(cmd.source.take(200))
+                  .map(_.group(1))
+                  .getOrElse(s"${cmd.span.name} (unnamed)")
+            }.getOrElse("(unknown)")
           }
+
+          val positions = commands.zipWithIndex.collect {
+            case ((cmd, offset), idx) if sorryKeywords.contains(cmd.span.name) =>
+              val line = lineDoc.position(offset).line + 1
+              val enclosingProof = findEnclosingProof(idx)
+              Map(
+                "line" -> line,
+                "keyword" -> cmd.span.name,
+                "offset" -> offset,
+                "in_proof" -> enclosingProof
+              )
+          }
+
+          Right(Map(
+            "path" -> filePath,
+            "count" -> positions.length,
+            "positions" -> positions
+          ))
         }
       case _ => Left(s"File not tracked: $filePath")
     }

--- a/iq/src/IQUtils.scala
+++ b/iq/src/IQUtils.scala
@@ -587,23 +587,56 @@ object IQUtils {
    * Block until a document model has a stable snapshot (no pending edits).
    * This is a utility function that can be used by both the server and dockable.
    *
+   * Flushes buffer edits to the session (via PIDE.editor.flush() on the EDT)
+   * so that PIDE.session.snapshot() reflects pending changes, then uses an
+   * event-driven wait (Session.Commands_Changed listener + CountDownLatch)
+   * instead of polling, to avoid blocking the EDT.
+   *
    * @param model The document model to wait for
    * @return A tuple containing (stable snapshot, whether the original snapshot was outdated)
    */
   def blockOnStableSnapshot(model: Document_Model): (Document.Snapshot, Boolean) = {
-    val initial_snapshot = GUI_Thread.now { Document_Model.snapshot(model) }
-    val was_outdated = initial_snapshot.is_outdated
+    val node_name = model.node_name
 
-    if (!was_outdated) {
+    // Flush buffer edits so PIDE.session.snapshot() sees them
+    GUI_Thread.now { PIDE.editor.flush() }
+
+    val initial_snapshot = PIDE.session.snapshot(node_name = node_name)
+
+    if (!initial_snapshot.is_outdated) {
       (initial_snapshot, false)
     } else {
-      var current_snapshot = initial_snapshot
-      while (current_snapshot.is_outdated) {
-        // Sleep briefly to avoid tight loop
-        Thread.sleep(50)
-        current_snapshot = GUI_Thread.now { Document_Model.snapshot(model) }
+      val latch = new java.util.concurrent.CountDownLatch(1)
+      @volatile var stable_snapshot: Document.Snapshot = initial_snapshot
+
+      val consumer = Session.Consumer[Session.Commands_Changed](
+        "IQUtils.blockOnStableSnapshot"
+      ) {
+        case Session.Commands_Changed(_, nodes, _) if nodes.contains(node_name) =>
+          val snap = PIDE.session.snapshot(node_name = node_name)
+          if (!snap.is_outdated) {
+            stable_snapshot = snap
+            latch.countDown()
+          }
+        case _ =>
       }
-      (current_snapshot, true)
+
+      PIDE.session.commands_changed += consumer
+      try {
+        // Re-check after subscribing to avoid TOCTOU race
+        val recheck = PIDE.session.snapshot(node_name = node_name)
+        if (!recheck.is_outdated) {
+          stable_snapshot = recheck
+          latch.countDown()
+        }
+        val completed = latch.await(30, java.util.concurrent.TimeUnit.SECONDS)
+        if (!completed) {
+          Output.warning(s"I/Q: blockOnStableSnapshot timed out after 30s for $node_name")
+        }
+      } finally {
+        PIDE.session.commands_changed -= consumer
+      }
+      (stable_snapshot, true)
     }
   }
 }


### PR DESCRIPTION
* [refactor] I/Q: Avoid EDT for read-only PIDE snapshots

  Several MCP tool handlers blocked the EDT to obtain snapshots they
only read. Use PIDE.session.snapshot(node_name) directly from the
worker thread instead.

  Name worker threads iq-worker-N, set daemon + MIN_PRIORITY so the
OS scheduler prefers the EDT when CPU is contended.

* I/Q: Replace polling loops with event-driven waiting

  Theory completion, command retrieval, and stable-snapshot waits all
polled with Thread.sleep, stalling the calling thread and — in some
paths — the EDT. jEdit would freeze for the duration of long-running
proof checks.

  Subscribe to Session.Commands_Changed and count down a latch when
the target condition is met. Re-check immediately after subscribing
to close the TOCTOU window. Add PIDE.editor.flush() after
write_to_theory so PIDE.session.snapshot() reflects the pending
edit without an EDT round-trip.