### PR TITLE
Add verified µRust examples

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ dependencies/
 
 # Other
 Conformance_Testing/
+.DS_Store

--- a/Micro_Rust_Examples/FSet_Ref.thy
+++ b/Micro_Rust_Examples/FSet_Ref.thy
@@ -1,0 +1,75 @@
+(* Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+   SPDX-License-Identifier: MIT *)
+
+theory FSet_Ref
+  imports
+    Micro_Rust_Std_Lib.StdLib_All
+    "HOL-Library.FSet"
+begin
+
+section\<open>Finite Set References\<close>
+
+text\<open>Makes HOL-Library.FSet available as a reference-backed uRust type with contains and insert operations.\<close>
+
+locale fset_ref =
+  reference reference_types
+  + ref_fset: reference_allocatable reference_types _ _ _ _ _ _ _ fset_prism
+  for reference_types :: \<open>'s::{sepalg} \<Rightarrow> 'addr \<Rightarrow> 'gv \<Rightarrow> 'abort \<Rightarrow> 'i prompt \<Rightarrow> 'o prompt_output \<Rightarrow> unit\<close>
+  and fset_prism :: \<open>('gv, 't fset) prism\<close>
+begin
+
+adhoc_overloading store_reference_const \<rightleftharpoons> ref_fset.new
+adhoc_overloading store_update_const \<rightleftharpoons> update_fun
+
+abbreviation fset_points_to :: \<open>'t fset \<Rightarrow> ('addr, 'gv, 't fset) Global_Store.ref \<Rightarrow> 's assert\<close>
+  where \<open>fset_points_to xs s \<equiv> (\<Squnion>g. s \<mapsto>\<langle>\<top>\<rangle> g\<down>xs)\<close>
+
+definition contains :: \<open>('addr, 'gv, 't fset) Global_Store.ref \<Rightarrow> 't \<Rightarrow>
+    ('s, bool, 'abort, 'i prompt, 'o prompt_output) function_body\<close> where
+  \<open>contains s x \<equiv> FunctionBody \<lbrakk>
+     let xs = *s;
+     \<llangle>x |\<in>| xs\<rrangle>
+  \<rbrakk>\<close>
+
+definition contains_contract ::
+    \<open>'t fset \<Rightarrow> ('addr, 'gv, 't fset) Global_Store.ref \<Rightarrow> 't \<Rightarrow> ('s, bool, 'abort) function_contract\<close> where
+  [crush_contracts]: \<open>contains_contract xs s x \<equiv>
+     let pre = fset_points_to xs s in
+     let post = \<lambda>b. fset_points_to xs s \<star> \<langle>b = (x |\<in>| xs)\<rangle> in
+     make_function_contract pre post\<close>
+ucincl_auto contains_contract
+
+lemma contains_spec [crush_specs]:
+  shows \<open>\<Gamma>; contains s x \<Turnstile>\<^sub>F contains_contract xs s x\<close>
+  apply (crush_boot f: contains_def contract: contains_contract_def)
+  apply crush_base
+  done
+
+definition fset_insert ::
+  \<open>('addr, 'gv, 't fset) Global_Store.ref \<Rightarrow> 't \<Rightarrow>
+     ('s, unit, 'abort, 'i prompt, 'o prompt_output) function_body\<close> where
+  \<open>fset_insert s x \<equiv> FunctionBody \<lbrakk>
+     let xs = *s;
+     s = \<llangle>finsert x xs\<rrangle>
+   \<rbrakk>\<close>
+
+definition fset_insert_contract ::
+  \<open>('addr, 'gv, 't fset) Global_Store.ref \<Rightarrow> 't \<Rightarrow> 't fset \<Rightarrow>
+   ('s, unit, 'abort) function_contract\<close> where
+  [crush_contracts]: \<open>fset_insert_contract s x xs \<equiv>
+     let pre = fset_points_to xs s in
+     let post = \<lambda>_. fset_points_to (finsert x xs) s in
+     make_function_contract pre post\<close>
+ucincl_auto fset_insert_contract
+
+lemma fset_insert_spec [crush_specs]:
+  shows \<open>\<Gamma>; fset_insert s x \<Turnstile>\<^sub>F fset_insert_contract s x xs\<close>
+  apply (crush_boot f: fset_insert_def contract: fset_insert_contract_def)
+  apply crush_base
+  done
+
+no_adhoc_overloading store_update_const \<rightleftharpoons> update_fun
+
+end
+
+end

--- a/Micro_Rust_Examples/Graph.thy
+++ b/Micro_Rust_Examples/Graph.thy
@@ -1,0 +1,297 @@
+(* Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+   SPDX-License-Identifier: MIT *)
+
+theory Graph
+  imports
+    FSet_Ref
+    Stack
+begin
+
+section\<open>Finite Simple Directed Graphs\<close>
+
+record 'a graph =
+  V :: \<open>'a set\<close>
+  E :: \<open>('a \<times> 'a) set\<close>
+
+locale finite_directed_graph =
+  fixes G :: \<open>'a graph\<close>
+  assumes finite_V: \<open>finite (V G)\<close>
+      and edges_in_V: \<open>E G \<subseteq> V G \<times> V G\<close>
+begin
+
+subsection\<open>Notation and basic definitions\<close>
+
+lemma finite_E: \<open>finite (E G)\<close>
+  using finite_V edges_in_V by (auto intro: finite_subset)
+
+abbreviation edge :: \<open>'a \<Rightarrow> 'a \<Rightarrow> bool\<close> (infix \<open>\<rightarrow>\<^sub>G\<close> 50) where
+  \<open>u \<rightarrow>\<^sub>G v \<equiv> (u,v) \<in> E G\<close>
+
+abbreviation reaches :: \<open>'a \<Rightarrow> 'a \<Rightarrow> bool\<close> (infix \<open>\<rightarrow>\<^sub>G\<^sup>*\<close> 50) where
+  \<open>u \<rightarrow>\<^sub>G\<^sup>* v \<equiv> (u,v) \<in> (E G)\<^sup>*\<close>
+
+abbreviation reachable :: \<open>'a \<Rightarrow> 'a set\<close> where
+  \<open>reachable v \<equiv> (E G)\<^sup>* `` {v}\<close>
+
+abbreviation neighbours_of :: \<open>'a set \<Rightarrow> 'a set\<close> where
+  \<open>neighbours_of Vs \<equiv> E G `` Vs\<close>
+
+definition edges_from_vertex :: \<open>'a \<Rightarrow> ('a \<times> 'a) set\<close> where
+  \<open>edges_from_vertex v \<equiv> {(v, w) | w. (v, w) \<in> E G}\<close>
+
+definition edges_from_set :: \<open>'a set \<Rightarrow> ('a \<times> 'a) set\<close> where
+  \<open>edges_from_set U \<equiv> (\<Union>v\<in>U. edges_from_vertex v)\<close>
+
+\<comment> \<open>Neighbours of v as a list, so DFS can iterate over them.\<close>
+definition neighbours :: \<open>'a \<Rightarrow> 'a list\<close> where
+  \<open>neighbours v \<equiv> SOME xs. set xs = {w. v \<rightarrow>\<^sub>G w} \<and> distinct xs\<close>
+
+subsection\<open>Reachability and closed sets\<close>
+
+lemma reachable_subset_V:
+  assumes \<open>v \<in> V G\<close>
+  shows \<open>reachable v \<subseteq> V G\<close>
+  using edges_in_V assms Image_closed_trancl[of \<open>E G\<close> \<open>V G\<close>] by blast
+
+lemma reachable_fixpoint:
+  assumes \<open>v \<in> Vs\<close>
+      and \<open>Vs \<subseteq> reachable v\<close>
+      and \<open>neighbours_of Vs \<subseteq> Vs\<close>
+  shows \<open>Vs = reachable v\<close>
+proof -
+  have \<open>v \<rightarrow>\<^sub>G\<^sup>* x \<Longrightarrow> x \<in> Vs\<close> for x
+    by (induction rule: rtrancl_induct) (use assms(1,3) in blast)+
+  thus ?thesis using assms(2) by blast
+qed
+
+corollary reachable_fixpoint_mem:
+  assumes \<open>v \<in> Vs\<close>
+      and \<open>Vs \<subseteq> reachable v\<close>
+      and \<open>neighbours_of Vs \<subseteq> Vs\<close>
+      and \<open>v \<rightarrow>\<^sub>G\<^sup>* x\<close>
+  shows \<open>x \<in> Vs\<close>
+  using reachable_fixpoint[OF assms(1-3)] assms(4) by simp
+
+subsection\<open>Edge counting\<close>
+
+lemma edges_from_set_subset_E: \<open>edges_from_set U \<subseteq> E G\<close>
+  by (auto simp: edges_from_set_def edges_from_vertex_def)
+
+lemma finite_edges_from_set: \<open>finite (edges_from_set U)\<close>
+  using edges_from_set_subset_E finite_E by (rule finite_subset)
+
+lemma card_edges_from_vertex:
+  \<open>card (edges_from_vertex v) = card {w. v \<rightarrow>\<^sub>G w}\<close>
+proof -
+  have \<open>edges_from_vertex v = (\<lambda>w. (v,w)) ` {w. v \<rightarrow>\<^sub>G w}\<close>
+    by (auto simp: edges_from_vertex_def)
+  thus ?thesis by (simp add: card_image inj_on_def)
+qed
+
+lemma card_edges_from_set_split:
+  assumes \<open>v \<in> U\<close>
+  shows \<open>card (edges_from_set U)
+       = card (edges_from_set (U - {v})) + card {w. v \<rightarrow>\<^sub>G w}\<close>
+proof -
+  have split: \<open>edges_from_set U = edges_from_set (U - {v}) \<union> edges_from_vertex v\<close>
+    using assms by (auto simp: edges_from_set_def)
+  have disj: \<open>edges_from_set (U - {v}) \<inter> edges_from_vertex v = {}\<close>
+    by (auto simp: edges_from_set_def edges_from_vertex_def)
+  have fin2: \<open>finite (edges_from_vertex v)\<close>
+    using finite_E edges_from_set_subset_E[of \<open>{v}\<close>]
+    by (auto simp: edges_from_set_def intro: finite_subset)
+  show ?thesis
+    using split disj finite_edges_from_set fin2
+    by (simp add: card_Un_disjoint card_edges_from_vertex)
+qed
+
+lemma neighbours_correct:
+  shows \<open>set (neighbours v) = {w. v \<rightarrow>\<^sub>G w}\<close>
+    and \<open>distinct (neighbours v)\<close>
+proof -
+  have \<open>{w. v \<rightarrow>\<^sub>G w} = E G `` {v}\<close> by auto
+  then have \<open>finite {w. v \<rightarrow>\<^sub>G w}\<close> using finite_E by (auto intro: finite_Image)
+  then obtain xs where \<open>set xs = {w. v \<rightarrow>\<^sub>G w} \<and> distinct xs\<close>
+    using finite_distinct_list by blast
+  thus \<open>set (neighbours v) = {w. v \<rightarrow>\<^sub>G w}\<close> and \<open>distinct (neighbours v)\<close>
+    unfolding neighbours_def by (metis (mono_tags, lifting) someI_ex)+
+qed
+
+lemma length_neighbours:
+  \<open>length (neighbours v) = card {w. v \<rightarrow>\<^sub>G w}\<close>
+  using distinct_card[OF neighbours_correct(2)] neighbours_correct(1) by simp
+
+end
+
+section\<open>Depth-First Search\<close>
+
+locale dfs =
+    fset_ref _ _ _ _ _ _ _ reference_types fset_prism
+  + stack
+      where ll_focus = \<open>prism_to_focus node_prism'\<close>
+        and node_prism = node_prism'
+        and reference_types = reference_types
+  + finite_directed_graph G
+  for reference_types :: \<open>'s::{sepalg} \<Rightarrow> 'addr \<Rightarrow> 'gv \<Rightarrow> 'abort \<Rightarrow> 'i prompt \<Rightarrow> 'o prompt_output \<Rightarrow> unit\<close>
+    and fset_prism :: \<open>('gv, 'a fset) prism\<close>
+    and node_prism' :: \<open>('gv, ('addr, 'gv, 'a) ll_node_raw) prism\<close>
+    and G :: \<open>'a graph\<close>
+begin
+
+definition remaining_work :: \<open>'a \<Rightarrow> 'a fset \<Rightarrow> 'a list \<Rightarrow> nat\<close> where
+  \<open>remaining_work s0 Vis Fr \<equiv> length Fr + 2 * card (edges_from_set (reachable s0 - fset Vis))\<close>
+
+definition fuel_bound :: \<open>'a \<Rightarrow> nat\<close> where
+  \<open>fuel_bound s0 \<equiv> remaining_work s0 {||} [s0] + 1\<close>
+
+\<comment> \<open>Vertices DFS has seen so far: visited plus pending on the frontier.\<close>
+abbreviation seen :: \<open>'a fset \<Rightarrow> 'a list \<Rightarrow> 'a set\<close> where
+  \<open>seen Vis Fr \<equiv> fset Vis \<union> set Fr\<close>
+
+definition dfs where
+  \<open>dfs (s0::'a) \<equiv> FunctionBody \<lbrakk>
+     let mut visited = \<llangle>{||} :: 'a fset\<rrangle>;
+     let frontier = empty();
+     push(frontier, s0);
+
+     #[fuel(\<epsilon>\<open>fuel_bound s0\<close>)] while let Some(v) = pop(frontier) {
+       if !contains(visited, v) {
+         fset_insert(visited, v);
+         push_all(frontier, \<llangle>neighbours v\<rrangle>);
+       }
+     };
+
+     *visited
+   \<rbrakk>\<close>
+
+definition dfs_contract where
+  \<open>dfs_contract s0 \<equiv>
+     make_function_contract
+       (can_alloc_reference \<star> \<langle>s0 \<in> V G\<rangle>)
+       (\<lambda>ret. \<langle>fset ret = reachable s0\<rangle> \<star> can_alloc_reference)\<close>
+ucincl_auto dfs_contract
+
+abbreviation dfs_inv where
+  \<open>dfs_inv s0 visited frontier k \<equiv>
+     \<Squnion>Vis Fr.
+       fset_points_to Vis visited \<star> stack_points_to Fr frontier
+     \<star> can_alloc_reference
+     \<star> \<langle>seen Vis Fr \<subseteq> reachable s0\<rangle>
+     \<star> \<langle>neighbours_of (fset Vis) \<subseteq> seen Vis Fr\<rangle>
+     \<star> \<langle>s0 \<in> seen Vis Fr\<rangle>
+     \<star> \<langle>remaining_work s0 Vis Fr \<le> k\<rangle>\<close>
+
+\<comment> \<open>One DFS body iteration strictly decreases \<^verbatim>\<open>remaining_work\<close>.\<close>
+lemma remaining_work_decrease:
+  shows stale: \<open>remaining_work s0 Vis W < remaining_work s0 Vis (v # W)\<close>
+    and fresh: \<open>v \<notin> fset Vis \<Longrightarrow> v \<in> reachable s0
+              \<Longrightarrow> remaining_work s0 (finsert v Vis) (rev (neighbours v) @ W)
+                  < remaining_work s0 Vis (v # W)\<close>
+proof -
+  show \<open>remaining_work s0 Vis W < remaining_work s0 Vis (v # W)\<close>
+    by (simp add: remaining_work_def)
+next
+  assume \<open>v \<notin> fset Vis\<close> and \<open>v \<in> reachable s0\<close>
+  hence \<open>v \<in> reachable s0 - fset Vis\<close> by simp
+  hence \<open>card (edges_from_set (reachable s0 - fset Vis))
+       = card (edges_from_set (reachable s0 - fset Vis - {v})) + length (neighbours v)\<close>
+    by (simp add: card_edges_from_set_split length_neighbours)
+  moreover have \<open>reachable s0 - fset (finsert v Vis) = reachable s0 - fset Vis - {v}\<close>
+    by auto
+  ultimately show \<open>remaining_work s0 (finsert v Vis) (rev (neighbours v) @ W)
+                 < remaining_work s0 Vis (v # W)\<close>
+    unfolding remaining_work_def by simp
+qed
+
+\<comment> \<open>The invariant is preserved by one DFS iteration.\<close>
+lemma dfs_inv_preserved:
+  assumes seen_sub:   \<open>seen Vis (v#vs) \<subseteq> reachable s0\<close>
+      and closure:    \<open>neighbours_of (fset Vis) \<subseteq> seen Vis (v#vs)\<close>
+      and s0_in_seen: \<open>s0 \<in> seen Vis (v#vs)\<close>
+      and s0_in_V:    \<open>s0 \<in> V G\<close>
+  shows stale_inv: \<open>v \<in> fset Vis \<Longrightarrow>
+          seen Vis vs \<subseteq> reachable s0
+        \<and> neighbours_of (fset Vis) \<subseteq> seen Vis vs
+        \<and> s0 \<in> seen Vis vs\<close>
+    and fresh_inv: \<open>v \<notin> fset Vis \<Longrightarrow>
+          seen (finsert v Vis) (rev (neighbours v) @ vs) \<subseteq> reachable s0
+        \<and> neighbours_of (fset (finsert v Vis)) \<subseteq> seen (finsert v Vis) (rev (neighbours v) @ vs)
+        \<and> s0 \<in> seen (finsert v Vis) (rev (neighbours v) @ vs)\<close>
+proof -
+  show \<open>v \<in> fset Vis \<Longrightarrow>
+          seen Vis vs \<subseteq> reachable s0
+        \<and> neighbours_of (fset Vis) \<subseteq> seen Vis vs
+        \<and> s0 \<in> seen Vis vs\<close>
+    using assms by auto
+next
+  assume \<open>v \<notin> fset Vis\<close>
+  have \<open>set (neighbours v) \<subseteq> reachable s0\<close>
+    using seen_sub reachable_subset_V[OF s0_in_V] neighbours_correct by force
+  thus \<open>seen (finsert v Vis) (rev (neighbours v) @ vs) \<subseteq> reachable s0
+      \<and> neighbours_of (fset (finsert v Vis)) \<subseteq> seen (finsert v Vis) (rev (neighbours v) @ vs)
+      \<and> s0 \<in> seen (finsert v Vis) (rev (neighbours v) @ vs)\<close>
+    using seen_sub closure s0_in_seen neighbours_correct
+      reachable_subset_V[OF s0_in_V]
+    by auto
+qed
+
+\<comment> \<open>Once visited is neighbor-closed, the frontier must be empty.\<close>
+lemma remaining_work_exhausted:
+  assumes \<open>fset Vis \<subseteq> reachable s0\<close>
+      and \<open>neighbours_of (fset Vis) \<subseteq> fset Vis\<close>
+      and \<open>s0 \<in> fset Vis\<close>
+  shows \<open>remaining_work s0 Vis [] = 0\<close>
+proof -
+  have \<open>fset Vis = reachable s0\<close>
+    using reachable_fixpoint[OF assms(3,1,2)] by simp
+  thus ?thesis by (simp add: remaining_work_def edges_from_set_def)
+qed
+
+lemma remaining_work_Suc:
+  shows stale_Suc: \<open>remaining_work s0 Vis (v # W) \<le> Suc k \<Longrightarrow> remaining_work s0 Vis W \<le> k\<close>
+    and fresh_Suc: \<open>v \<notin> fset Vis \<Longrightarrow> v \<in> reachable s0
+              \<Longrightarrow> remaining_work s0 Vis (v # W) \<le> Suc k
+              \<Longrightarrow> remaining_work s0 (finsert v Vis) (rev (neighbours v) @ W) \<le> k\<close>
+proof -
+  show \<open>remaining_work s0 Vis (v # W) \<le> Suc k \<Longrightarrow> remaining_work s0 Vis W \<le> k\<close>
+    using remaining_work_decrease(1)[of s0 Vis W v] by linarith
+  show \<open>v \<notin> fset Vis \<Longrightarrow> v \<in> reachable s0
+    \<Longrightarrow> remaining_work s0 Vis (v # W) \<le> Suc k
+    \<Longrightarrow> remaining_work s0 (finsert v Vis) (rev (neighbours v) @ W) \<le> k\<close>
+    using remaining_work_decrease(2)[of v Vis s0 W] by linarith
+qed
+
+lemma dfs_spec:
+  shows \<open>\<Gamma>; dfs s0 \<Turnstile>\<^sub>F dfs_contract s0\<close>
+  apply (crush_boot f: dfs_def contract: dfs_contract_def)
+  apply crush_base
+  subgoal for visited_ref frontier_ref
+    apply (ucincl_discharge\<open>
+      rule_tac
+        INV  = \<open>\<lambda>k. dfs_inv s0 visited_ref frontier_ref k\<close> and
+        INV' = \<open>\<lambda>k. dfs_inv s0 visited_ref frontier_ref k\<close> and
+        \<tau>    = \<open>\<lambda>_. \<langle>False\<rangle>\<close> and
+        \<theta>    = \<open>\<lambda>_. \<langle>False\<rangle>\<close>
+      in wp_bounded_while_framedI
+    \<close>)
+    \<comment> \<open>entry: \<^verbatim>\<open>fuel_bound\<close> slots suffice\<close>
+    subgoal
+      apply (crush_base simp add: fuel_bound_def remaining_work_def)
+      by (meson reachable_fixpoint_mem fset_rev_mp)
+    \<comment> \<open>loop body: pop, contains, insert and push\<close>
+    subgoal
+      apply crush_base
+      apply (crush_base split!: list.splits option.splits
+             simp add: remaining_work_exhausted)
+      apply (auto intro: remaining_work_Suc dfs_inv_preserved
+                  dest: reachable_subset_V[THEN subsetD]
+                  simp add: neighbours_correct)
+      done
+    \<comment> \<open>*visited\<close>
+    subgoal by crush_base
+    done
+  done
+
+end
+
+end

--- a/Micro_Rust_Examples/Number_Theory.thy
+++ b/Micro_Rust_Examples/Number_Theory.thy
@@ -1,0 +1,426 @@
+(* Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+   SPDX-License-Identifier: MIT *)
+
+theory Number_Theory
+  imports Micro_Rust_Std_Lib.StdLib_All "HOL-Number_Theory.Totient"
+begin
+
+section\<open>Number Theory\<close>
+
+locale number_theory =
+  reference reference_types +
+  ref_word: reference_allocatable reference_types _ _ _ _ _ _ _ word_prism +
+  ref_nat: reference_allocatable reference_types _ _ _ _ _ _ _ nat_prism +
+  ref_int: reference_allocatable reference_types _ _ _ _ _ _ _ int_prism
+  for reference_types :: \<open>'s::{sepalg} \<Rightarrow> 'addr \<Rightarrow> 'gv \<Rightarrow> 'abort \<Rightarrow> 'i prompt \<Rightarrow> 'o prompt_output \<Rightarrow> unit\<close>
+  and word_prism :: \<open>('gv, 'w::len word) prism\<close>
+  and nat_prism :: \<open>('gv, nat) prism\<close>
+  and int_prism :: \<open>('gv, int) prism\<close>
+begin
+
+adhoc_overloading store_reference_const \<rightleftharpoons> ref_word.new
+adhoc_overloading store_reference_const \<rightleftharpoons> ref_nat.new
+adhoc_overloading store_reference_const \<rightleftharpoons> ref_int.new
+adhoc_overloading store_update_const \<rightleftharpoons> update_fun
+adhoc_overloading urust_add \<rightleftharpoons> \<open>bind2 (lift_exp2 (plus :: nat \<Rightarrow> nat \<Rightarrow> nat))\<close>
+
+abbreviation fully_owns where \<open>fully_owns r v \<equiv> \<Squnion>g. r \<mapsto>\<langle>\<top>\<rangle> g\<down>v\<close>
+
+subsection\<open>Fibonacci\<close>
+
+fun fib :: \<open>nat \<Rightarrow> nat\<close> where
+  \<open>fib 0 = 0\<close>
+| \<open>fib (Suc 0) = 1\<close>
+| \<open>fib (Suc (Suc n)) = fib n + fib (Suc n)\<close>
+
+definition fib_prog where
+  \<open>fib_prog n \<equiv> FunctionBody \<lbrakk>
+    let mut a = \<llangle>0 :: nat\<rrangle>;
+    let mut b = \<llangle>1 :: nat\<rrangle>;
+    for i in 0..n {
+      let old_a = *a;
+      let old_b = *b;
+      a = old_b;
+      b = old_a + old_b
+    };
+    *a
+  \<rbrakk>\<close>
+
+definition fib_contract where
+  \<open>fib_contract n \<equiv>
+    make_function_contract
+      (can_alloc_reference)
+      (\<lambda>ret. \<langle>ret = fib (unat n)\<rangle> \<star> can_alloc_reference)\<close>
+ucincl_auto fib_contract
+
+lemma fib_spec:
+  shows \<open>\<Gamma>; fib_prog n \<Turnstile>\<^sub>F fib_contract n\<close>
+  apply (crush_boot f: fib_prog_def contract: fib_contract_def)
+  apply crush_base
+  subgoal for a_ref b_ref
+    apply (ucincl_discharge\<open>
+      rule_tac
+        INV=\<open>\<lambda>_ i. fully_owns a_ref (fib i) \<star> fully_owns b_ref (fib (i + 1))\<close> and
+        \<tau>=\<open>\<lambda>_. \<langle>False\<rangle>\<close> and
+        \<theta>=\<open>\<lambda>_. \<langle>False\<rangle>\<close>
+      in wp_raw_for_loop_framedI'
+    \<close>)
+    apply (crush_base simp add: unat_of_nat_eq le_unat_uoi')
+    done
+  done
+
+subsection\<open>GCD\<close>
+
+definition gcd_prog where
+  \<open>gcd_prog a b \<equiv> FunctionBody \<lbrakk>
+    let mut x = \<llangle>a :: nat\<rrangle>;
+    let mut y = \<llangle>b :: nat\<rrangle>;
+    #[fuel(\<epsilon>\<open>a + b\<close>)] while (*y != 0) {
+      let xv = *x;
+      let yv = *y;
+      x = yv;
+      y = \<llangle>xv mod yv\<rrangle>
+    };
+    *x
+  \<rbrakk>\<close>
+
+definition gcd_contract where
+  \<open>gcd_contract a b \<equiv>
+    make_function_contract
+      (can_alloc_reference)
+      (\<lambda>ret. \<langle>ret = gcd a b\<rangle> \<star> can_alloc_reference)\<close>
+ucincl_auto gcd_contract
+
+lemma gcd_spec:
+  shows \<open>\<Gamma>; gcd_prog a b \<Turnstile>\<^sub>F gcd_contract a b\<close>
+  apply (crush_boot f: gcd_prog_def contract: gcd_contract_def)
+  apply crush_base
+  subgoal for x_ref y_ref
+    apply (ucincl_discharge\<open>
+      rule_tac
+        INV=\<open>\<lambda>k. \<Squnion> xv yv. fully_owns x_ref xv \<star> fully_owns y_ref yv \<star> \<langle>gcd xv yv = gcd a b \<and> yv \<le> k\<rangle>\<close> and
+        INV'=\<open>\<lambda>k. \<Squnion> xv yv. fully_owns x_ref xv \<star> fully_owns y_ref yv \<star> \<langle>gcd xv yv = gcd a b \<and> 0 < yv \<and> yv \<le> k + 1\<rangle>\<close> and
+        \<tau>=\<open>\<lambda>_. \<langle>False\<rangle>\<close> and
+        \<theta>=\<open>\<lambda>_. \<langle>False\<rangle>\<close>
+      in wp_bounded_while_framedI
+    \<close>)
+    apply crush_base
+    subgoal for k _ _ r ra
+      using mod_less_divisor[of ra r] by linarith
+    subgoal by (simp add: gcd.commute)
+    done
+  done
+
+subsection\<open>Extended GCD\<close>
+
+definition egcd_prog where
+  \<open>egcd_prog (a :: int) b \<equiv> FunctionBody \<lbrakk>
+    let mut old_remainder = \<llangle>a\<rrangle>;
+    let mut remainder = \<llangle>b\<rrangle>;
+
+    let mut old_a_coef = \<llangle>1 :: int\<rrangle>;
+    let mut a_coef = \<llangle>0 :: int\<rrangle>;
+
+    let mut old_b_coef = \<llangle>0 :: int\<rrangle>;
+    let mut b_coef = \<llangle>1 :: int\<rrangle>;
+    #[fuel(\<epsilon>\<open>nat a + nat b\<close>)] while (*remainder > \<llangle>0 :: int\<rrangle>) {
+      let old_remainder_val = *old_remainder;
+      let remainder_val = *remainder;
+      let quotient = \<llangle>old_remainder_val div remainder_val\<rrangle>;
+      old_remainder = remainder_val;
+      remainder = \<llangle>old_remainder_val - quotient * remainder_val\<rrangle>;
+
+      let old_a_coef_val = *old_a_coef;
+      let a_coef_val = *a_coef;
+      old_a_coef = a_coef_val;
+      a_coef = \<llangle>old_a_coef_val - quotient * a_coef_val\<rrangle>;
+
+      let old_b_coef_val = *old_b_coef;
+      let b_coef_val = *b_coef;
+      old_b_coef = b_coef_val;
+      b_coef = \<llangle>old_b_coef_val - quotient * b_coef_val\<rrangle>
+    };
+
+    let final_remainder = *old_remainder;
+    let final_a_coef = *old_a_coef;
+    let final_b_coef = *old_b_coef;
+
+    (final_remainder, final_a_coef, final_b_coef)
+  \<rbrakk>\<close>
+
+definition egcd_contract where
+  \<open>egcd_contract (a :: int) b \<equiv>
+    make_function_contract
+      (\<langle>0 \<le> a \<and> 0 \<le> b\<rangle> \<star> can_alloc_reference)
+      (\<lambda>(g, s, t, _). \<langle>g = gcd a b \<and> a * s + b * t = g\<rangle> \<star> can_alloc_reference)\<close>
+ucincl_proof egcd_contract by (clarsimp split: prod.splits; ucincl_solve)
+
+\<comment> \<open>Heap layout + Bezout identity + gcd preservation\<close>
+abbreviation egcd_inv where
+  \<open>egcd_inv a b old_remainder_ref remainder_ref old_a_coef_ref a_coef_ref old_b_coef_ref b_coef_ref
+            old_remainder remainder old_a_coef a_coef old_b_coef b_coef \<equiv>
+    fully_owns old_remainder_ref old_remainder \<star>
+    fully_owns remainder_ref remainder \<star>
+    fully_owns old_a_coef_ref old_a_coef \<star>
+    fully_owns a_coef_ref a_coef \<star>
+    fully_owns old_b_coef_ref old_b_coef \<star>
+    fully_owns b_coef_ref b_coef \<star>
+    \<langle>a * old_a_coef + b * old_b_coef = old_remainder \<and>
+     a * a_coef + b * b_coef = remainder \<and>
+     0 \<le> old_remainder \<and> 0 \<le> remainder \<and>
+     gcd old_remainder remainder = gcd a b\<rangle>\<close>
+
+lemma egcd_spec:
+  shows \<open>\<Gamma>; egcd_prog a b \<Turnstile>\<^sub>F egcd_contract a b\<close>
+  apply (crush_boot f: egcd_prog_def contract: egcd_contract_def)
+  apply crush_base
+  subgoal for old_remainder_ref remainder_ref old_a_coef_ref a_coef_ref old_b_coef_ref b_coef_ref
+    apply (ucincl_discharge\<open>
+      rule_tac
+        INV=\<open>\<lambda>k. \<Squnion> old_remainder remainder old_a_coef a_coef old_b_coef b_coef.
+          egcd_inv a b old_remainder_ref remainder_ref old_a_coef_ref a_coef_ref old_b_coef_ref b_coef_ref old_remainder remainder old_a_coef a_coef old_b_coef b_coef \<star>
+          \<langle>remainder \<le> int k\<rangle>\<close> and
+        INV'=\<open>\<lambda>k. \<Squnion> old_remainder remainder old_a_coef a_coef old_b_coef b_coef.
+          egcd_inv a b old_remainder_ref remainder_ref old_a_coef_ref a_coef_ref old_b_coef_ref b_coef_ref old_remainder remainder old_a_coef a_coef old_b_coef b_coef \<star>
+          \<langle>0 < remainder \<and> remainder \<le> int k + 1\<rangle>\<close> and
+        \<tau>=\<open>\<lambda>_. \<langle>False\<rangle>\<close> and
+        \<theta>=\<open>\<lambda>_. \<langle>False\<rangle>\<close>
+      in wp_bounded_while_framedI
+    \<close>)
+      apply crush_base
+      subgoal for k _ _ _ _ _ _ r ra rb rc
+        apply (simp add: minus_div_mult_eq_mod)
+        using pos_mod_bound[of \<open>a * ra + b * rc\<close> \<open>a * r + b * rb\<close>]
+        by linarith
+      subgoal
+        by (simp add: minus_div_mult_eq_mod) (metis gcd.commute gcd_red_int)
+      subgoal
+        by (metis minus_div_mult_eq_mod pos_mod_sign diff_ge_0_iff_ge)
+      subgoal
+        by (simp add: algebra_simps)
+    done
+  done
+
+subsection\<open>Euler's Totient\<close>
+
+definition totient_prog where
+  \<open>totient_prog n \<equiv> FunctionBody \<lbrakk>
+    let mut count = \<llangle>0 :: nat\<rrangle>;
+    for i in 0..n {
+      let g = gcd_prog(\<llangle>unat i + 1\<rrangle>, \<llangle>unat n\<rrangle>);
+      if (\<llangle>g = 1\<rrangle>) {
+        count = *count + 1
+      }
+    };
+    *count
+  \<rbrakk>\<close>
+
+definition totient_contract where
+  \<open>totient_contract n \<equiv>
+    make_function_contract
+      (can_alloc_reference)
+      (\<lambda>ret. \<langle>ret = totient (unat n)\<rangle> \<star> can_alloc_reference)\<close>
+ucincl_auto totient_contract
+
+\<comment> \<open>\<^verbatim>\<open>|{k in {1..i+1}. P(k)}| = |{k in {1..i}. P(k)}| + (if P(i+1) then 1 else 0)\<close>\<close>
+lemma card_coprime_step:
+  \<open>card {k. Suc 0 \<le> k \<and> k \<le> Suc i \<and> P k} =
+   card {k. Suc 0 \<le> k \<and> k \<le> i \<and> P k} + (if P (Suc i) then 1 else 0)\<close>
+proof -
+  have \<open>{k. Suc 0 \<le> k \<and> k \<le> Suc i \<and> P k} =
+        {k. Suc 0 \<le> k \<and> k \<le> i \<and> P k} \<union> (if P (Suc i) then {Suc i} else {})\<close>
+    by (auto simp: le_Suc_eq)
+  thus ?thesis by (simp add: card_insert_if finite_subset[of _ "{0..i}"])
+qed
+
+lemma totient_spec:
+  shows \<open>\<Gamma>; totient_prog n \<Turnstile>\<^sub>F totient_contract n\<close>
+  apply (simp only: totient_contract_def totient_def totatives_def
+                    atLeastSucAtMost_greaterThanAtMost)
+  apply (crush_boot f: totient_prog_def)
+  apply crush_base
+  subgoal for count_ref
+    apply (ucincl_discharge\<open>
+      rule_tac
+        INV=\<open>\<lambda>_ i. fully_owns count_ref (card {k \<in> {1..i}. coprime k (unat n)}) \<star> can_alloc_reference\<close> and
+        \<tau>=\<open>\<lambda>_. \<langle>False\<rangle>\<close> and
+        \<theta>=\<open>\<lambda>_. \<langle>False\<rangle>\<close>
+      in wp_raw_for_loop_framedI'
+    \<close>)
+    apply (crush_base specs add: gcd_spec contracts add: gcd_contract_def simp add: unat_of_nat_eq le_unat_uoi')
+    subgoal by (auto simp: le_Suc_eq coprime_iff_gcd_eq_1 intro: arg_cong[of _ _ card])
+    subgoal by (simp add: card_coprime_step coprime_iff_gcd_eq_1)
+    subgoal by (auto intro: arg_cong[of _ _ card])
+  done
+done
+
+subsection\<open>Modular Exponentiation\<close>
+
+definition mod_exp_prog where
+  \<open>mod_exp_prog base ex m \<equiv> FunctionBody \<lbrakk>
+    let mut b = \<llangle>base :: nat\<rrangle>;
+    let mut e = \<llangle>ex :: nat\<rrangle>;
+    let mut acc = \<llangle>1 :: nat\<rrangle>;
+
+    #[fuel(\<epsilon>\<open>ex\<close>)] while (*e != 0) {
+      let ev = *e;
+      let bv = *b;
+      let av = *acc;
+
+      if (\<llangle>ev mod 2 = 1\<rrangle>) {
+        acc = \<llangle>av * bv mod m\<rrangle>
+      };
+
+      b = \<llangle>bv * bv mod m\<rrangle>;
+      e = \<llangle>ev div 2\<rrangle>
+    };
+
+    *acc
+  \<rbrakk>\<close>
+
+definition mod_exp_contract where
+  \<open>mod_exp_contract base ex m \<equiv>
+    make_function_contract
+      (\<langle>m \<noteq> 1\<rangle> \<star> can_alloc_reference)
+      (\<lambda>ret. \<langle>ret = base ^ ex mod m\<rangle> \<star> can_alloc_reference)\<close>
+ucincl_auto mod_exp_contract
+
+lemma sq_pow_even: \<open>even n \<Longrightarrow> (x * x) ^ (n div 2) = x ^ n\<close>
+  for x :: nat
+proof (elim evenE)
+  fix k assume \<open>n = 2 * k\<close>
+  thus \<open>(x * x) ^ (n div 2) = x ^ n\<close>
+    by (simp add: power_mult_distrib mult_2 flip: power_add)
+qed
+
+lemma sq_pow_odd: \<open>n mod 2 = Suc 0 \<Longrightarrow> x * (x * x) ^ (n div 2) = x ^ n\<close>
+  for x :: nat
+proof -
+  assume \<open>n mod 2 = Suc 0\<close>
+  hence nk: \<open>n = Suc (2 * (n div 2))\<close> by arith
+  show ?thesis
+    by (subst nk) (simp add: power_mult_distrib mult_2 power_add)
+qed
+
+lemma mod_exp_spec:
+  shows \<open>\<Gamma>; mod_exp_prog base ex m \<Turnstile>\<^sub>F mod_exp_contract base ex m\<close>
+  apply (crush_boot f: mod_exp_prog_def contract: mod_exp_contract_def)
+  apply crush_base
+  subgoal for b_ref e_ref acc_ref
+    apply (ucincl_discharge\<open>
+      rule_tac
+        INV=\<open>\<lambda>k. \<Squnion> bv ev av. fully_owns b_ref bv \<star> fully_owns e_ref ev \<star> fully_owns acc_ref av \<star> \<langle>(av * bv ^ ev) mod m = base ^ ex mod m \<and> (0 < m \<longrightarrow> av < m) \<and> ev \<le> k\<rangle>\<close> and
+        INV'=\<open>\<lambda>k. \<Squnion> bv ev av. fully_owns b_ref bv \<star> fully_owns e_ref ev \<star> fully_owns acc_ref av \<star> \<langle>(av * bv ^ ev) mod m = base ^ ex mod m \<and> (0 < m \<longrightarrow> av < m) \<and> 0 < ev \<and> ev \<le> k + 1\<rangle>\<close> and
+        \<tau>=\<open>\<lambda>_. \<langle>False\<rangle>\<close> and
+        \<theta>=\<open>\<lambda>_. \<langle>False\<rangle>\<close>
+      in wp_bounded_while_framedI
+    \<close>)
+    apply crush_base
+    subgoal by linarith
+    subgoal for k _ _ _ ev bv av
+      using sq_pow_even[of ev bv]
+      by (metis mod_mult_right_eq power_mod)
+    subgoal by linarith
+    subgoal for k _ _ _ ev bv av
+      using sq_pow_odd[of ev bv]
+      by (simp add: mod_mult_left_eq mult.assoc) (metis mod_mult_right_eq power_mod)
+    subgoal by auto
+  done
+done
+
+subsection\<open>Primality Testing\<close>
+
+definition is_prime_prog where
+  \<open>is_prime_prog n \<equiv> FunctionBody \<lbrakk>
+    if (\<llangle>unat n < 2\<rrangle>) {
+      return False;
+    };
+
+    for i in 0..n {
+      if (\<llangle>(unat i + 2) * (unat i + 2) \<le> unat n \<and> unat n mod (unat i + 2) = 0\<rrangle>) {
+        return False;
+      }
+    };
+
+    True
+  \<rbrakk>\<close>
+
+definition is_prime_contract where
+  \<open>is_prime_contract n \<equiv>
+    make_function_contract
+      (can_alloc_reference)
+      (\<lambda>ret. \<langle>ret = prime (unat n)\<rangle> \<star> can_alloc_reference)\<close>
+ucincl_auto is_prime_contract
+
+lemma primeI_no_small_divisor:
+  assumes \<open>1 < (n :: nat)\<close> \<open>\<forall>d \<in> {2..n}. d\<^sup>2 \<le> n \<longrightarrow> \<not> d dvd n\<close>
+  shows \<open>prime n\<close>
+proof (rule ccontr)
+  assume np: \<open>\<not> prime n\<close>
+  from prime_factor_nat[of n] assms(1) obtain p where p: \<open>prime p\<close> \<open>p dvd n\<close> by auto
+  let ?q = \<open>n div p\<close>
+  have n_eq: \<open>n = p * ?q\<close> using p(2) by simp
+  have p2: \<open>2 \<le> p\<close> using p(1) prime_ge_2_nat by simp
+  have q_nz: \<open>?q \<noteq> 0\<close> using n_eq assms(1) by (cases ?q) auto
+  have q_n1: \<open>?q \<noteq> 1\<close> using n_eq p(1) np by auto
+  have q2: \<open>2 \<le> ?q\<close> using q_nz q_n1 by linarith
+  define d where \<open>d = min p ?q\<close>
+  have \<open>d\<^sup>2 \<le> p * ?q\<close> unfolding d_def power2_eq_square
+    by (simp add: min_def mult_le_mono1 mult_le_mono2)
+  moreover have \<open>d dvd n\<close> unfolding d_def using p(2) n_eq by (auto simp: min_def dvd_div_iff_mult)
+  moreover have \<open>d \<in> {2..n}\<close>
+    unfolding d_def using p2 q2 dvd_imp_le[OF p(2)] div_le_dividend[of n p] assms(1) by (auto simp: min_def)
+  ultimately show False using assms(2) n_eq by auto
+qed
+
+lemmas prime_natD = prime_nat_iff[THEN iffD1, THEN conjunct2, rule_format]
+
+\<comment> \<open>Extending the no-small-divisor range by one\<close>
+lemma no_small_divisor_step:
+  assumes inv: \<open>\<forall>d \<in> {2..i+1}. d\<^sup>2 \<le> n \<longrightarrow> \<not> d dvd n\<close>
+    and body: \<open>\<not> ((i+2)\<^sup>2 \<le> n \<and> (i+2) dvd n)\<close>
+  shows \<open>\<forall>d \<in> {2..i+2}. d\<^sup>2 \<le> n \<longrightarrow> \<not> d dvd (n :: nat)\<close>
+proof (intro ballI impI notI)
+  fix d assume \<open>d \<in> {2..i+2}\<close> \<open>d\<^sup>2 \<le> n\<close> \<open>d dvd n\<close>
+  hence \<open>d \<in> {2..i+1} \<or> d = i+2\<close> by auto
+  thus False
+  proof
+    assume \<open>d \<in> {2..i+1}\<close>
+    with inv \<open>d\<^sup>2 \<le> n\<close> \<open>d dvd n\<close> show False by auto
+  next
+    assume \<open>d = i+2\<close>
+    with body \<open>d\<^sup>2 \<le> n\<close> \<open>d dvd n\<close> show False by auto
+  qed
+qed
+
+lemma is_prime_spec:
+  shows \<open>\<Gamma>; is_prime_prog n \<Turnstile>\<^sub>F is_prime_contract n\<close>
+  apply (crush_boot f: is_prime_prog_def contract: is_prime_contract_def)
+  apply crush_base
+  subgoal
+    apply (ucincl_discharge\<open>
+      rule_tac
+        INV=\<open>\<lambda>_ i. \<langle>\<forall>d \<in> {2..i + 1}. d\<^sup>2 \<le> unat n \<longrightarrow> \<not> d dvd unat n\<rangle> \<star> can_alloc_reference\<close> and
+        \<tau>=\<open>\<lambda>ret. \<langle>ret = False \<and> \<not> prime (unat n)\<rangle> \<star> can_alloc_reference\<close> and
+        \<theta>=\<open>\<lambda>_. \<langle>False\<rangle>\<close>
+      in wp_raw_for_loop_framedI'
+    \<close>)
+    apply crush_base
+    subgoal for i d
+      apply (frule le_unat_uoi', simp)
+      apply (drule no_small_divisor_step[of i \<open>unat n\<close>, simplified])
+      apply (simp add: power2_eq_square algebra_simps dvd_eq_mod_eq_0)
+      by auto
+    subgoal for i
+      apply (frule le_unat_uoi')
+      apply simp
+      apply (drule(1) prime_natD)
+      by (simp add: algebra_simps)
+    subgoal using primeI_no_small_divisor by auto
+    done
+  subgoal using not_prime_0 not_prime_1 by (auto simp: less_2_cases_iff unat_eq_zero)
+  done
+
+end
+
+end

--- a/Micro_Rust_Examples/ROOT
+++ b/Micro_Rust_Examples/ROOT
@@ -23,6 +23,9 @@ session Micro_Rust_Examples = HOL +
     Reference_Examples
     Showcase
     Number_Theory
+    FSet_Ref
+    Stack
+    Graph
     MLKEM_Parameters
     MLKEM_Specification
     MLKEM_Zq

--- a/Micro_Rust_Examples/ROOT
+++ b/Micro_Rust_Examples/ROOT
@@ -2,6 +2,7 @@ session Micro_Rust_Examples = HOL +
   options [document = pdf, document_output = "output"]
   sessions
     "HOL-Library"
+    "HOL-Number_Theory"
     Separation_Lenses
     Shallow_Micro_Rust
     Shallow_Separation_Logic
@@ -21,6 +22,7 @@ session Micro_Rust_Examples = HOL +
     Linked_List_Executable_Physical_Memory
     Reference_Examples
     Showcase
+    Number_Theory
     MLKEM_Parameters
     MLKEM_Specification
     MLKEM_Zq

--- a/Micro_Rust_Examples/Stack.thy
+++ b/Micro_Rust_Examples/Stack.thy
@@ -1,0 +1,193 @@
+(* Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+   SPDX-License-Identifier: MIT *)
+
+theory Stack
+  imports
+    Micro_Rust_Examples.Linked_List
+begin
+
+section\<open>Stack\<close>
+
+text\<open>Linked-list backed uRust stack type.\<close>
+
+locale stack =
+    ll_example _ _ _ _ _ _ _ reference_types ref_gref_opt_prism \<open>iso_prism id id\<close> ll_focus
+  + ref_ll_node: reference_allocatable reference_types _ _ _ _ _ _ _ node_prism
+  for
+    reference_types :: \<open>'s::{sepalg} \<Rightarrow> 'addr \<Rightarrow> 'gv \<Rightarrow> 'abort \<Rightarrow> 'i prompt \<Rightarrow> 'o prompt_output \<Rightarrow> unit\<close> and
+    ref_gref_opt_prism :: \<open>('gv, ('addr, 'gv) gref option) prism\<close> and
+    ll_focus :: \<open>('gv, ('addr, 'gv, 't) ll_node_raw) focus\<close> and
+    node_prism :: \<open>('gv, ('addr, 'gv, 't) ll_node_raw) prism\<close>
+  + assumes ll_focus_node_prism: \<open>ll_focus = prism_to_focus node_prism\<close>
+begin
+
+adhoc_overloading store_reference_const \<rightleftharpoons> ref_ll_node.new
+
+lemma prism_embed_iso_prism_id [simp]: \<open>prism_embed (iso_prism id id) = id\<close>
+  by (auto simp: iso_prism_def)
+
+lemma gref_map_id [simp]: \<open>gref_map id = id\<close>
+  by (auto simp: gref_map_def)
+
+abbreviation gref_of_ref ::
+  \<open>('addr, 'gv, ('addr, 'gv, 't) ll_node_raw) Global_Store.ref \<Rightarrow> ('addr, 'gv) gref\<close> where
+  \<open>gref_of_ref r \<equiv> unwrap_focused r\<close>
+
+\<comment> \<open>Separation logic predicate relating a stack reference and a list\<close>
+
+definition stack_points_to :: \<open>'t list \<Rightarrow> ('addr, 'gv, ('addr, 'gv) gref option) Global_Store.ref \<Rightarrow> 's assert\<close>
+  where \<open>stack_points_to ts s \<equiv> (\<Squnion>b h. s \<mapsto>\<langle>\<top>\<rangle> b\<down>h \<star> ll_points_to ts h None)\<close>
+
+lemma ucincl_stack_points_to [ucincl_intros]:
+  shows \<open>ucincl (stack_points_to ts s)\<close>
+  unfolding stack_points_to_def by (auto intro!: ucincl_intros)
+
+lemma ll_ptr_as_ref'_gref_of_ref:
+  assumes \<open>\<integral> xa = \<integral>\<^sub>p node_prism\<close>
+  shows \<open>ll_ptr_as_ref' (gref_of_ref xa) = xa\<close>
+  using assms by (simp add: ll_focus_node_prism focused.expand)
+
+subsection\<open>Empty\<close>
+
+definition empty ::
+  \<open>('s, ('addr, 'gv, ('addr, 'gv) gref option) Global_Store.ref, 'abort, 'i prompt, 'o prompt_output) function_body\<close> where
+  \<open>empty \<equiv> FunctionBody \<lbrakk>
+     let mut s = \<llangle>None :: ('addr, 'gv) gref option\<rrangle>;
+     s
+   \<rbrakk>\<close>
+
+definition empty_contract ::
+  \<open>('s, ('addr, 'gv, ('addr, 'gv) gref option) Global_Store.ref, 'abort) function_contract\<close> where
+  [crush_contracts]: \<open>empty_contract \<equiv>
+     let pre = can_alloc_reference in
+     let post = \<lambda>r. can_alloc_reference \<star> stack_points_to [] r in
+     make_function_contract pre post\<close>
+ucincl_auto empty_contract
+
+lemma empty_spec [crush_specs]:
+  shows \<open>\<Gamma>; empty \<Turnstile>\<^sub>F empty_contract\<close>
+  apply (crush_boot f: empty_def contract: empty_contract_def)
+  apply (clarsimp simp add: stack_points_to_def ll_points_to_None asepconj_simp)
+  apply crush_base
+  done
+
+subsection\<open>Push\<close>
+
+definition push :: \<open>('addr, 'gv, ('addr, 'gv) gref option) Global_Store.ref \<Rightarrow> 't \<Rightarrow>
+     ('s, unit, 'abort, 'i prompt, 'o prompt_output) function_body\<close> where
+  \<open>push s x \<equiv> FunctionBody \<lbrakk>
+     let h = *s;
+     let mut node = \<llangle>make_ll_node_raw x\<rrangle>\<^sub>1(h);
+     s = Some(\<llangle>gref_of_ref\<rrangle>\<^sub>1(node))
+   \<rbrakk>\<close>
+
+definition push_contract ::
+  \<open>('addr, 'gv, ('addr, 'gv) gref option) Global_Store.ref \<Rightarrow> 't \<Rightarrow> 't list \<Rightarrow>
+   ('s, unit, 'abort) function_contract\<close> where
+  [crush_contracts]: \<open>push_contract s x ts \<equiv>
+     let pre = can_alloc_reference \<star> stack_points_to ts s in
+     let post = \<lambda>_. can_alloc_reference \<star> stack_points_to (x # ts) s in
+     make_function_contract pre post\<close>
+ucincl_auto push_contract
+
+lemma push_spec [crush_specs]:
+  shows \<open>\<Gamma>; push s x \<Turnstile>\<^sub>F push_contract s x ts\<close>
+  apply (crush_boot f: push_def contract: push_contract_def)
+  apply (clarsimp simp add: stack_points_to_def)
+  apply crush_base
+  apply (simp_all add: ll_focus_node_prism aentails_refl is_valid_ref_for_def)
+  done
+
+subsection\<open>Pop\<close>
+
+definition pop :: \<open>('addr, 'gv, ('addr, 'gv) gref option) Global_Store.ref \<Rightarrow>
+     ('s, 't option, 'abort, 'i prompt, 'o prompt_output) function_body\<close> where
+  \<open>pop s \<equiv> FunctionBody \<lbrakk>
+     match *s {
+       None \<Rightarrow> None,
+       Some(r) \<Rightarrow> {
+         let node = *\<llangle>ll_ptr_as_ref'\<rrangle>\<^sub>1(r);
+         s = \<llangle>ll_node_raw.next\<rrangle>\<^sub>1(node);
+         Some(\<llangle>ll_node_raw.data\<rrangle>\<^sub>1(node))
+       }
+     }
+   \<rbrakk>\<close>
+
+definition pop_contract ::
+  \<open>('addr, 'gv, ('addr, 'gv) gref option) Global_Store.ref \<Rightarrow> 't list \<Rightarrow>
+   ('s, 't option, 'abort) function_contract\<close> where
+  [crush_contracts]: \<open>pop_contract s ts \<equiv>
+     let pre = stack_points_to ts s in
+     let post = \<lambda>r. (case ts of
+          []    \<Rightarrow> stack_points_to [] s \<star> \<langle>r = None\<rangle>
+        | x#xs  \<Rightarrow> stack_points_to xs s \<star> \<langle>r = Some x\<rangle>) in
+     make_function_contract pre post\<close>
+ucincl_proof pop_contract
+  by (auto split: list.splits intro: ucincl_intros)
+
+lemma pop_spec [crush_specs]:
+  shows \<open>\<Gamma>; pop s \<Turnstile>\<^sub>F pop_contract s ts\<close>
+  apply (crush_boot f: pop_def contract: pop_contract_def)
+  apply (cases ts; clarsimp simp add: stack_points_to_def ll_points_to_None asepconj_simp)
+   apply (crush_base split!: option.splits)+
+  done
+
+subsection\<open>Is-empty\<close>
+
+definition is_empty :: \<open>('addr, 'gv, ('addr, 'gv) gref option) Global_Store.ref \<Rightarrow>
+     ('s, bool, 'abort, 'i prompt, 'o prompt_output) function_body\<close> where
+  \<open>is_empty s \<equiv> FunctionBody \<lbrakk>
+     match *s { None \<Rightarrow> True, Some(_) \<Rightarrow> False }
+   \<rbrakk>\<close>
+
+definition is_empty_contract ::
+  \<open>('addr, 'gv, ('addr, 'gv) gref option) Global_Store.ref \<Rightarrow> 't list \<Rightarrow>
+   ('s, bool, 'abort) function_contract\<close> where
+  [crush_contracts]: \<open>is_empty_contract s ts \<equiv>
+     let pre = stack_points_to ts s in
+     let post = \<lambda>r. stack_points_to ts s \<star> \<langle>r \<longleftrightarrow> ts = []\<rangle> in
+     make_function_contract pre post\<close>
+ucincl_auto is_empty_contract
+
+lemma is_empty_spec [crush_specs]:
+  shows \<open>\<Gamma>; is_empty s \<Turnstile>\<^sub>F is_empty_contract s ts\<close>
+  apply (crush_boot f: is_empty_def contract: is_empty_contract_def)
+  apply (cases ts; clarsimp simp add: stack_points_to_def ll_points_to_None asepconj_simp)
+   apply (crush_base split!: option.splits)+
+  done
+
+subsection\<open>Push-all\<close>
+
+definition push_all :: \<open>('addr, 'gv, ('addr, 'gv) gref option) Global_Store.ref \<Rightarrow> 't list \<Rightarrow>
+     ('s, unit, 'abort, 'i prompt, 'o prompt_output) function_body\<close> where
+  \<open>push_all s xs \<equiv> FunctionBody \<lbrakk>
+     for w in \<llangle>xs\<rrangle> {
+       push(s, w);
+     }
+   \<rbrakk>\<close>
+
+definition push_all_contract where
+  [crush_contracts]: \<open>push_all_contract s xs ts \<equiv>
+     make_function_contract
+       (can_alloc_reference \<star> stack_points_to ts s)
+       (\<lambda>_. can_alloc_reference \<star> stack_points_to (rev xs @ ts) s)\<close>
+ucincl_auto push_all_contract
+
+lemma push_all_spec [crush_specs]:
+  shows \<open>\<Gamma>; push_all s xs \<Turnstile>\<^sub>F push_all_contract s xs ts\<close>
+  apply (crush_boot f: push_all_def contract: push_all_contract_def)
+  apply (crush_base simp add: list_into_iter_def)
+  apply (ucincl_discharge\<open>
+    rule_tac
+      INV = \<open>\<lambda>_ i. can_alloc_reference \<star> stack_points_to (rev (take i xs) @ ts) s\<close> and
+      \<tau>   = \<open>\<lambda>_. \<langle>False\<rangle>\<close> and
+      \<theta>   = \<open>\<lambda>_. \<langle>False\<rangle>\<close>
+    in wp_raw_for_loop_framedI'
+  \<close>)
+  subgoal by crush_base
+  subgoal by (crush_base simp add: take_Suc_conv_app_nth)
+  done
+
+end
+
+end


### PR DESCRIPTION
*Description of changes:* Adds some more examples of µRust programs, verified using AutoCorrode. 

- Number_Theory.thy: Fibonacci, GCD, extended GCD, Euler's totient, modular exponentiation, and a simple primality test
- FSet_Ref.thy: Reference-backed finite sets
- Stack.thy: Linked-list backed stack
- Graph.thy: Finite directed graphs with verified depth-first search

(Also adds `.DS_Store` to .gitignore. `.DS_Store` is a hidden macOS Finder settings file.)

**Tested:** `isabelle build -d . Micro_Rust_Examples`.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.