### PR TITLE
Extend function call and lift_fun syntax to support up to 14 arguments

### DIFF
--- a/Micro_Rust_Parsing_Frontend/Micro_Rust_Syntax.thy
+++ b/Micro_Rust_Parsing_Frontend/Micro_Rust_Syntax.thy
@@ -113,6 +113,14 @@ syntax
     ("\<llangle>_\<rrangle>\<^sub>9" [0]1000)
   "_urust_fun_literal10" :: "'value \<Rightarrow> urust_fun_literal"
     ("\<llangle>_\<rrangle>\<^sub>1\<^sub>0" [0]1000)
+  "_urust_fun_literal11" :: "'value \<Rightarrow> urust_fun_literal"
+    ("\<llangle>_\<rrangle>\<^sub>1\<^sub>1" [0]1000)
+  "_urust_fun_literal12" :: "'value \<Rightarrow> urust_fun_literal"
+    ("\<llangle>_\<rrangle>\<^sub>1\<^sub>2" [0]1000)
+  "_urust_fun_literal13" :: "'value \<Rightarrow> urust_fun_literal"
+    ("\<llangle>_\<rrangle>\<^sub>1\<^sub>3" [0]1000)
+  "_urust_fun_literal14" :: "'value \<Rightarrow> urust_fun_literal"
+    ("\<llangle>_\<rrangle>\<^sub>1\<^sub>4" [0]1000)
   \<comment>\<open>Primitive casts\<close>
   "_urust_primitive_integral_cast_u8" :: "urust \<Rightarrow> urust"
     ("(_) as/ u8" [100]1000)

