### PR TITLE
[feature] Crush: Log schematic-variable instantiations per branch

### DIFF
--- a/Crush/config.ML
+++ b/Crush/config.ML
@@ -46,6 +46,10 @@ sig
   val log_calls : bool Config.T
   (* log ucincl discharge *)
   val log_ucincl : bool Config.T
+  (* log schematic variable instantiations performed by each crush branch *)
+  val log_schematics : bool Config.T
+  (* pause after each schematic instantiation and prompt the user *)
+  val ask_schematics : bool Config.T
   (* log sub-branches of transaction tactic *)
   val log_transactions : bool Config.T
   (* log crush setup time *)
@@ -123,6 +127,8 @@ struct
   val log_clarsimp = Attrib.setup_config_bool @{binding "crush_log_clarsimp"} (K false)
   val log_calls = Attrib.setup_config_bool @{binding "crush_log_calls"} (K true)
   val log_ucincl = Attrib.setup_config_bool @{binding "crush_log_ucincl"} (K false)
+  val log_schematics = Attrib.setup_config_bool @{binding "crush_log_schematics"} (K false)
+  val ask_schematics = Attrib.setup_config_bool @{binding "crush_ask_schematics"} (K false)
   val log_aentails_cancel = Attrib.setup_config_bool @{binding "crush_log_aentails_cancel"} (K false)
   val log_aentails_core = Attrib.setup_config_bool @{binding "crush_log_aentails_core"} (K false)
   val log_base_simps = Attrib.setup_config_bool @{binding "crush_log_base_simps"} (K false)

--- a/Crush/crush.ML
+++ b/Crush/crush.ML
@@ -542,11 +542,16 @@ struct
             invocation only needs to thread `log` through precomputed decorators. *)
          val time_toplevel_enabled = Config.get ctxt Crush_Config.time_toplevel
          val log_toplevel_enabled  = Config.get ctxt Crush_Config.log_toplevel
+         val log_schematics        = Config.get ctxt Crush_Config.log_schematics
+         val ask_schematics        = Config.get ctxt Crush_Config.ask_schematics
+         val schematics_flags      = {log = log_schematics, ask = ask_schematics}
          fun mk_decorator (msg, pos) =
            let val msg' = "crush_branch_" ^ msg
-               val time_dec = TIME_pos' ctxt pos time_toplevel_enabled msg'
-               val log_dec  = LOG_pos'  ctxt pos log_toplevel_enabled  msg'
-           in fn log => fn tac' => tac' |> time_dec log |> log_dec log end
+               val time_dec  = TIME_pos'           ctxt pos time_toplevel_enabled msg'
+               val log_dec   = LOG_pos'            ctxt pos log_toplevel_enabled  msg'
+               val schem_dec = LOG_SCHEMATICS_pos' ctxt pos schematics_flags      msg'
+           in fn log => fn tac' =>
+                tac' |> time_dec log |> log_dec log |> schem_dec log end
          (* We are hoisting this out because it dominates the runtime of very short
             crush calls, and is used 4 times in the branches below; we also defer
             evaluation to when we actually need it *)
@@ -781,6 +786,7 @@ struct
                      make_arg_parser "bigstep" Parser.parse_bool  (Config.put Crush_Config.do_big_steps) \<^here>,
                      make_modifier_parser "stepwise" (Config.put Crush_Config.stepwise true #>
                                                       Config.put Crush_Config.log_toplevel true #>
+                                                      Config.put Crush_Config.log_schematics true #>
                                                       Config.put Crush_Config.do_big_steps false) \<^here>,
                      make_modifier_parser "history"  (Config.put Crush_Config.keep_history true #>
                                                       Config.put Crush_Config.do_big_steps false) \<^here>,
