### PR TITLE
Fixed various IQ/IR issues

### DIFF
--- a/ip/ip_plugin/Makefile
+++ b/ip/ip_plugin/Makefile
@@ -6,6 +6,8 @@ endif
 
 PLUGIN_DIR := $(shell pwd)
 ISABELLE_HOME ?= /Applications/Isabelle2025-2.app
+JAVA_HOME ?= $(shell ls -d $(ISABELLE_HOME)/contrib/jdk-*/arm64-darwin 2>/dev/null | head -1)
+export JAVA_HOME
 JEDIT_DIR := $(shell ls -d $(ISABELLE_HOME)/contrib/jedit-* 2>/dev/null | head -1)
 JEDIT_JAR ?= $(JEDIT_DIR)/jedit5.7.0-patched/jedit.jar
 SCALA_HOME ?= $(ISABELLE_HOME)/contrib/scala-3.3.4

--- a/iq/src/Extended_Query_Operation.scala
+++ b/iq/src/Extended_Query_Operation.scala
@@ -265,12 +265,18 @@ class Extended_Query_Operation(
         }
     }
 
+  @volatile private var active = false
+
   def activate(): Unit = {
     editor.session.commands_changed += main
+    active = true
   }
 
   def deactivate(): Unit = {
-    editor.session.commands_changed -= main
-    cleanup_state()
+    if (active) {
+      active = false
+      editor.session.commands_changed -= main
+      cleanup_state()
+    }
   }
 }

--- a/iq/src/IQNormalization.scala
+++ b/iq/src/IQNormalization.scala
@@ -106,6 +106,16 @@ object IQNormalization {
       val endOffset =
         if (endIdx < normalized.offsetMap.length) normalized.offsetMap(endIdx)
         else text.length
+
+      // Guard: if the pattern contains newlines, the original-text slice must
+      // have the same count.  Whitespace compression can collapse \n runs into
+      // a single space, widening the match across blank-line boundaries.
+      if (substring.contains('\n')) {
+        val patternNewlines = substring.count(_ == '\n')
+        val sliceNewlines   = text.substring(startOffset, endOffset).count(_ == '\n')
+        if (patternNewlines != sliceNewlines) return Left(SubstringNotFound)
+      }
+
       Right((startOffset, endOffset))
     }
   }

