### PR TITLE
Harden I/R for concurrent usage

### DIFF
--- a/ir/ir.ML
+++ b/ir/ir.ML
@@ -242,6 +242,15 @@ fun the_repl id = get_repl_in (Synchronized.value repl_tab) id;
 fun update_repl id r =
   Synchronized.change repl_tab (Symtab.update (id, Repl r));
 
+fun descendants tab id =
+  let fun is_desc rid =
+        case Symtab.lookup tab rid of
+          SOME entry => (case entry_origin entry of
+            From_REPL (pid, _) => pid = id orelse is_desc pid
+          | _ => false)
+        | NONE => false
+  in filter is_desc (Symtab.keys tab) end;
+
 fun timeout id secs =
   let val _ = the_repl id
       val _ = Synchronized.change repl_tab (Symtab.map_entry id
@@ -479,14 +488,17 @@ fun truncate id raw_idx =
       val _ = if idx < ~1 orelse idx >= n
               then error ("Step " ^ string_of_int raw_idx ^ " out of range ("
                           ^ string_of_int n ^ " steps)") else ()
-      (* Remove sub-REPLs attached to dropped steps *)
+      (* Remove sub-REPLs rooted at dropped steps (and their descendants) *)
       val dropped = length steps - idx - 1
       val _ = Synchronized.change repl_tab (fn tab =>
-        Symtab.fold (fn (rid, entry) =>
-          case entry_origin entry of
-            From_REPL (pid, si) =>
-              if pid = id andalso si > idx then Symtab.delete rid else I
-          | _ => I) tab tab)
+        let val base_orphans = Symtab.fold (fn (rid, entry) =>
+              case entry_origin entry of
+                From_REPL (pid, si) =>
+                  if pid = id andalso si > idx then cons rid else I
+              | _ => I) tab []
+            val all_orphans =
+              base_orphans @ flat (map (descendants tab) base_orphans)
+        in fold (fn rid => Symtab.delete_safe rid) all_orphans tab end)
       val r' : repl = {origin = #origin r, base_state = #base_state r,
                         steps = if idx < 0 then [] else List.take (steps, idx + 1),
                         timeout = #timeout r}
@@ -517,14 +529,8 @@ fun merge id =
 
 fun remove id =
   let val _ = the_repl id
-      fun is_descendant rid =
-        case Symtab.lookup (Synchronized.value repl_tab) rid of
-          SOME entry => (case entry_origin entry of
-            From_REPL (pid, _) => pid = id orelse is_descendant pid
-          | _ => false)
-        | NONE => false
-      val all_ids = Symtab.keys (Synchronized.value repl_tab)
-      val to_remove = id :: filter is_descendant all_ids
+      val tab = Synchronized.value repl_tab
+      val to_remove = id :: descendants tab id
       val _ = List.app (fn rid =>
         Synchronized.change repl_tab (Symtab.delete_safe rid)) to_remove
   in out ("Removed " ^ commas (map quote to_remove)) end;

--- a/ir/ir.ML
+++ b/ir/ir.ML
@@ -239,9 +239,6 @@ fun get_repl_in tab id =
 
 fun the_repl id = get_repl_in (Synchronized.value repl_tab) id;
 
-fun update_repl id r =
-  Synchronized.change repl_tab (Symtab.update (id, Repl r));
-
 fun descendants tab id =
   let fun is_desc rid =
         case Symtab.lookup tab rid of