--- a/Shallow_Micro_Rust/Core_Expression.thy
+++ b/Shallow_Micro_Rust/Core_Expression.thy
@@ -433,6 +433,18 @@ definition lift_fun9 :: \<open>('t0 \<Rightarrow> 't1 \<Rightarrow> 't2 \<Righta
 definition lift_fun10 :: \<open>('t0 \<Rightarrow> 't1 \<Rightarrow> 't2 \<Rightarrow> 't3 \<Rightarrow> 't4 \<Rightarrow> 't5 \<Rightarrow> 't6 \<Rightarrow> 't7 \<Rightarrow> 't8 \<Rightarrow> 't9 \<Rightarrow> 'v) \<Rightarrow>
                          ('t0 \<Rightarrow> 't1 \<Rightarrow> 't2 \<Rightarrow> 't3 \<Rightarrow> 't4 \<Rightarrow> 't5 \<Rightarrow> 't6 \<Rightarrow> 't7 \<Rightarrow> 't8 \<Rightarrow> 't9 \<Rightarrow> ('s, 'v, 'abort, 'i, 'o) function_body)\<close>
   where [micro_rust_simps]: \<open>lift_fun10 \<equiv> deep_compose10 fun_literal\<close>
+definition lift_fun11 :: \<open>('t0 \<Rightarrow> 't1 \<Rightarrow> 't2 \<Rightarrow> 't3 \<Rightarrow> 't4 \<Rightarrow> 't5 \<Rightarrow> 't6 \<Rightarrow> 't7 \<Rightarrow> 't8 \<Rightarrow> 't9 \<Rightarrow> 't10 \<Rightarrow> 'v) \<Rightarrow>
+                         ('t0 \<Rightarrow> 't1 \<Rightarrow> 't2 \<Rightarrow> 't3 \<Rightarrow> 't4 \<Rightarrow> 't5 \<Rightarrow> 't6 \<Rightarrow> 't7 \<Rightarrow> 't8 \<Rightarrow> 't9 \<Rightarrow> 't10 \<Rightarrow> ('s, 'v, 'abort, 'i, 'o) function_body)\<close>
+  where [micro_rust_simps]: \<open>lift_fun11 \<equiv> deep_compose11 fun_literal\<close>
+definition lift_fun12 :: \<open>('t0 \<Rightarrow> 't1 \<Rightarrow> 't2 \<Rightarrow> 't3 \<Rightarrow> 't4 \<Rightarrow> 't5 \<Rightarrow> 't6 \<Rightarrow> 't7 \<Rightarrow> 't8 \<Rightarrow> 't9 \<Rightarrow> 't10 \<Rightarrow> 't11 \<Rightarrow> 'v) \<Rightarrow>
+                         ('t0 \<Rightarrow> 't1 \<Rightarrow> 't2 \<Rightarrow> 't3 \<Rightarrow> 't4 \<Rightarrow> 't5 \<Rightarrow> 't6 \<Rightarrow> 't7 \<Rightarrow> 't8 \<Rightarrow> 't9 \<Rightarrow> 't10 \<Rightarrow> 't11 \<Rightarrow> ('s, 'v, 'abort, 'i, 'o) function_body)\<close>
+  where [micro_rust_simps]: \<open>lift_fun12 \<equiv> deep_compose12 fun_literal\<close>
+definition lift_fun13 :: \<open>('t0 \<Rightarrow> 't1 \<Rightarrow> 't2 \<Rightarrow> 't3 \<Rightarrow> 't4 \<Rightarrow> 't5 \<Rightarrow> 't6 \<Rightarrow> 't7 \<Rightarrow> 't8 \<Rightarrow> 't9 \<Rightarrow> 't10 \<Rightarrow> 't11 \<Rightarrow> 't12 \<Rightarrow> 'v) \<Rightarrow>
+                         ('t0 \<Rightarrow> 't1 \<Rightarrow> 't2 \<Rightarrow> 't3 \<Rightarrow> 't4 \<Rightarrow> 't5 \<Rightarrow> 't6 \<Rightarrow> 't7 \<Rightarrow> 't8 \<Rightarrow> 't9 \<Rightarrow> 't10 \<Rightarrow> 't11 \<Rightarrow> 't12 \<Rightarrow> ('s, 'v, 'abort, 'i, 'o) function_body)\<close>
+  where [micro_rust_simps]: \<open>lift_fun13 \<equiv> deep_compose13 fun_literal\<close>
+definition lift_fun14 :: \<open>('t0 \<Rightarrow> 't1 \<Rightarrow> 't2 \<Rightarrow> 't3 \<Rightarrow> 't4 \<Rightarrow> 't5 \<Rightarrow> 't6 \<Rightarrow> 't7 \<Rightarrow> 't8 \<Rightarrow> 't9 \<Rightarrow> 't10 \<Rightarrow> 't11 \<Rightarrow> 't12 \<Rightarrow> 't13 \<Rightarrow> 'v) \<Rightarrow>
+                         ('t0 \<Rightarrow> 't1 \<Rightarrow> 't2 \<Rightarrow> 't3 \<Rightarrow> 't4 \<Rightarrow> 't5 \<Rightarrow> 't6 \<Rightarrow> 't7 \<Rightarrow> 't8 \<Rightarrow> 't9 \<Rightarrow> 't10 \<Rightarrow> 't11 \<Rightarrow> 't12 \<Rightarrow> 't13 \<Rightarrow> ('s, 'v, 'abort, 'i, 'o) function_body)\<close>
+  where [micro_rust_simps]: \<open>lift_fun14 \<equiv> deep_compose14 fun_literal\<close>
 
 text\<open>As an example of a \<^term>\<open>fun_literal\<close> Micro Rust expression, we introduce the \<^emph>\<open>skip\<close> command:
 This is just an abbreviation for the unit literal, though with a more suggestive name for when we

--- a/Shallow_Micro_Rust/Core_Syntax.thy
+++ b/Shallow_Micro_Rust/Core_Syntax.thy
@@ -551,6 +551,40 @@ translations
        (_urust_shallow_args_app a6 (_urust_shallow_args_app a7
        (_urust_shallow_args_app a8 (_urust_shallow_args_single a9))))))))))"
     \<rightleftharpoons> "CONST funcall10 func a0 a1 a2 a3 a4 a5 a6 a7 a8 a9"
+  "_urust_shallow_fun_with_args func
+       (_urust_shallow_args_app a0 (_urust_shallow_args_app a1
+       (_urust_shallow_args_app a2 (_urust_shallow_args_app a3
+       (_urust_shallow_args_app a4 (_urust_shallow_args_app a5
+       (_urust_shallow_args_app a6 (_urust_shallow_args_app a7
+       (_urust_shallow_args_app a8 (_urust_shallow_args_app a9
+       (_urust_shallow_args_single a10)))))))))))"
+    \<rightleftharpoons> "CONST funcall11 func a0 a1 a2 a3 a4 a5 a6 a7 a8 a9 a10"
+  "_urust_shallow_fun_with_args func
+       (_urust_shallow_args_app a0 (_urust_shallow_args_app a1
+       (_urust_shallow_args_app a2 (_urust_shallow_args_app a3
+       (_urust_shallow_args_app a4 (_urust_shallow_args_app a5
+       (_urust_shallow_args_app a6 (_urust_shallow_args_app a7
+       (_urust_shallow_args_app a8 (_urust_shallow_args_app a9
+       (_urust_shallow_args_app a10 (_urust_shallow_args_single a11))))))))))))"
+    \<rightleftharpoons> "CONST funcall12 func a0 a1 a2 a3 a4 a5 a6 a7 a8 a9 a10 a11"
+  "_urust_shallow_fun_with_args func
+       (_urust_shallow_args_app a0 (_urust_shallow_args_app a1
+       (_urust_shallow_args_app a2 (_urust_shallow_args_app a3
+       (_urust_shallow_args_app a4 (_urust_shallow_args_app a5
+       (_urust_shallow_args_app a6 (_urust_shallow_args_app a7
+       (_urust_shallow_args_app a8 (_urust_shallow_args_app a9
+       (_urust_shallow_args_app a10 (_urust_shallow_args_app a11
+       (_urust_shallow_args_single a12)))))))))))))"
+    \<rightleftharpoons> "CONST funcall13 func a0 a1 a2 a3 a4 a5 a6 a7 a8 a9 a10 a11 a12"
+  "_urust_shallow_fun_with_args func
+       (_urust_shallow_args_app a0 (_urust_shallow_args_app a1
+       (_urust_shallow_args_app a2 (_urust_shallow_args_app a3
+       (_urust_shallow_args_app a4 (_urust_shallow_args_app a5
+       (_urust_shallow_args_app a6 (_urust_shallow_args_app a7
+       (_urust_shallow_args_app a8 (_urust_shallow_args_app a9
+       (_urust_shallow_args_app a10 (_urust_shallow_args_app a11
+       (_urust_shallow_args_app a12 (_urust_shallow_args_single a13))))))))))))))"
+    \<rightleftharpoons> "CONST funcall14 func a0 a1 a2 a3 a4 a5 a6 a7 a8 a9 a10 a11 a12 a13"
 
   \<comment>\<open>These rules decompose method calls into calls using explicit self arguments.
      The translation is one-way; otherwise it fires for basically all functions.\<close>

--- a/Shallow_Micro_Rust/Micro_Rust_Shallow_Embedding.thy
+++ b/Shallow_Micro_Rust/Micro_Rust_Shallow_Embedding.thy
@@ -320,6 +320,14 @@ translations
     \<rightharpoonup> "CONST lift_fun9 f"
   "_shallow(_urust_fun_literal10 f)"
     \<rightharpoonup> "CONST lift_fun10 f"
+  "_shallow(_urust_fun_literal11 f)"
+    \<rightharpoonup> "CONST lift_fun11 f"
+  "_shallow(_urust_fun_literal12 f)"
+    \<rightharpoonup> "CONST lift_fun12 f"
+  "_shallow(_urust_fun_literal13 f)"
+    \<rightharpoonup> "CONST lift_fun13 f"
+  "_shallow(_urust_fun_literal14 f)"
+    \<rightharpoonup> "CONST lift_fun14 f"
   "_shallow(_urust_numeral num)"
     \<rightharpoonup> "CONST literal (_Numeral num)" \<comment>\<open>TODO: What type should we cast numerals to by default?\<close>
   "_shallow(_urust_numeral_0)"
@@ -1071,11 +1079,11 @@ ML\<open>
       val mk = Syntax.const
       fun mk_antiquotation t = mk \<^syntax_const>\<open>_urust_antiquotation\<close> $ t
       fun mk_callable_lifted ctor arity =
-        if arity >= 0 andalso arity <= 10 then
+        if arity >= 0 andalso arity <= 14 then
           mk_antiquotation (mk ("lift_fun" ^ Int.toString arity) $ ctor)
         else
           error ("struct expression: constructor arity " ^ Int.toString arity ^
-            " is unsupported (max 10)")
+            " is unsupported (max 14)")
       fun mk_args [e] = mk \<^syntax_const>\<open>_urust_args_single\<close> $ e
         | mk_args (e :: es) = mk \<^syntax_const>\<open>_urust_args_app\<close> $ e $ mk_args es
         | mk_args [] = error "struct expression: empty field list"


### PR DESCRIPTION
This fixes parsing failures for function/constructor calls with more than 10 arguments (e.g. struct constructors with 11 fields).

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