@@ -799,7 +805,10 @@ struct
   val log_parsers = [make_log_parser "toplevel" Crush_Config.log_toplevel,
                      make_log_parser "clarsimp" Crush_Config.log_clarsimp,
                      make_log_parser "calls"    Crush_Config.log_calls,
-                     make_log_parser "ucincl"   Crush_Config.log_ucincl]
+                     make_log_parser "ucincl"   Crush_Config.log_ucincl,
+                     make_log_parser "schematics" Crush_Config.log_schematics,
+                     make_arg_parser' (Args.$$$ "ask" -- Args.$$$ "schematics")
+                       Parser.parse_bool (Config.put Crush_Config.ask_schematics) \<^here>]
 
   val add_del_parsers = [
      make_add_parser' (Args.$$$ "seplog" -- Args.$$$ "drule") @{named_theorems crush_aentails_drules} \<^here>,

--- a/Crush/tacticals.ML
+++ b/Crush/tacticals.ML
@@ -26,6 +26,12 @@ sig
   val LOG_pos : Proof.context -> Position.T -> bool -> string -> logger -> tactic -> tactic
   val LOG_pos' : Proof.context -> Position.T -> bool -> string -> logger -> (int -> tactic) -> (int -> tactic)
 
+  (* Log newly-instantiated schematics after each step of the wrapped tactic.
+     If `ask = true`, also pause and prompt the user for Continue / Abort
+     in an interactive frontend; in batch mode the ask component is a no-op. *)
+  val LOG_SCHEMATICS_pos' : Proof.context -> Position.T -> {log: bool, ask: bool}
+    -> string -> logger -> (int -> tactic) -> (int -> tactic)
+
   (* Log and report runtime of successful and failed invocations of tactic *)
   val LOGFULL : Proof.context -> bool -> string -> tactic -> tactic
   val LOGFULL' : Proof.context -> bool -> string -> (int -> tactic) -> (int -> tactic)
@@ -66,6 +72,8 @@ end;
 
 structure Crush_Tacticals: CRUSH_TACTICALS =
 struct
+
+  exception SMART of string
 
   fun IF' (guard : term -> bool) (t :int -> tactic) : int -> tactic =
     SUBGOAL (fn (goal, i) => if guard goal then t i else no_tac)
@@ -160,6 +168,78 @@ struct
 
   val LOG' = fn ctxt => fn enable => fn msg => LOG_pos' ctxt Position.none enable msg default_logger
 
+  fun LOG_SCHEMATICS_pos' (ctxt : Proof.context) (pos : Position.T)
+      ({log = enable_log, ask = enable_ask} : {log: bool, ask: bool})
+    : string -> logger -> (int -> tactic) -> (int -> tactic) =
+    if not (enable_log orelse enable_ask) then K (K I) else
+    fn msg => fn log => fn tac' => fn i => fn st =>
+      let
+        val thy = Proof_Context.theory_of ctxt
+        val vars_before = Term.add_vars (Thm.prop_of st) []
+        val names_before = map fst vars_before
+        val goal_before = SOME (Thm.prem_of st i) handle THM _ => NONE
+        fun pretty_ixn (nm, idx) =
+          Pretty.str ("?" ^ nm ^ (if idx = 0 then "" else "." ^ Int.toString idx))
+        fun pretty_binding value_of ((ixn, T) : (indexname * typ)) =
+          Pretty.block
+            ([pretty_ixn ixn, Pretty.brk 1, Pretty.str "::", Pretty.brk 1,
+              Syntax.pretty_typ ctxt T, Pretty.brk 1, Pretty.str ":="] @
+             (case value_of ixn of
+                SOME t => [Pretty.brk 1, Syntax.pretty_term ctxt t]
+              | NONE   => [Pretty.brk 1, Pretty.str "<unrecovered>"]))
+        fun inspect st' =
+          let
+            val names_after = Term.add_var_names (Thm.prop_of st') []
+            val newly = filter (fn (ixn, _) => not (member (op =) names_after ixn)) vars_before
+          in
+            if null newly then () else
+            let
+              val env_opt =
+                SOME (Pattern.match thy (Thm.prop_of st, Thm.prop_of st')
+                        (Vartab.empty, Vartab.empty))
+                handle Pattern.MATCH => NONE
+              fun value_of ixn =
+                env_opt |> Option.mapPartial (fn (_, tenv) =>
+                  Vartab.lookup tenv ixn |> Option.map snd)
+              val header = Pretty.block
+                [Pretty.mark_str
+                   (Markup.properties (Position.properties_of pos) Markup.position, msg),
+                 Pretty.brk 1, Pretty.str "instantiated:"]
+              val bindings = map (pretty_binding value_of) newly
+              val subgoal_block =
+                case goal_before of
+                  SOME g => [Pretty.item
+                              [Pretty.str "from subgoal:", Pretty.brk 1,
+                               Syntax.pretty_term ctxt g]]
+                | NONE => []
+              val body = header :: bindings @ subgoal_block
+              val _ = if enable_log then Pretty.chunks body |> log else ()
+            in
+              if enable_ask andalso Context_Position.reports_enabled ctxt then
+                let
+                  val (mkbtn, promise) = Active.dialog_text ()
+                  val prompt = Pretty.block
+                    [Pretty.str "Accept instantiation?", Pretty.brk 2,
+                     Pretty.str (mkbtn "Continue"), Pretty.brk 2,
+                     Pretty.str (mkbtn "Abort")]
+                  val _ = Pretty.chunks (body @ [prompt]) |> log
+                  val ans = Future.join promise
+                in
+                  if ans = "Continue" then ()
+                  else raise SMART "schematic instantiation rejected by user"
+                end
+              else ()
+            end
+          end
+        val cb = fn _ => fn t' => fn _ => fn success =>
+          if success then Option.app inspect t' else ()
+      in
+        (* Fast path: if there are no schematics in the pre-state, the wrapped
+           tactic cannot instantiate any, so skip the observation entirely. *)
+        if null names_before then tac' i st
+        else Crush_Time.time_seq cb (tac' i) st
+      end
+
   fun LOGFULL' (ctxt : Proof.context) (enable : bool) : string -> (int -> tactic) -> (int -> tactic) =
      let val l = LOGFULL ctxt enable in fn msg => fn t => l msg o t end
 
@@ -215,7 +295,6 @@ struct
 
   fun intlist_to_string ls = "[" ^ (fold (fn i => fn s => s ^ " " ^ (i |> Int.toString)) ls "") ^ " ]"
 
-  exception SMART of string
   fun REPEAT_SMART (ctxt : Proof.context) (log : logger) (aggressive : bool) (m : logger -> tactic) : tactic = let
 
      fun debug lvl = if lvl <= (Config.get ctxt Crush_Config.debug_level)  then tracing else K ()

--- a/Micro_Rust_Examples/Crush_Examples.thy
+++ b/Micro_Rust_Examples/Crush_Examples.thy
@@ -714,6 +714,57 @@ end
 text\<open>There are various other logging options which can be used to trace individual branches.
 See \<^file>\<open>../Crush/config.ML\<close> for a complete list.\<close>
 
+paragraph\<open>Tracing schematic-variable instantiations\<close>
+
+text\<open>A common source of failures deep inside a \<^verbatim>\<open>crush\<close> run is a branch silently picking the
+wrong witness for a schematic variable (e.g. the wrong existential witness in a separation-logic
+entailment). By the time the bad choice is noticed, several further steps have fired on top of it,
+making the root cause hard to locate.
+
+Set \<^verbatim>\<open>crush_log_schematics\<close> asks \<^verbatim>\<open>crush\<close> to log, for every step, any schematic variable that
+was *newly instantiated* by that step, together with the value chosen and the subgoal the branch
+was applied to. This is most useful with \<^verbatim>\<open>stepwise\<close>, which implies \<^verbatim>\<open>crush_log_schematics\<close>.
+You can also set \<^verbatim>\<open>crush_ask_schematics\<close> if you want to be able to confirm every instantiation.\<close>
+
+experiment
+  fixes P Q :: \<open>'a \<Rightarrow> 's::sepalg assert\<close>
+    and \<alpha> \<beta> \<gamma> \<delta> :: \<open>'s assert\<close>
+    and R :: bool
+  assumes PQ: \<open>\<And>x. R \<Longrightarrow> P x \<star> \<beta> \<longlongrightarrow> Q x \<star> \<gamma>\<close>
+     and P_ucincl[ucincl_intros]: \<open>\<And>x. ucincl (P x)\<close>
+begin
+  definition \<open>Some_Ex \<equiv> \<Squnion>x. P x\<close>
+ 
+  lemma \<open>\<delta> \<star> Some_Ex \<star> (\<alpha> \<star> \<beta>) \<star> \<langle>R\<rangle> \<longlongrightarrow> \<alpha> \<star> (\<Squnion>x. Q x) \<star> (\<gamma> \<star> \<delta>)\<close>
+    using [[crush_log_schematics]]
+    apply (crush_base simp prems add: Some_Ex_def seplog rule add: PQ)
+    oops
+
+  \<comment>\<open>Again, but this time implicit in \<^verbatim>\<open>stepwise\<close>, and giving a finer breakdown of steps:\<close>
+  lemma \<open>\<delta> \<star> Some_Ex \<star> (\<alpha> \<star> \<beta>) \<star> \<langle>R\<rangle> \<longlongrightarrow> \<alpha> \<star> (\<Squnion>x. Q x) \<star> (\<gamma> \<star> \<delta>)\<close>
+    apply (crush_base simp prems add: Some_Ex_def seplog rule add: PQ stepwise)
+    step *
+    oops
+    \<comment>\<open>Each line reports the branch name, the bindings it introduced, and the subgoal seen just
+       before the step.\<close>
+end
+
+text\<open>The fact that \<^verbatim>\<open>crush_log_schematics\<close> pinpoints which branch instantiated a schematic makes
+it especially useful in combination with the separation-logic entailment branches
+(\<^verbatim>\<open>aentails_rule_tac\<close>, \<^verbatim>\<open>aentails_drule_tac\<close>, \<^verbatim>\<open>aentails_crule_tac\<close>, \<^verbatim>\<open>schematics_tac\<close>),
+where a wrong witness for an existential is the typical failure mode.
+
+For even tighter control you can set \<^verbatim>\<open>crush_ask_schematics\<close>. This enables the same diff, but
+additionally *pauses* the proof in jEdit after every instantiation and offers a
+\<^verbatim>\<open>Continue\<close>/\<^verbatim>\<open>Abort\<close> dialog in the output panel. Clicking \<^verbatim>\<open>Abort\<close> terminates \<^verbatim>\<open>crush\<close> cleanly
+so the bad step can be inspected with the current proof state intact. In batch builds (no
+interactive frontend) the prompt is silently skipped so \<^verbatim>\<open>crush_ask_schematics\<close> degrades to
+the same behaviour as \<^verbatim>\<open>crush_log_schematics\<close>.
+
+Usage is identical to the other logging options, e.g.
+\<^verbatim>\<open>using [[crush_ask_schematics]]\<close> inside an \<^verbatim>\<open>experiment\<close> block, or
+\<^verbatim>\<open>crush_base (ask schematics: True)\<close> as a method argument.\<close>
+
 paragraph\<open>Comparing two \<^verbatim>\<open>crush\<close> calls\<close>
 
 text\<open>It sometimes happens that one notices one \<^verbatim>\<open>crush\<close> call succeeding and another failing, but it


### PR DESCRIPTION
Add `crush_log_schematics` to report newly instantiated schematics after each branch step, including the chosen value and the subgoal seen just before the step. Implied by `stepwise`. Also add `crush_ask_schematics` to pause and prompt Continue/Abort in jEdit after each instantiation; degrades to logging in batch builds.

Implemented as a new tactical `LOG_SCHEMATICS_pos'` in tacticals.ML, wired into `crush_base_step_tac_core`, with parser support for `log schematics:` and `ask schematics:` modifiers. Documented in Crush_Examples.thy.