--- a/iq/src/IQServer.scala
+++ b/iq/src/IQServer.scala
@@ -2907,6 +2907,17 @@ class IQServer(
     *         - Option[String]: The file content if successful, None otherwise
     *         - Option[Document_Model]: The model if one exists, None otherwise
     */
+  private def getDocumentModel(filePath: String): Option[Document_Model] = {
+    try {
+      val nodeName = PIDE.resources.node_name(filePath)
+      Document_Model.get_model(nodeName)
+    } catch {
+      case ex: Exception =>
+        Output.writeln(s"I/Q Server: Error getting document model: ${ex.getMessage}")
+        None
+    }
+  }
+
   private def getFileContentAndModel(filePath: String): (Option[String], Option[Document_Model]) = {
     try {
       // Convert the file path to a node name
@@ -5333,27 +5344,27 @@ end"""
       case None => return Left("Missing required parameter: path")
     }
 
-    getFileContentAndModel(filePath) match {
-      case (_, Some(model)) =>
-        GUI_Thread.now {
-          val snapshot = Document_Model.snapshot(model)
-          val nodeStatus = Document_Status.Node_Status.make(
-            Date.now(), snapshot.state, snapshot.version, model.node_name
-          )
+    // Counter read only — kept off-EDT so polling loops never stall behind UI rendering.
+    // Uses getDocumentModel (not getFileContentAndModel) to avoid touching jEdit buffers.
+    getDocumentModel(filePath) match {
+      case Some(model) =>
+        val snapshot = Document_Model.snapshot(model)
+        val nodeStatus = Document_Status.Node_Status.make(
+          Date.now(), snapshot.state, snapshot.version, model.node_name
+        )
 
-          Right(Map(
-            "path" -> filePath,
-            "fully_processed" -> (nodeStatus.terminated && nodeStatus.unprocessed == 0 && nodeStatus.running == 0),
-            "unprocessed" -> nodeStatus.unprocessed,
-            "running" -> nodeStatus.running,
-            "finished" -> nodeStatus.finished,
-            "failed" -> nodeStatus.failed,
-            "has_errors" -> (nodeStatus.failed > 0),
-            "error_count" -> nodeStatus.failed,
-            "consolidated" -> nodeStatus.consolidated
-          ))
-        }
-      case _ => Left(s"File not tracked: $filePath")
+        Right(Map(
+          "path" -> filePath,
+          "fully_processed" -> (nodeStatus.terminated && nodeStatus.unprocessed == 0 && nodeStatus.running == 0),
+          "unprocessed" -> nodeStatus.unprocessed,
+          "running" -> nodeStatus.running,
+          "finished" -> nodeStatus.finished,
+          "failed" -> nodeStatus.failed,
+          "has_errors" -> (nodeStatus.failed > 0),
+          "error_count" -> nodeStatus.failed,
+          "consolidated" -> nodeStatus.consolidated
+        ))
+      case None => Left(s"File not tracked: $filePath")
     }
   }
 

--- a/iq/src/IQServer.scala
+++ b/iq/src/IQServer.scala
@@ -1225,7 +1225,7 @@ class IQServer(
           safeOutput(s"I/Q Server: Unknown tool name: '$name'")
           Left((ErrorCodes.METHOD_NOT_FOUND, s"Unknown tool: $name"))
         case Left(err) =>
-          Right(wrapToolCallResult(Map("text" -> err.message), isError = true))
+          Left((err.code, err.message))
       }
     } catch {
       case ex: Exception =>
@@ -1829,7 +1829,9 @@ class IQServer(
       ),
       Map(
         "name" -> "get_diagnostics",
-        "description" -> "Read-only diagnostics retrieval for errors or warnings in either a canonical command selection or an entire file.",
+        "description" -> ("Read-only diagnostics retrieval for errors or warnings in either a canonical command selection or an entire file. " +
+          "Response also carries processing state for the target (is_fully_processed, unprocessed, running, finished) so an " +
+          "empty diagnostics list can be distinguished from 'file still being processed'."),
         "inputSchema" -> Map(
           "type" -> "object",
           "properties" -> Map(
@@ -4687,6 +4689,24 @@ end"""
       .toList
   }
 
+  private def processingStatusFields(
+      snapshot: Document.Snapshot,
+      nodeName: Document.Node.Name
+  ): Map[String, Any] = {
+    val nodeStatus = Document_Status.Node_Status.make(
+      Date.now(), snapshot.state, snapshot.version, nodeName
+    )
+    val fullyProcessed = nodeStatus.terminated &&
+                         nodeStatus.unprocessed == 0 &&
+                         nodeStatus.running == 0
+    Map(
+      "is_fully_processed" -> fullyProcessed,
+      "unprocessed" -> nodeStatus.unprocessed,
+      "running" -> nodeStatus.running,
+      "finished" -> nodeStatus.finished
+    )
+  }
+
   private def handleGetDiagnostics(
       params: Map[String, Any]
   ): Either[String, Map[String, Any]] = {
@@ -4741,7 +4761,7 @@ end"""
                 "node_name" -> model.node_name.toString,
                 "count" -> diagnostics.length,
                 "diagnostics" -> diagnostics
-              )
+              ) ++ processingStatusFields(snapshot, model.node_name)
             )
           case _ =>
             Left(
@@ -4778,7 +4798,7 @@ end"""
               "command" -> commandInfoMap(command),
               "count" -> diagnostics.length,
               "diagnostics" -> diagnostics
-            )
+            ) ++ processingStatusFields(snapshot, command.node_name)
           }
         }
       }

--- a/iq/src/IQServer.scala
+++ b/iq/src/IQServer.scala
@@ -1909,6 +1909,16 @@ class IQServer(
             "max_results" -> Map(
               "type" -> "integer",
               "description" -> "Optional result limit for query='find_theorems'. Values <= 0 are ignored and default 20 is used."
+            ),
+            "max_chars_per_result" -> Map(
+              "type" -> "integer",
+              "description" -> ("Optional per-result size cap in characters; results longer than this are truncated with a trailing marker. " +
+                s"Default ${ExploreResultCollector.DefaultMaxCharsPerResult}. Set to 0 to disable.")
+            ),
+            "max_total_chars" -> Map(
+              "type" -> "integer",
+              "description" -> ("Optional total response-body size cap in characters (applied after joining results). " +
+                s"Default ${ExploreResultCollector.DefaultMaxTotalChars}. Set to 0 to disable.")
             )
           ),
           "required" -> List("query", "command_selection"),