@@ -266,15 +263,20 @@ fun with_claim id (f : repl -> repl * 'a) : 'a =
      | Exn.Exn e => (release id r; Exn.reraise e)
   end;
 
+fun with_repl id f =
+  Synchronized.change_result repl_tab (fn tab => f (get_repl_in tab id) tab);
+
+fun map_repl id (f : repl -> repl * 'a) : 'a =
+  with_repl id (fn r => fn tab =>
+    let val (r', result) = f r
+    in (result, Symtab.update (id, Repl r') tab) end);
+
 fun timeout id secs =
-  let val _ = the_repl id
-      val _ = Synchronized.change repl_tab (Symtab.map_entry id
-        (fn Repl r => Repl {origin = #origin r, base_state = #base_state r,
-                            steps = #steps r, timeout = secs}
-          | e => e))
-  in out ("Timeout for " ^ quote id ^ " set to " ^
-          (if secs = 0 then "unlimited" else string_of_int secs ^ "s"))
-  end;
+  (map_repl id (fn r =>
+    ({origin = #origin r, base_state = #base_state r,
+      steps = #steps r, timeout = secs}, ()));
+   out ("Timeout for " ^ quote id ^ " set to " ^
+        (if secs = 0 then "unlimited" else string_of_int secs ^ "s")));
 
 (* Execute Isar text against a state *)
 fun exec_text timeout_secs text st =
@@ -316,10 +318,7 @@ fun parse_spec spec =
 (* Create a new REPL.  The theory must already be loaded — either present
    in the initial heap or previously loaded via Ir.load_theory. *)
 fun init id specs =
-  let val _ = if Symtab.defined (Synchronized.value repl_tab) id
-              then error ("REPL " ^ quote id ^ " already exists")
-              else ()
-      val _ = if null specs then error "init requires at least one spec" else ()
+  let val _ = if null specs then error "init requires at least one spec" else ()
       val parsed = map parse_spec specs
       val (origin, st) =
         case parsed of
@@ -339,14 +338,15 @@ fun init id specs =
             in (From_Theory (String.concatWith "+" thy_names),
                 Toplevel.make_state (SOME thy)) end
       val r : repl = {origin = origin, base_state = st, steps = [], timeout = default_timeout}
-  in update_repl id r;
+  in Synchronized.change_result repl_tab (fn tab =>
+       if Symtab.defined tab id
+       then error ("REPL " ^ quote id ^ " already exists")
+       else ((), Symtab.update (id, Repl r) tab));
      out ("Created REPL " ^ quote id)
   end;
 
 fun init_from_document id node_name command_id =
   let
-    val _ = if Symtab.defined (Synchronized.value repl_tab) id
-            then error ("REPL " ^ quote id ^ " already exists") else ()
     val st = Document.state ()
     val exec =
       (case Exn.capture (Document.command_exec st node_name) command_id of
@@ -365,31 +365,32 @@ fun init_from_document id node_name command_id =
     val toplevel_st = Command.eval_result_state eval
     val r : repl = {origin = From_Document (node_name, command_id),
                     base_state = toplevel_st, steps = [], timeout = default_timeout}
-  in update_repl id r;
+  in Synchronized.change_result repl_tab (fn tab =>
+       if Symtab.defined tab id
+       then error ("REPL " ^ quote id ^ " already exists")
+       else ((), Symtab.update (id, Repl r) tab));
      out ("Created REPL " ^ quote id ^ " from document " ^ quote node_name ^
           " command " ^ string_of_int command_id ^
           (if Toplevel.is_proof toplevel_st then " [proof]" else " [theory]"))
   end;
 
 fun fork parent_id new_id state_idx =
-  let val _ = if Symtab.defined (Synchronized.value repl_tab) new_id
-              then error ("REPL " ^ quote new_id ^ " already exists")
-              else ()
-      val parent = the_repl parent_id
-      val steps = #steps parent
-      val n = length steps
-      (* Use same indexing as state: 0=base, 1=after step 0, ... *)
-      val i = if state_idx < 0 then n + 1 + state_idx else state_idx
-      val st = if i = 0 then #base_state parent
-               else if i >= 1 andalso i <= n then #post_state (nth steps (i - 1))
-               else error ("State " ^ string_of_int state_idx ^ " out of range (0.." ^
-                           string_of_int n ^ ")")
-      val r : repl = {origin = From_REPL (parent_id, i), base_state = st, steps = [],
-                      timeout = #timeout parent}
-  in update_repl new_id r;
-     out ("Forked REPL " ^ quote new_id ^ " from " ^ quote parent_id ^
-          " at state " ^ string_of_int i)
-  end;
+  (Synchronized.change repl_tab (fn tab =>
+    let val _ = if Symtab.defined tab new_id
+                then error ("REPL " ^ quote new_id ^ " already exists") else ()
+        val parent = get_repl_in tab parent_id
+        val steps = #steps parent
+        val n = length steps
+        val i = if state_idx < 0 then n + 1 + state_idx else state_idx
+        val st = if i = 0 then #base_state parent
+                 else if i >= 1 andalso i <= n then #post_state (nth steps (i - 1))
+                 else error ("State " ^ string_of_int state_idx ^
+                             " out of range (0.." ^ string_of_int n ^ ")")
+        val r : repl = {origin = From_REPL (parent_id, i), base_state = st,
+                        steps = [], timeout = #timeout parent}
+    in Symtab.update (new_id, Repl r) tab end);
+   out ("Forked REPL " ^ quote new_id ^ " from " ^ quote parent_id ^
+        " at state " ^ string_of_int state_idx));
 
 fun step_repl timeout_secs text (r : repl) : repl =
   let val pre = last_state r
@@ -490,36 +491,33 @@ fun edit id idx new_text =
                  string_of_int after_count ^ " subsequent steps marked stale")) end);
 
 fun truncate id raw_idx =
-  let val r = the_repl id
-      val steps = #steps r
-      val n = length steps
-      val idx = if raw_idx < 0 then n + raw_idx - 1 else raw_idx
-      val _ = if idx < ~1 orelse idx >= n
-              then error ("Step " ^ string_of_int raw_idx ^ " out of range ("
-                          ^ string_of_int n ^ " steps)") else ()
-      (* Remove sub-REPLs rooted at dropped steps (and their descendants) *)
-      val dropped = length steps - idx - 1
-      val _ = Synchronized.change repl_tab (fn tab =>
-        let val base_orphans = Symtab.fold (fn (rid, entry) =>
-              case entry_origin entry of
-                From_REPL (pid, si) =>
-                  if pid = id andalso si > idx then cons rid else I
-              | _ => I) tab []
-            val all_orphans =
-              base_orphans @ flat (map (descendants tab) base_orphans)
-            val _ = List.app (fn rid =>
-              case Symtab.lookup tab rid of
-                SOME (Claimed _) =>
-                  error ("Cannot truncate: sub-REPL " ^ quote rid ^ " is busy")
-              | _ => ()) all_orphans
-        in fold (fn rid => Symtab.delete_safe rid) all_orphans tab end)
-      val r' : repl = {origin = #origin r, base_state = #base_state r,
-                        steps = if idx < 0 then [] else List.take (steps, idx + 1),
-                        timeout = #timeout r}
-  in update_repl id r';
-     out ("Truncated to step " ^ string_of_int idx ^ ", dropped " ^
-          string_of_int dropped ^ " steps")
-  end;
+  with_repl id (fn r => fn tab =>
+    let val steps = #steps r
+        val n = length steps
+        val idx = if raw_idx < 0 then n + raw_idx - 1 else raw_idx
+        val _ = if idx < ~1 orelse idx >= n
+                then error ("Step " ^ string_of_int raw_idx ^ " out of range ("
+                            ^ string_of_int n ^ " steps)") else ()
+        val dropped = length steps - idx - 1
+        val base_orphans = Symtab.fold (fn (rid, entry) =>
+          case entry_origin entry of
+            From_REPL (pid, si) =>
+              if pid = id andalso si > idx then cons rid else I
+          | _ => I) tab []
+        val all_orphans =
+          base_orphans @ flat (map (descendants tab) base_orphans)
+        val _ = List.app (fn rid =>
+          case Symtab.lookup tab rid of
+            SOME (Claimed _) =>
+              error ("Cannot truncate: sub-REPL " ^ quote rid ^ " is busy")
+          | _ => ()) all_orphans
+        val tab' = fold (fn rid => Symtab.delete_safe rid) all_orphans tab
+        val r' : repl = {origin = #origin r, base_state = #base_state r,
+                          steps = if idx < 0 then [] else List.take (steps, idx + 1),
+                          timeout = #timeout r}
+    in (out ("Truncated to step " ^ string_of_int idx ^ ", dropped " ^
+             string_of_int dropped ^ " steps"),
+        Symtab.update (id, Repl r') tab') end);
 
 fun back id = truncate id ~1;
 
@@ -548,17 +546,18 @@ fun merge id =
   end;
 
 fun remove id =
-  let val _ = the_repl id
-      val tab = Synchronized.value repl_tab
-      val to_remove = id :: descendants tab id
-      val _ = List.app (fn rid =>
-        case Symtab.lookup tab rid of
-          SOME (Claimed _) =>
-            error ("Cannot remove: sub-REPL " ^ quote rid ^ " is busy")
-        | _ => ()) to_remove
-      val _ = List.app (fn rid =>
-        Synchronized.change repl_tab (Symtab.delete_safe rid)) to_remove
-  in out ("Removed " ^ commas (map quote to_remove)) end;
+  let val removed =
+    with_repl id (fn _ => fn tab =>
+      let val descs = descendants tab id
+          val _ = List.app (fn rid =>
+            case Symtab.lookup tab rid of
+              SOME (Claimed _) =>
+                error ("Cannot remove: sub-REPL " ^ quote rid ^ " is busy")
+            | _ => ()) descs
+          val to_remove = id :: descs
+          val tab' = fold (fn rid => Symtab.delete_safe rid) to_remove tab
+      in (to_remove, tab') end)
+  in out ("Removed " ^ commas (map quote removed)) end;
 
 fun repls () =
   let fun origin_str orig = case orig of

--- a/ir/ir.ML
+++ b/ir/ir.ML
@@ -367,15 +367,18 @@ fun fork parent_id new_id state_idx =
           " at state " ^ string_of_int i)
   end;
 
+fun step_repl timeout_secs text (r : repl) : repl =
+  let val pre = last_state r
+      val post = exec_text timeout_secs text pre
+      val s : repl_step = {text = text, pre_state = pre, post_state = post, stale = false}
+  in {origin = #origin r, base_state = #base_state r,
+      steps = #steps r @ [s], timeout = #timeout r} end;
+
 fun step id text =
   let val r = the_repl id
-      val pre = last_state r
-      val post = exec_text (#timeout r) text pre
-      val s : repl_step = {text = text, pre_state = pre, post_state = post, stale = false}
-      val r' : repl = {origin = #origin r, base_state = #base_state r,
-                        steps = #steps r @ [s], timeout = #timeout r}
+      val r' = step_repl (#timeout r) text r
   in update_repl id r';
-     out (pretty_state post)
+     out (pretty_state (last_state r'))
   end;
 
 fun state id state_idx =
@@ -420,9 +423,8 @@ fun text id =
       val t = map #text (#steps r)
   in out (String.concatWith "\n" t) end;
 
-fun replay id =
-  let val r = the_repl id
-      fun go _ [] acc = rev acc
+fun replay_repl (r : repl) : repl =
+  let fun go _ [] acc = rev acc
         | go prev_post (s :: rest) acc =
             if #stale (s : repl_step) then
               let val post = exec_text (#timeout r) (#text s) prev_post
@@ -430,16 +432,20 @@ fun replay id =
                                          post_state = post, stale = false}
               in go post rest (s' :: acc) end
             else go (#post_state s) rest (s :: acc)
-      val steps' = go (#base_state r) (#steps r) []
-      val r' : repl = {origin = #origin r, base_state = #base_state r, steps = steps',
-                        timeout = #timeout r}
+  in {origin = #origin r, base_state = #base_state r,
+      steps = go (#base_state r) (#steps r) [],
+      timeout = #timeout r} end;
+
+fun replay id =
+  let val r = the_repl id
+      val stale_count = length (filter #stale (#steps r))
+      val r' = replay_repl r
   in update_repl id r';
-     out ("Replayed " ^ string_of_int (length (filter #stale (#steps r))) ^ " stale steps")
+     out ("Replayed " ^ string_of_int stale_count ^ " stale steps")
   end;
 
-fun edit id idx new_text =
-  let val r = the_repl id
-      val steps = #steps r
+fun edit_repl idx new_text (r : repl) : repl =
+  let val steps = #steps r
       val _ = if idx < 0 orelse idx >= length steps
               then error ("Step " ^ string_of_int idx ^ " out of range") else ()
       val pre = if idx = 0 then #base_state r
@@ -453,10 +459,16 @@ fun edit id idx new_text =
       val r' : repl = {origin = #origin r, base_state = #base_state r,
                         steps = before_steps @ [edited] @ after_steps,
                         timeout = #timeout r}
+  in if #auto_replay (get_cfg ()) andalso not (null after_steps)
+     then replay_repl r' else r' end;
+
+fun edit id idx new_text =
+  let val r = the_repl id
+      val r' = edit_repl idx new_text r
+      val after_count = length (#steps r) - idx - 1
   in update_repl id r';
      out ("Edited step " ^ string_of_int idx ^ ", " ^
-          string_of_int (length after_steps) ^ " subsequent steps marked stale");
-     if #auto_replay (get_cfg ()) andalso not (null after_steps) then replay id else ()
+          string_of_int after_count ^ " subsequent steps marked stale")
   end;
 
 fun truncate id raw_idx =
@@ -493,12 +505,12 @@ fun merge id =
         | _ => error ("REPL " ^ quote id ^ " is not a sub-REPL")
       val merged_text = String.concatWith "\n" (map #text (#steps r))
       val _ = Synchronized.change repl_tab (Symtab.delete_safe id)
-      val target = pidx
-  in if target < length (#steps (the_repl pid))
-     then (edit pid target merged_text;
+      val parent = the_repl pid
+  in if pidx < length (#steps parent)
+     then (update_repl pid (edit_repl pidx merged_text parent);
            out ("Merged " ^ quote id ^ " into " ^ quote pid ^
-                " (replaced step " ^ string_of_int target ^ ")"))
-     else (step pid merged_text;
+                " (replaced step " ^ string_of_int pidx ^ ")"))
+     else (update_repl pid (step_repl (#timeout parent) merged_text parent);
            out ("Merged " ^ quote id ^ " into " ^ quote pid ^
                 " (appended as new step)"))
   end;

--- a/ir/ir.ML
+++ b/ir/ir.ML
@@ -209,6 +209,19 @@ type repl = {
   timeout: int
 };
 
+(* Concurrency guard: repl_tab stores repl_entry values.  A slow mutation
+   (step, edit, replay) atomically transitions Repl -> Claimed before
+   running exec_text, then Claimed -> Repl with the result.  Any operation
+   that calls the_repl/entry_repl on a Claimed entry fails immediately
+   with "is busy", preventing concurrent mutations from racing. *)
+datatype repl_entry = Repl of repl | Claimed of origin;
+
+fun entry_repl id (Repl r) = r
+  | entry_repl id (Claimed _) = error ("REPL " ^ quote id ^ " is busy");
+
+fun entry_origin (Repl r) = #origin r
+  | entry_origin (Claimed orig) = orig;
+
 (* Sledgehammer bridge: structure-qualified vars survive heap save/load,
    unlike top-level val bindings. Used by ML_Compiler.eval in sledgehammer. *)
 val sledgehammer_state : (Proof.state * int) option Synchronized.var =
@@ -216,22 +229,25 @@ val sledgehammer_state : (Proof.state * int) option Synchronized.var =
 val sledgehammer_result : string Synchronized.var =
   Synchronized.var "Ir.sledgehammer_result" "";
 
-val repl_tab : repl Symtab.table Synchronized.var
+val repl_tab : repl_entry Symtab.table Synchronized.var
   = Synchronized.var "Ir.repls" Symtab.empty;
 
-fun the_repl id =
-  case Symtab.lookup (Synchronized.value repl_tab) id of
-    SOME r => r
-  | NONE => error ("No REPL " ^ quote id);
+fun get_repl_in tab id =
+  case Symtab.lookup tab id of
+    NONE => error ("No REPL " ^ quote id)
+  | SOME e => entry_repl id e;
+
+fun the_repl id = get_repl_in (Synchronized.value repl_tab) id;
 
 fun update_repl id r =
-  Synchronized.change repl_tab (Symtab.update (id, r));
+  Synchronized.change repl_tab (Symtab.update (id, Repl r));
 
 fun timeout id secs =
   let val _ = the_repl id
       val _ = Synchronized.change repl_tab (Symtab.map_entry id
-        (fn r : repl => {origin = #origin r, base_state = #base_state r,
-                         steps = #steps r, timeout = secs}))
+        (fn Repl r => Repl {origin = #origin r, base_state = #base_state r,
+                            steps = #steps r, timeout = secs}
+          | e => e))
   in out ("Timeout for " ^ quote id ^ " set to " ^
           (if secs = 0 then "unlimited" else string_of_int secs ^ "s"))
   end;
@@ -454,8 +470,8 @@ fun truncate id raw_idx =
       (* Remove sub-REPLs attached to dropped steps *)
       val dropped = length steps - idx - 1
       val _ = Synchronized.change repl_tab (fn tab =>
-        Symtab.fold (fn (rid, r') =>
-          case #origin (r' : repl) of
+        Symtab.fold (fn (rid, entry) =>
+          case entry_origin entry of
             From_REPL (pid, si) =>
               if pid = id andalso si > idx then Symtab.delete rid else I
           | _ => I) tab tab)
@@ -488,11 +504,13 @@ fun merge id =
   end;
 
 fun remove id =
-  let val _ = the_repl id (* check exists *)
+  let val _ = the_repl id
       fun is_descendant rid =
-        case #origin (the_repl rid) of
-          From_REPL (pid, _) => pid = id orelse is_descendant pid
-        | _ => false
+        case Symtab.lookup (Synchronized.value repl_tab) rid of
+          SOME entry => (case entry_origin entry of
+            From_REPL (pid, _) => pid = id orelse is_descendant pid
+          | _ => false)
+        | NONE => false
       val all_ids = Symtab.keys (Synchronized.value repl_tab)
       val to_remove = id :: filter is_descendant all_ids
       val _ = List.app (fn rid =>
@@ -500,19 +518,24 @@ fun remove id =
   in out ("Removed " ^ commas (map quote to_remove)) end;
 
 fun repls () =
-  Symtab.fold (fn (id, r : repl) => fn () =>
-    let val n = length (#steps r)
-        val orig = case #origin r of
-            From_Theory t => "theory " ^ t
-          | From_Segment (t, i) => t ^ ":" ^ string_of_int i
-          | From_REPL (p, i) => "REPL " ^ quote p ^ " state " ^ string_of_int i
-          | From_Document (n, i) => "document " ^ quote n ^ " cmd " ^ string_of_int i
-        val stale = length (filter #stale (#steps r))
-        val desc = id ^ " (" ^ string_of_int n ^ " steps" ^
-            (if stale > 0 then ", " ^ string_of_int stale ^ " stale" else "") ^
-            ", from " ^ orig ^ ")"
-    in out ("    " ^ desc)
-    end) (Synchronized.value repl_tab) ();
+  let fun origin_str orig = case orig of
+          From_Theory t => "theory " ^ t
+        | From_Segment (t, i) => t ^ ":" ^ string_of_int i
+        | From_REPL (p, i) => "REPL " ^ quote p ^ " state " ^ string_of_int i
+        | From_Document (n, i) => "document " ^ quote n ^ " cmd " ^ string_of_int i
+  in Symtab.fold (fn (id, entry) => fn () =>
+    case entry of
+      Claimed orig =>
+        out ("    " ^ id ^ " (busy, from " ^ origin_str orig ^ ")")
+    | Repl r =>
+      let val n = length (#steps r)
+          val stale = length (filter #stale (#steps r))
+          val desc = id ^ " (" ^ string_of_int n ^ " steps" ^
+              (if stale > 0 then ", " ^ string_of_int stale ^ " stale" else "") ^
+              ", from " ^ origin_str (#origin r) ^ ")"
+      in out ("    " ^ desc) end)
+    (Synchronized.value repl_tab) ()
+  end;
 
 (* Lists theories in the initial heap plus those loaded via load_theory. *)
 fun theories () =

--- a/ir/ir.ML
+++ b/ir/ir.ML
@@ -251,6 +251,21 @@ fun descendants tab id =
         | NONE => false
   in filter is_desc (Symtab.keys tab) end;
 
+fun claim id =
+  Synchronized.change_result repl_tab (fn tab =>
+    let val r = get_repl_in tab id
+    in (r, Symtab.update (id, Claimed (#origin r)) tab) end);
+
+fun release id r =
+  Synchronized.change repl_tab (Symtab.update (id, Repl r));
+
+fun with_claim id (f : repl -> repl * 'a) : 'a =
+  let val r = claim id
+  in case Exn.capture f r of
+       Exn.Res (r', result) => (release id r'; result)
+     | Exn.Exn e => (release id r; Exn.reraise e)
+  end;
+
 fun timeout id secs =
   let val _ = the_repl id
       val _ = Synchronized.change repl_tab (Symtab.map_entry id
@@ -384,11 +399,9 @@ fun step_repl timeout_secs text (r : repl) : repl =
       steps = #steps r @ [s], timeout = #timeout r} end;
 
 fun step id text =
-  let val r = the_repl id
-      val r' = step_repl (#timeout r) text r
-  in update_repl id r';
-     out (pretty_state (last_state r'))
-  end;
+  with_claim id (fn r =>
+    let val r' = step_repl (#timeout r) text r
+    in (r', out (pretty_state (last_state r'))) end);
 
 fun state id state_idx =
   let val r = the_repl id
@@ -446,12 +459,10 @@ fun replay_repl (r : repl) : repl =
       timeout = #timeout r} end;
 
 fun replay id =
-  let val r = the_repl id
-      val stale_count = length (filter #stale (#steps r))
-      val r' = replay_repl r
-  in update_repl id r';
-     out ("Replayed " ^ string_of_int stale_count ^ " stale steps")
-  end;
+  with_claim id (fn r =>
+    let val stale_count = length (filter #stale (#steps r))
+        val r' = replay_repl r
+    in (r', out ("Replayed " ^ string_of_int stale_count ^ " stale steps")) end);
 
 fun edit_repl idx new_text (r : repl) : repl =
   let val steps = #steps r
@@ -472,13 +483,11 @@ fun edit_repl idx new_text (r : repl) : repl =
      then replay_repl r' else r' end;
 
 fun edit id idx new_text =
-  let val r = the_repl id
-      val r' = edit_repl idx new_text r
-      val after_count = length (#steps r) - idx - 1
-  in update_repl id r';
-     out ("Edited step " ^ string_of_int idx ^ ", " ^
-          string_of_int after_count ^ " subsequent steps marked stale")
-  end;
+  with_claim id (fn r =>
+    let val r' = edit_repl idx new_text r
+        val after_count = length (#steps r) - idx - 1
+    in (r', out ("Edited step " ^ string_of_int idx ^ ", " ^
+                 string_of_int after_count ^ " subsequent steps marked stale")) end);
 
 fun truncate id raw_idx =
   let val r = the_repl id
@@ -515,21 +524,27 @@ fun truncate id raw_idx =
 fun back id = truncate id ~1;
 
 fun merge id =
-  let val r = the_repl id
+  let val child = claim id
       val (pid, pidx) =
-        case #origin r of
+        case #origin child of
           From_REPL (p, i) => (p, i)
-        | _ => error ("REPL " ^ quote id ^ " is not a sub-REPL")
-      val merged_text = String.concatWith "\n" (map #text (#steps r))
-      val _ = Synchronized.change repl_tab (Symtab.delete_safe id)
-      val parent = the_repl pid
-  in if pidx < length (#steps parent)
-     then (update_repl pid (edit_repl pidx merged_text parent);
-           out ("Merged " ^ quote id ^ " into " ^ quote pid ^
-                " (replaced step " ^ string_of_int pidx ^ ")"))
-     else (update_repl pid (step_repl (#timeout parent) merged_text parent);
-           out ("Merged " ^ quote id ^ " into " ^ quote pid ^
-                " (appended as new step)"))
+        | _ => (release id child;
+                error ("REPL " ^ quote id ^ " is not a sub-REPL"))
+      val merged_text = String.concatWith "\n" (map #text (#steps child))
+  in
+    case Exn.capture (with_claim pid) (fn parent =>
+      let val r' =
+            if pidx < length (#steps parent)
+            then edit_repl pidx merged_text parent
+            else step_repl (#timeout parent) merged_text parent
+          val _ = Synchronized.change repl_tab (Symtab.delete id)
+          val msg = if pidx < length (#steps parent)
+                    then "replaced step " ^ string_of_int pidx
+                    else "appended as new step"
+      in (r', out ("Merged " ^ quote id ^ " into " ^ quote pid ^
+                   " (" ^ msg ^ ")")) end) of
+      Exn.Res x => x
+    | Exn.Exn e => (release id child; Exn.reraise e)
   end;
 
 fun remove id =

--- a/ir/ir.ML
+++ b/ir/ir.ML
@@ -498,6 +498,11 @@ fun truncate id raw_idx =
               | _ => I) tab []
             val all_orphans =
               base_orphans @ flat (map (descendants tab) base_orphans)
+            val _ = List.app (fn rid =>
+              case Symtab.lookup tab rid of
+                SOME (Claimed _) =>
+                  error ("Cannot truncate: sub-REPL " ^ quote rid ^ " is busy")
+              | _ => ()) all_orphans
         in fold (fn rid => Symtab.delete_safe rid) all_orphans tab end)
       val r' : repl = {origin = #origin r, base_state = #base_state r,
                         steps = if idx < 0 then [] else List.take (steps, idx + 1),
@@ -531,6 +536,11 @@ fun remove id =
   let val _ = the_repl id
       val tab = Synchronized.value repl_tab
       val to_remove = id :: descendants tab id
+      val _ = List.app (fn rid =>
+        case Symtab.lookup tab rid of
+          SOME (Claimed _) =>
+            error ("Cannot remove: sub-REPL " ^ quote rid ^ " is busy")
+        | _ => ()) to_remove
       val _ = List.app (fn rid =>
         Synchronized.change repl_tab (Symtab.delete_safe rid)) to_remove
   in out ("Removed " ^ commas (map quote to_remove)) end;

--- a/ir/test_repl.py
+++ b/ir/test_repl.py
@@ -237,6 +237,26 @@ def core_tests(sock, prefix):
         send_recv(sock, f'Ir.remove {q(t)};')
     tests.append(("truncate_negative_multi", test_truncate_negative_multi))
 
+    def test_truncate_deep_descendants():
+        """Truncate must remove grandchildren, not just direct children."""
+        t = f"{prefix}_tdd"
+        s = f"{prefix}_tdd_s"
+        u = f"{prefix}_tdd_t"
+        send_recv(sock, f'Ir.init {q(t)} ["Main"];')
+        send_recv(sock, f'Ir.step {q(t)} "lemma a: True by simp";')
+        send_recv(sock, f'Ir.fork {q(t)} {q(s)} 1;')
+        send_recv(sock, f'Ir.step {q(s)} "lemma b: True by simp";')
+        send_recv(sock, f'Ir.fork {q(s)} {q(u)} 1;')
+        # u is a grandchild of t (t -> s -> u)
+        # Truncate t to step 0 — s (forked at state 1) becomes orphaned,
+        # and u (a descendant of s) should also be removed.
+        send_recv(sock, f'Ir.truncate {q(t)} ~1;')
+        out = send_recv(sock, 'Ir.repls ();')
+        assert s not in out, f"Expected {s} removed, got:\n{out}"
+        assert u not in out, f"Expected {u} (grandchild) removed, got:\n{out}"
+        send_recv(sock, f'Ir.remove {q(t)};')
+    tests.append(("truncate_deep_descendants", test_truncate_deep_descendants))
+
     def test_back():
         t = f"{prefix}_bk"
         send_recv(sock, f'Ir.init {q(t)} ["Main"];')


### PR DESCRIPTION
*Description of changes:* In `ir.ML`, functions like `step`, `remove` are implemented as
```
let val state = the_repl id in
... some computations ...
let val state' = ... some new state..
update_repl id state'
```
This is problematic in the face of concurrent calls to I/R, where e.g. a long running `step` racing with a `remove` can cause a REPL to suddenly reappear.

To address this, change the type of the REPLs table from `repl Symtab.table Synchronized.var` to
```
datatype repl_entry = Repl of repl | Claimed of origin;
val repl_tab : repl_entry Symtab.table Synchronized.var
```
Potentially long running operations (e.g. `step`) will first 'claim' a REPL, transitioning from `Repl` to `Claimed`. This means they have exclusive ownership of the claimed ID for the duration of the operation. Concurrent operations are not allowed to modify this REPL ID. On finishing the operation, they will release the claimed REPL again.

Faster operations (e.g. `remove`) are done entirely inside a `Synchronized.change`, and take care not to touch `Claimed` REPLs.

Commits should be individually reviewable.

______

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