@@ -4822,6 +4832,14 @@ end"""
         case Right(v) => v
         case Left(err) => return Left(err)
       }
+      val maxCharsPerResult = IQArgumentUtils.optionalIntParam(params, "max_chars_per_result") match {
+        case Right(v) => v.getOrElse(ExploreResultCollector.DefaultMaxCharsPerResult)
+        case Left(err) => return Left(err)
+      }
+      val maxTotalChars = IQArgumentUtils.optionalIntParam(params, "max_total_chars") match {
+        case Right(v) => v.getOrElse(ExploreResultCollector.DefaultMaxTotalChars)
+        case Left(err) => return Left(err)
+      }
 
       if (query.isEmpty) {
         return Left("Missing required parameter: query")
@@ -4841,9 +4859,9 @@ end"""
         resolveTargetSelection(selection).map { resolvedTarget =>
           // Check if this is a batch find_theorems query (semicolon-separated patterns)
           if (parsedQuery == ExploreQuery.FindTheorems && arguments.contains(";")) {
-            executeBatchFindTheorems(resolvedTarget, arguments, maxResults)
+            executeBatchFindTheorems(resolvedTarget, arguments, maxResults, maxCharsPerResult, maxTotalChars)
           } else {
-            executeExploration(resolvedTarget, parsedQuery, arguments, maxResults)
+            executeExploration(resolvedTarget, parsedQuery, arguments, maxResults, maxCharsPerResult, maxTotalChars)
           }
         }
       }
@@ -4871,10 +4889,12 @@ end"""
   private def executeBatchFindTheorems(
     resolvedTarget: IQUtils.TargetResolution,
     patterns: String,
-    maxResults: Option[Int]
+    maxResults: Option[Int],
+    maxCharsPerResult: Int,
+    maxTotalChars: Int
   ): Map[String, Any] = {
     val patternList = patterns.split(";").map(_.trim).filter(_.nonEmpty).toList
-    
+
     if (patternList.isEmpty) {
       return Map(
         "success" -> false,
@@ -4883,19 +4903,20 @@ end"""
         "message" -> "Empty pattern list after splitting by semicolon"
       )
     }
-    
+
     Output.writeln(s"I/Q Server: Executing batch find_theorems with ${patternList.length} patterns")
-    
+
     // Execute each pattern query and collect results
     val allResults = scala.collection.mutable.ListBuffer[String]()
     var anySuccess = false
     var anyTimedOut = false
     val errors = scala.collection.mutable.ListBuffer[String]()
-    
+
     for ((pattern, idx) <- patternList.zipWithIndex) {
       Output.writeln(s"I/Q Server: Running find_theorems query ${idx + 1}/${patternList.length}: $pattern")
-      val result = executeExploration(resolvedTarget, ExploreQuery.FindTheorems, pattern, maxResults)
-      
+      // Pass per-result cap but disable per-call total cap: the total cap applies to the aggregated output below.
+      val result = executeExploration(resolvedTarget, ExploreQuery.FindTheorems, pattern, maxResults, maxCharsPerResult, 0)
+
       if (boolField(result, "success")) {
         anySuccess = true
         val results = stringField(result, "results").trim
@@ -4908,8 +4929,10 @@ end"""
         result.get("error").foreach(err => errors += s"Pattern ${idx + 1} ($pattern): ${err.toString}")
       }
     }
-    
-    val aggregatedResults = if (allResults.nonEmpty) allResults.mkString("\n\n") else "No results"
+
+    val aggregatedResults =
+      if (allResults.isEmpty) "No results"
+      else ExploreResultCollector.truncateResults(allResults.toList, 0, maxTotalChars)
     val message = if (anySuccess && allResults.nonEmpty) {
       s"Batch find_theorems completed: ${allResults.length} of ${patternList.length} patterns found results"
     } else if (anyTimedOut) {
@@ -4930,6 +4953,30 @@ end"""
       "patterns_count" -> patternList.length,
       "successful_patterns" -> allResults.length
     ) ++ (if (errors.nonEmpty) Map("errors" -> errors.toList) else Map.empty)
+  }
+
+  private object ExploreResultCollector {
+    val DefaultMaxCharsPerResult: Int = 5000
+    val DefaultMaxTotalChars: Int = 100000
+
+    def truncateResults(
+        results: List[String],
+        maxCharsPerResult: Int,
+        maxTotalChars: Int
+    ): String = {
+      val capped =
+        if (maxCharsPerResult <= 0) results
+        else results.map(r =>
+          if (r.length > maxCharsPerResult)
+            r.take(maxCharsPerResult) +
+              s"\n… (result truncated: ${r.length - maxCharsPerResult} more chars)"
+          else r
+        )
+      val joined = capped.mkString("\n\n")
+      if (maxTotalChars <= 0 || joined.length <= maxTotalChars) joined
+      else joined.take(maxTotalChars) +
+        s"\n\n… (response truncated: ${joined.length - maxTotalChars} more chars)"
+    }
   }
 
   /**
@@ -4984,7 +5031,10 @@ end"""
       }
     }
 
-    def getResultsAsString(): String = {
+    def getResultsAsString(
+        maxCharsPerResult: Int = ExploreResultCollector.DefaultMaxCharsPerResult,
+        maxTotalChars: Int = ExploreResultCollector.DefaultMaxTotalChars
+    ): String = {
       val resultsSnapshot = xmlResults
       // Debug: log result collection
       Output.writeln(s"I/Q Server: Getting results as string, xmlResults.size=${resultsSnapshot.size}")
@@ -5014,9 +5064,9 @@ end"""
       } else {
         // Apply sledgehammer-specific filtering
         if (queryType == "sledgehammer") {
-          filterSledgehammerResults(results)
+          filterSledgehammerResults(results, maxTotalChars)
         } else {
-          results.mkString("\n\n")
+          ExploreResultCollector.truncateResults(results, maxCharsPerResult, maxTotalChars)
         }
       }
     }
@@ -5025,7 +5075,7 @@ end"""
      * Filters sledgehammer results to only include those with "Try this: .* ms)"
      * that have been successfully replayed.
      */
-    private def filterSledgehammerResults(results: List[String]): String = {
+    private def filterSledgehammerResults(results: List[String], maxTotalChars: Int): String = {
       // Fixed regex to handle prover name before "Try this" and decimal milliseconds
       val tryThisPattern = """.*Try this:\s+(.+?)\s+\((\d+(?:\.\d+)?)\s*ms\)""".r
 
@@ -5051,7 +5101,7 @@ end"""
         distinctResults.foreach { result =>
           Output.writeln(s"I/Q Server: Final result: ${result.take(100)}")
         }
-        distinctResults.mkString("\n\n")
+        ExploreResultCollector.truncateResults(distinctResults, 0, maxTotalChars)
       }
     }
 
@@ -5075,7 +5125,9 @@ end"""
     resolvedTarget: IQUtils.TargetResolution,
     query: ExploreQuery,
     arguments: String,
-    maxResults: Option[Int]
+    maxResults: Option[Int],
+    maxCharsPerResult: Int = ExploreResultCollector.DefaultMaxCharsPerResult,
+    maxTotalChars: Int = ExploreResultCollector.DefaultMaxTotalChars
   ): Map[String, Any] = {
 
     try {
@@ -5167,7 +5219,7 @@ end"""
           "arguments" -> finalArguments,
           "selection" -> targetSelectionToMap(resolvedTarget.selection),
           "command_found" -> displayText,
-          "results" -> collector.getResultsAsString(),
+          "results" -> collector.getResultsAsString(maxCharsPerResult, maxTotalChars),
           "timed_out" -> timedOut,
           "message" -> (if (timedOut) "Query timed out after 30 seconds"
                         else if (collector.wasSuccessful())

--- a/iq/src/IQServer.scala
+++ b/iq/src/IQServer.scala
@@ -435,95 +435,95 @@ class IQServer(
       Document_Model.node_required(node_name, set = true)
     }
 
-    // Get initial status to ensure we always have a valid status object
-    var currentStatus: Document_Status.Node_Status = GUI_Thread.now {
-      val snapshot = Document_Model.snapshot(model)
-      val state = snapshot.state
-      val version = snapshot.version
-      Document_Status.Node_Status.make(Date.now(), state, version, node_name)
-    }
-
-    var completed = false
-    var iterations = 0
-    var perCommandTimerStart: Option[Long] = None
-
-    def is_timeout() : Boolean = {
-      timeout_ms match {
-        case Some(t) => (System.currentTimeMillis() - startTime) >= t
-        case _ => false
-      }
-    }
-
-    while (!completed && !is_timeout()) {
-      currentStatus = GUI_Thread.now {
+    try {
+      // Get initial status to ensure we always have a valid status object
+      var currentStatus: Document_Status.Node_Status = GUI_Thread.now {
         val snapshot = Document_Model.snapshot(model)
         val state = snapshot.state
         val version = snapshot.version
         Document_Status.Node_Status.make(Date.now(), state, version, node_name)
       }
 
-      // Check completion status
-      completed = currentStatus.terminated &&
-                  (currentStatus.consolidated ||
-                   (currentStatus.unprocessed == 0 && currentStatus.running == 0))
+      var completed = false
+      var iterations = 0
+      var perCommandTimerStart: Option[Long] = None
 
-      // Per-command timeout logic
-      if (currentStatus.unprocessed == 0 && perCommandTimerStart.isEmpty) {
-        // First time we see unprocessed == 0, start the timer
-        perCommandTimerStart = Some(System.currentTimeMillis())
-        Output.writeln(s"I/Q Server: All commands processed, starting per-command timer for running commands")
-      }
-
-      // Check per-command timeout abort conditions
-      if (currentStatus.unprocessed == 0) {
-        if (currentStatus.running == 0) {
-          // No commands running, we're done
-          completed = true
-          Output.writeln(s"I/Q Server: No commands running, completion achieved")
-        } else {
-          // Check if per-command timer has fired
-          timeoutPerCommandMs match {
-            case Some(perCmdTimeout) =>
-              perCommandTimerStart match {
-                case Some(timerStart) =>
-                  val perCommandElapsed = System.currentTimeMillis() - timerStart
-                  if (perCommandElapsed >= perCmdTimeout) {
-                    Output.writeln(s"I/Q Server: Per-command timeout of ${perCmdTimeout}ms exceeded (${perCommandElapsed}ms elapsed), aborting")
-                    completed = true
-                  }
-                case None =>
-              }
-            case None => // No per-command timeout set
-          }
+      def is_timeout() : Boolean = {
+        timeout_ms match {
+          case Some(t) => (System.currentTimeMillis() - startTime) >= t
+          case _ => false
         }
       }
 
-      iterations += 1
+      while (!completed && !is_timeout()) {
+        currentStatus = GUI_Thread.now {
+          val snapshot = Document_Model.snapshot(model)
+          val state = snapshot.state
+          val version = snapshot.version
+          Document_Status.Node_Status.make(Date.now(), state, version, node_name)
+        }
 
-      // Log progress every 5 iterations (5 seconds)
-      if (iterations % 5 == 0) {
-        Output.writeln(s"I/Q Server: Theory completion progress - unprocessed: ${currentStatus.unprocessed}, running: ${currentStatus.running}, finished: ${currentStatus.finished}, failed: ${currentStatus.failed}, terminated: ${currentStatus.terminated}, consolidated: ${currentStatus.consolidated}")
+        // Check completion status
+        completed = currentStatus.terminated &&
+                    (currentStatus.consolidated ||
+                     (currentStatus.unprocessed == 0 && currentStatus.running == 0))
+
+        // Per-command timeout logic
+        if (currentStatus.unprocessed == 0 && perCommandTimerStart.isEmpty) {
+          // First time we see unprocessed == 0, start the timer
+          perCommandTimerStart = Some(System.currentTimeMillis())
+          Output.writeln(s"I/Q Server: All commands processed, starting per-command timer for running commands")
+        }
+
+        // Check per-command timeout abort conditions
+        if (currentStatus.unprocessed == 0) {
+          if (currentStatus.running == 0) {
+            // No commands running, we're done
+            completed = true
+            Output.writeln(s"I/Q Server: No commands running, completion achieved")
+          } else {
+            // Check if per-command timer has fired
+            timeoutPerCommandMs match {
+              case Some(perCmdTimeout) =>
+                perCommandTimerStart match {
+                  case Some(timerStart) =>
+                    val perCommandElapsed = System.currentTimeMillis() - timerStart
+                    if (perCommandElapsed >= perCmdTimeout) {
+                      Output.writeln(s"I/Q Server: Per-command timeout of ${perCmdTimeout}ms exceeded (${perCommandElapsed}ms elapsed), aborting")
+                      completed = true
+                    }
+                  case None =>
+                }
+              case None => // No per-command timeout set
+            }
+          }
+        }
+
+        iterations += 1
+
+        // Log progress every 5 iterations (5 seconds)
+        if (iterations % 5 == 0) {
+          Output.writeln(s"I/Q Server: Theory completion progress - unprocessed: ${currentStatus.unprocessed}, running: ${currentStatus.running}, finished: ${currentStatus.finished}, failed: ${currentStatus.failed}, terminated: ${currentStatus.terminated}, consolidated: ${currentStatus.consolidated}")
+        }
+
+        if (!completed) {
+          Thread.sleep(1000)
+        }
       }
 
-      if (!completed) {
-        Thread.sleep(1000)
+      val elapsedMs = System.currentTimeMillis() - startTime
+      if (completed) {
+        Output.writeln(s"I/Q Server: Theory completion succeeded after ${elapsedMs}ms")
+      } else {
+        Output.writeln(s"I/Q Server: Theory completion timed out after ${elapsedMs}ms")
+      }
+
+      (completed, currentStatus)
+    } finally {
+      GUI_Thread.now {
+        Document_Model.node_required(node_name, set = originalRequiredState)
       }
     }
-
-    val elapsedMs = System.currentTimeMillis() - startTime
-    if (completed) {
-      Output.writeln(s"I/Q Server: Theory completion succeeded after ${elapsedMs}ms")
-    } else {
-      Output.writeln(s"I/Q Server: Theory completion timed out after ${elapsedMs}ms")
-    }
-
-    // Restore the original required state
-    GUI_Thread.now {
-      Document_Model.node_required(node_name, set = originalRequiredState)
-    }
-
-    // Ensure we always return a valid status object
-    (completed, currentStatus)
   }
 
   /**
@@ -5166,6 +5166,7 @@ end"""
         s"I/Q Server: Starting query execution for $internalQuery with arguments: $formattedArgs"
       )
 
+      var operationToCleanup: Extended_Query_Operation = null
       try {
         val operation = GUI_Thread.now {
           val activeView = jEdit.getActiveView()
@@ -5187,6 +5188,7 @@ end"""
 
           Output.writeln("I/Q Server: Activating operation and applying query")
           operation.activate()
+          operationToCleanup = operation
 
           Output.writeln(s"I/Q Server: Formatted args: $formattedArgs")
           operation.apply_query_at_command(command, formattedArgs)
@@ -5215,9 +5217,10 @@ end"""
           s"I/Q Server: Finished waiting after ${elapsed}ms, isFinished=${collector.isFinished()}"
         )
 
-        Output.writeln("I/Q Server: Deactivating operation")
-        GUI_Thread.now {
-          operation.deactivate()
+        if (!completedInTime) {
+          Output.writeln("I/Q Server: Query timed out, cancelling ML execution")
+          try { GUI_Thread.now { operation.cancel_query() } }
+          catch { case _: Exception => }
         }
 
         val timedOut = !completedInTime
@@ -5254,6 +5257,11 @@ end"""
             "results" -> "",
             "message" -> s"Failed to execute query operation due to linkage error: ${throwableMessage(err)}"
           )
+      } finally {
+        if (operationToCleanup != null) {
+          try { GUI_Thread.now { operationToCleanup.deactivate() } }
+          catch { case _: Exception => }
+        }
       }
 
     } catch {

--- a/iq/src/test/scala/IQNormalizationTest.scala
+++ b/iq/src/test/scala/IQNormalizationTest.scala
@@ -475,6 +475,21 @@ object IQNormalizationTest {
       IQNormalization.SubstringNotUnique,
       "non-unique single char")
 
+    // Newline-count invariant: pattern with 1 newline must not match a span with 2
+    assertLeft(
+      IQNormalization.findUniqueMatch("(* comment *)\n\n  code", "(* comment *)\n  code"),
+      IQNormalization.SubstringNotFound,
+      "newline count mismatch: 1 vs 2 newlines")
+
+    // Same-newline-count match should still succeed
+    locally {
+      val (start, end) = assertRight(
+        IQNormalization.findUniqueMatch("(* comment *)\n  code", "(* comment *)\n  code"),
+        "newline count match: 1 vs 1")
+      assertEquals(start, 0, "newline match: start")
+      assertEquals(end, 20, "newline match: end")
+    }
+
     // Performance sanity: normalize a moderately large string
     locally {
       val largeText = "hello \\<Rightarrow> world " * 1000

--- a/ir/ir.ML
+++ b/ir/ir.ML
@@ -43,6 +43,8 @@ sig
   val sledgehammer_result : string Synchronized.var
   val find_theorems : string -> int -> string -> unit
   val timeout : string -> int -> unit
+  val epoch : unit -> string
+  val print_epoch : unit -> unit
   val is_interactive_session : unit -> bool
   val help : unit -> unit
 end;
@@ -65,6 +67,16 @@ fun get_cfg () = Synchronized.value cfg;
 (** Default step timeout (seconds, 0 = no limit) **)
 
 val default_timeout : int = 10;
+
+(** Server epoch — unique per ML process lifetime **)
+
+val ir_epoch : string =
+  let val now = Time.now ()
+      val date_part = Date.fmt "%Y%m%dT%H%M%S" (Date.fromTimeLocal now)
+      val ms = LargeInt.toString (Time.toMilliseconds now mod 1000)
+  in date_part ^ "." ^ StringCvt.padLeft #"0" 3 ms end;
+fun epoch () = ir_epoch;
+fun print_epoch () = out ("SERVER_EPOCH=" ^ ir_epoch);
 
 (** Markup-based token rendering **)
 
@@ -397,7 +409,9 @@ fun show id =
                     indent ^ render_isar_text thy text ^ stale_mark);
                pr (i + 1) rest
             end
-  in pr 0 (#steps r) end;
+  in pr 0 (#steps r);
+     out ("SERVER_EPOCH=" ^ ir_epoch)
+  end;
 
 fun text id =
   let val r = the_repl id
@@ -513,6 +527,7 @@ fun repls () =
             ", from " ^ orig ^ ")"
     in out ("    " ^ desc)
     end) (Synchronized.value repl_tab) ();
+  out ("SERVER_EPOCH=" ^ ir_epoch);
 
 (* Lists theories in the initial heap plus those loaded via load_theory. *)
 fun theories () =

--- a/ir/mcp_server.py
+++ b/ir/mcp_server.py
@@ -40,6 +40,7 @@ MCP configuration for communication via streaming-http
 """
 
 import asyncio
+import os
 import sys
 if hasattr(sys.stdout, "reconfigure"):
     sys.stdout.reconfigure(line_buffering=True)
@@ -67,6 +68,7 @@ class ReplClient:
         self.host = host
         self.port = port
         self.token = token
+        self.recv_timeout = int(os.environ.get("IR_REPL_RECV_TIMEOUT", "600"))
 
     def connect(self, host: str | None = None, port: int | None = None,
                 token: str | None = None):
@@ -106,12 +108,17 @@ class ReplClient:
         if not self.token:
             raise RuntimeError("Not connected — call the 'connect' tool first")
         sock = socket.create_connection((self.host, self.port))
+        sock.settimeout(self.recv_timeout)
         try:
             # Authenticate
             sock.sendall((self.token + "\n").encode())
             auth_buf = b""
             while b"\n" not in auth_buf:
-                chunk = sock.recv(1024)
+                try:
+                    chunk = sock.recv(1024)
+                except socket.timeout:
+                    raise RuntimeError(
+                        f"I/R auth handshake unresponsive for {self.recv_timeout}s")
                 if not chunk:
                     raise RuntimeError("Connection closed during auth handshake")
                 auth_buf += chunk
@@ -125,7 +132,12 @@ class ReplClient:
             # Read until sentinel
             buf = b""
             while True:
-                chunk = sock.recv(4096)
+                try:
+                    chunk = sock.recv(4096)
+                except socket.timeout:
+                    raise RuntimeError(
+                        f"I/R server unresponsive for {self.recv_timeout}s — "
+                        "check ML process health")
                 if not chunk:
                     raise EOFError("Connection closed by repl.py")
                 buf += chunk

--- a/ir/mcp_server.py
+++ b/ir/mcp_server.py
@@ -69,6 +69,7 @@ class ReplClient:
         self.port = port
         self.token = token
         self.recv_timeout = int(os.environ.get("IR_REPL_RECV_TIMEOUT", "600"))
+        self._last_epoch: str | None = None
 
     def connect(self, host: str | None = None, port: int | None = None,
                 token: str | None = None):
@@ -81,6 +82,30 @@ class ReplClient:
         # Probe reachability
         sock = socket.create_connection((self.host, self.port))
         sock.close()
+
+    def _check_epoch(self, result: str) -> tuple[str, str | None]:
+        """Extract SERVER_EPOCH line; warn if the ML process restarted."""
+        lines = result.split("\n")
+        epoch_line = None
+        rest = []
+        for line in lines:
+            if line.startswith("SERVER_EPOCH="):
+                epoch_line = line
+            else:
+                rest.append(line)
+        cleaned = "\n".join(rest)
+        if epoch_line is None:
+            return (cleaned, None)
+        new_epoch = epoch_line.split("=", 1)[1]
+        warning = None
+        if self._last_epoch is not None and new_epoch != self._last_epoch:
+            warning = (
+                f"[WARNING] I/R ML process restarted since last call "
+                f"(epoch was {self._last_epoch}, now {new_epoch}) — "
+                f"all previous REPL state is gone"
+            )
+        self._last_epoch = new_epoch
+        return (cleaned, warning)
 
     def disconnect(self):
         pass
@@ -147,6 +172,9 @@ class ReplClient:
                     result = apply_transforms(raw)
                     if result.startswith("ERR\n"):
                         raise RuntimeError(result[4:])
+                    result, epoch_warning = self._check_epoch(result)
+                    if epoch_warning:
+                        result = epoch_warning + "\n" + result
                     return result
         finally:
             sock.close()
@@ -252,6 +280,10 @@ async def connect(token: str, port: int = 0, ctx: Context = None) -> str:
         port = _repl_port
     client = _get_client(ctx)
     await asyncio.to_thread(client.connect, "127.0.0.1", port, token)
+    try:
+        await asyncio.to_thread(client.send, "Ir.print_epoch ();")
+    except Exception:
+        pass
     return f"Connected to {client.host}:{client.port}\n\n{await session_info(ctx=ctx)}"
 
 @mcp.tool(description="Disconnect from the I/R REPL server.")


### PR DESCRIPTION
  Fixes six bugs reported during use of the I/Q and I/R MCP servers:

  - get_diagnostics now reports processing status — responses include is_fully_processed, unprocessed, running, and finished fields, so an empty diagnostics list can be distinguished from
   "file still being processed". Also fixes capability-backend InvalidParams errors to surface as proper JSON-RPC protocol errors instead of being silently wrapped as tool results.
  - explore output is size-capped — new optional max_chars_per_result (default 5000) and max_total_chars (default 100000) MCP parameters prevent find_theorems from returning 400KB+
  responses when called at deep-record contexts. Set either to 0 to disable.
  - str_replace no longer collapses newlines across match boundaries — whitespace normalization could collapse \n runs into a single space, causing a pattern with one newline to match a
  span containing two. Adds a post-match newline-count invariant so mismatches return "not found" instead of silently eating blank lines.
  - get_processing_status no longer blocks on the Swing EDT — the handler was wrapped in GUI_Thread.now for a pure counter read, causing up to 60s stalls when PIDE was rendering large
  theories. Uses a new getDocumentModel helper that avoids touching jEdit buffers, keeping the entire operation off-EDT.
  - I/R MCP bridge has a recv timeout — send() now sets a configurable socket timeout (IR_REPL_RECV_TIMEOUT env var, default 600s) with clear error messages distinguishing "auth handshake
   timeout" from "ML server unresponsive".
  - I/R exposes ML-process epoch for restart detection — generates a millisecond-resolution timestamp at ML startup, appended to show/repls output. The Python bridge compares against the
  last-seen epoch and prepends a [WARNING] I/R ML process restarted message on mismatch. Epoch is seeded on connect so restarts are detected on the next show/repls call.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
