### PR TITLE
Crush: Avoid redundant or repeated computation of branch data

### DIFF
--- a/Crush/crush.ML
+++ b/Crush/crush.ML
@@ -536,13 +536,17 @@ struct
 
   val crush_base_step_tac_core = fn ctxt =>
      let
-         fun NOTE' log (msg, pos, tac') = let
-           val msg' = "crush_branch_" ^ msg
-           in
-               tac'
-            |> TIME_pos' ctxt pos (Config.get ctxt Crush_Config.time_toplevel) msg' log
-            |> LOG_pos' ctxt pos (Config.get ctxt Crush_Config.log_toplevel) msg' log
-           end
+         (* Hoisted out of the per-step closure: Config.get for time_toplevel /
+            log_toplevel only happens once per top-level apply, and TIME_pos' /
+            LOG_pos' are partially applied as far as possible, so each per-step
+            invocation only needs to thread `log` through precomputed decorators. *)
+         val time_toplevel_enabled = Config.get ctxt Crush_Config.time_toplevel
+         val log_toplevel_enabled  = Config.get ctxt Crush_Config.log_toplevel
+         fun mk_decorator (msg, pos) =
+           let val msg' = "crush_branch_" ^ msg
+               val time_dec = TIME_pos' ctxt pos time_toplevel_enabled msg'
+               val log_dec  = LOG_pos'  ctxt pos log_toplevel_enabled  msg'
+           in fn log => fn tac' => tac' |> time_dec log |> log_dec log end
          (* We are hoisting this out because it dominates the runtime of very short
             crush calls, and is used 4 times in the branches below; we also defer
             evaluation to when we actually need it *)
@@ -550,7 +554,7 @@ struct
              time_and_report ctxt "crush_instantiation_step_unfold_contract"
              (Config.get ctxt Crush_Config.time_step_instantiation_by_branch)
              (fn _ => crush_base_unfold_contract_tac ctxt))
-         val post_step_tac = crush_post_step_tac ctxt 
+         val post_step_tac = crush_post_step_tac ctxt
          val branches = [
             ("base_simps_tac"          , \<^here>, (fn _ => crush_branch_base_simps_tac ctxt)),
             ("destruct_tac"            , \<^here>, (fn _ => crush_branch_destruct_tac ctxt)),
@@ -579,11 +583,14 @@ struct
             ("clarsimp_filtered"       , \<^here>, (fn _ => crush_branch_filtered_clarsimp_tac ctxt)),
             ("clarsimp_fallback"       , \<^here>, (fn _ => crush_branch_clarsimp_fallback_tac ctxt))
            ] |>
-         List.map (fn (msg, pos, lazy_tac') => (msg, pos, LAZY' (fn _ =>
-           time_and_report ctxt ("crush_instantiation_step_" ^ msg)
-             (Config.get ctxt Crush_Config.time_step_instantiation_by_branch) lazy_tac')))
+         List.map (fn (msg, pos, lazy_tac') =>
+           let val tac = LAZY' (fn _ =>
+                 time_and_report ctxt ("crush_instantiation_step_" ^ msg)
+                   (Config.get ctxt Crush_Config.time_step_instantiation_by_branch) lazy_tac')
+               val decorate = mk_decorator (msg, pos)
+           in (decorate, tac) end)
      in fn log =>
-       let val branches = List.map (NOTE' log) branches in
+       let val branches = List.map (fn (decorate, tac) => decorate log tac) branches in
        fn i => fn st => (FIRST' branches THEN_ALL_NEW (TRY o post_step_tac)) i st
          handle ABORT msg => ("Early abort of crush step: " ^ msg |> Pretty.text |> Pretty.block |> Pretty.writeln; Seq.empty)
      end end

--- a/Crush/crush.ML
+++ b/Crush/crush.ML
@@ -257,8 +257,8 @@ struct
       specs |> filter spec_filter_schematic |> filter spec_filter_eager
     end
 
-  fun crush_branch_call_tac_core (ctxt: Proof.context) (func_name : string) (with_schematics: bool)
-    (eager: bool) (unfold_contract_tac : int -> tactic) : int -> tactic =
+  fun crush_branch_call_tac_core (ctxt: Proof.context) (with_schematics: bool)
+    (eager: bool) (unfold_contract_tac : int -> tactic) : string -> int -> tactic =
     let val LOG : string -> int -> tactic =
       if Config.get ctxt Crush_Config.log_calls then log_tac #> K else K (K all_tac)
     val eager_schematic_str = " (" ^ (eager |> Bool.toString) ^ "," ^ (with_schematics |> Bool.toString) ^ ")"
@@ -266,10 +266,6 @@ struct
     fun TIME_IT msg = time_and_report ctxt msg (Config.get ctxt Crush_Config.time_calls)
     val specs = TIME_IT "crush_branch_call_init_get_specs" (fn _ => crush_get_specs ctxt with_schematics eager)
     val unfold_contract_tac = TIME "crush_branch_call_intro_find_contract" unfold_contract_tac
-    val confirm_no_abort_tac = TIME "crush_branch_call_confirm_no_abort" (
-           (SOLVED' (TRY o unfold_contract_tac THEN' safe_asm_simp_tac (ctxt addsimps @{thms Let_def}))) ORELSE'
-           (LOG ("Failed to show that " ^ func_name ^ " has trivial abort-postcondition") THEN' K no_tac))
-
     val post_call_simp = TIME "crush_branch_post_call_simp" (TIME_IT "crush_branch_call_init_post_call_simp"
       (fn _ => if eager then
         let val post_call_unfold_thms = Named_Theorems.get ctxt @{named_theorems crush_specs_eager_unfold}
@@ -282,30 +278,38 @@ struct
            assumptions of the specification are present as pure premises. *)
         THEN_ALL_NEW assm_tac ctxt)
       ORELSE' assm_tac ctxt))
-    val call_without_abort =
-       TIME "crush_branch_call_intro" (intro_tac @{thms wp_callI} ctxt)
-       THEN'
-        ( find_spec
-          THEN' confirm_no_abort_tac
-          THEN' (
-            ( (unfold_contract_tac ORELSE' (LOG ("No contract for: " ^ func_name)))
-              THEN' post_call_simp
-              THEN' (LOG ("Call function: " ^ func_name) ) )
-            ORELSE' (LOG ("Failed to call function: " ^ func_name) ) ) )
-    val call_with_abort =
+    val intro_wp_call = TIME "crush_branch_call_intro" (intro_tac @{thms wp_callI} ctxt)
+    val intro_wp_call_with_abort =
        TIME "crush_branch_call_intro_with_abort" (intro_tac @{thms wp_call_with_abortI} ctxt)
-       THEN'
-        ( find_spec
-          THEN' (
-            ( (unfold_contract_tac ORELSE' (LOG ("No contract for: " ^ func_name)))
-              THEN' post_call_simp
-              THEN' (LOG ("Call function: " ^ func_name) ) )
-            ORELSE' (LOG ("Failed to call function: " ^ func_name) ) ) )
+
+    (* Hoisted: simpset construction and the goal-independent SOLVED' arm of the abort check. *)
+    val abort_simp_tac = safe_asm_simp_tac (ctxt addsimps @{thms Let_def})
+    val confirm_solved_arm = SOLVED' (TRY o unfold_contract_tac THEN' abort_simp_tac)
+    val time_confirm_no_abort = TIME "crush_branch_call_confirm_no_abort"
     in
-      call_without_abort ORELSE' call_with_abort
+      fn (func_name : string) =>
+        let
+          val log_no_abort_post = LOG ("Failed to show that " ^ func_name ^ " has trivial abort-postcondition")
+          val log_no_contract   = LOG ("No contract for: " ^ func_name)
+          val log_call_ok       = LOG ("Call function: " ^ func_name)
+          val log_call_failed   = LOG ("Failed to call function: " ^ func_name)
+          val confirm_no_abort_tac = time_confirm_no_abort
+                (confirm_solved_arm ORELSE' (log_no_abort_post THEN' K no_tac))
+          val body_after_find_spec =
+                ((unfold_contract_tac ORELSE' log_no_contract)
+                  THEN' post_call_simp
+                  THEN' log_call_ok)
+                ORELSE' log_call_failed
+          val call_without_abort =
+                intro_wp_call THEN' (find_spec THEN' confirm_no_abort_tac THEN' body_after_find_spec)
+          val call_with_abort =
+                intro_wp_call_with_abort THEN' (find_spec THEN' body_after_find_spec)
+        in
+          call_without_abort ORELSE' call_with_abort
+        end
     end
 
-  fun crush_branch_inline_call_tac (ctxt : Proof.context) (func_name : string) =
+  fun crush_branch_inline_call_tac (ctxt : Proof.context) : string -> int -> tactic =
     let
       val TIME = TIME' ctxt (Config.get ctxt Crush_Config.time_calls)
        val LOG : string -> int -> tactic =
@@ -317,18 +321,34 @@ struct
          (@{thm wp_call_inlineI} OF [thm]) handle THM _ => (@{thm wp_call_inline'I} OF [thm])
       val inlined_fun_defs = Named_Theorems.get ctxt @{named_theorems crush_inline}
       val inlined_call_rules = inlined_fun_defs |> List.map (pure_eta_expand #> make_wp_call_rule)
-    in TIME "crush_branch_inline_call" (
-      intro_tac inlined_call_rules ctxt
-      THEN' Separation_Logic_Tactics.aentails_wp_ssa_normalize_tac ctxt
-      THEN' LOG ("Call function: " ^ func_name ^ " (inlined)")
-    ) end
+      val intro_inlined = intro_tac inlined_call_rules ctxt
+      val ssa_normalize = Separation_Logic_Tactics.aentails_wp_ssa_normalize_tac ctxt
+      val timed = TIME "crush_branch_inline_call"
+    in
+      fn (func_name : string) =>
+        timed (intro_inlined
+               THEN' ssa_normalize
+               THEN' LOG ("Call function: " ^ func_name ^ " (inlined)"))
+    end
 
   fun crush_branch_call_tac (ctxt : Proof.context) (with_schematics : bool)
      (unfold_contract_tac : int -> tactic): int -> tactic =
-     IF_with_param' (Separation_Logic_Tactics.find_wp_call_function) (fn func =>
-               (if not with_schematics then crush_branch_inline_call_tac ctxt func else K no_tac)
-       ORELSE' crush_branch_call_tac_core ctxt func with_schematics true unfold_contract_tac
-       ORELSE' crush_branch_call_tac_core ctxt func with_schematics false unfold_contract_tac)
+     let
+       (* Build the per-(with_schematics, eager) call-tactics on first wp-call goal,
+          memoize across subsequent ones via Lazy.force. *)
+       val inline_call_lazy = Lazy.lazy (fn _ =>
+         if with_schematics then K (K no_tac)
+         else crush_branch_inline_call_tac ctxt)
+       val core_eager_lazy = Lazy.lazy (fn _ =>
+         crush_branch_call_tac_core ctxt with_schematics true  unfold_contract_tac)
+       val core_lazy_lazy = Lazy.lazy (fn _ =>
+         crush_branch_call_tac_core ctxt with_schematics false unfold_contract_tac)
+     in
+       IF_with_param' (Separation_Logic_Tactics.find_wp_call_function) (fn func =>
+                 Lazy.force inline_call_lazy func
+         ORELSE' Lazy.force core_eager_lazy  func
+         ORELSE' Lazy.force core_lazy_lazy   func)
+     end
 
   val crush_branch_aentails_core_tac : Proof.context -> int -> tactic = fn ctxt =>
     DWELL' ( IF' Separation_Logic_Tactics.is_entailment (

--- a/Crush/guards.ML
+++ b/Crush/guards.ML
@@ -149,10 +149,33 @@ struct
 
   fun update_guards_shallow_tac (ctxt : Proof.context) : int -> tactic =
     \<comment>\<open>We always want to ignore top-level pure binders\<close>
-    CONVERSION (Conv.params_conv ~1 update_guards_shallow_conv ctxt)
+    let
+      val add_guard_thms = Named_Theorems.get ctxt @{named_theorems add_guards}
+      fun conv_with_thms ctxt' =
+        let val update_single = update_guard_single_conv [] ctxt' add_guard_thms
+            fun core (t : cterm) =
+              (update_single then_conv
+               (is_guard_conv
+                else_conv (Conv.abs_conv (K Conv.all_conv) ctxt')
+                else_conv (Conv.comb_conv core)
+                else_conv Conv.all_conv)
+              ) t
+        in core end
+    in CONVERSION (Conv.params_conv ~1 conv_with_thms ctxt) end
   fun update_guards_deep_tac (ctxt : Proof.context) : int -> tactic =
     \<comment>\<open>We always want to ignore top-level pure binders\<close>
-    CONVERSION (Conv.params_conv ~1 (update_guards_deep_conv []) ctxt)
+    let
+      val add_guard_thms = Named_Theorems.get ctxt @{named_theorems add_guards}
+      fun core_conv (vs : cterm list) (ctxt' : Proof.context) =
+        let fun core (t : cterm) =
+          (update_guard_single_conv vs ctxt' add_guard_thms
+           then_conv (is_guard_conv
+             else_conv (Conv.abs_conv (fn (v, ctxt'') => fn t' => core_conv (v :: vs) ctxt'' t') ctxt')
+             else_conv (Conv.comb_conv core)
+            else_conv Conv.all_conv)
+          ) t
+        in core end
+    in CONVERSION (Conv.params_conv ~1 (core_conv []) ctxt) end
   fun update_guards_tac (deep : bool) : Proof.context -> int -> tactic =
     if deep then update_guards_deep_tac else update_guards_shallow_tac
 

--- a/Crush/tacticals.ML
+++ b/Crush/tacticals.ML
@@ -115,23 +115,24 @@ struct
 
   val time_to_str = fn t => (t |> #elapsed |> Time.fmt 6) ^ "s"
 
-  fun LOG_pos (ctxt : Proof.context) (pos : Position.T) (enable : bool) 
+  fun LOG_pos (ctxt : Proof.context) (pos : Position.T) (enable : bool)
     : string -> logger -> tactic -> tactic =
+    if not enable then K (K I) else
     let val log_goal = Config.get ctxt Crush_Config.log_goal in
-    if not enable then K (K I) else fn msg => fn log => fn tac =>
-      let val cb = fn (t : thm) => fn (t' : thm option) => fn (time : Timing.timing) => fn success => 
-             if success then 
-               [Pretty.mark_str (Markup.properties (Position.properties_of pos) Markup.position, msg), 
+    fn msg => fn log => fn tac =>
+      let val cb = fn (t : thm) => fn (t' : thm option) => fn (time : Timing.timing) => fn success =>
+             if success then
+               [Pretty.mark_str (Markup.properties (Position.properties_of pos) Markup.position, msg),
                  Pretty.brk 1, Pretty.str "success", Pretty.brk 1,
                  Pretty.enclose "(" ")" (time |> time_to_str |> Pretty.text)]
-                @ (if log_goal then 
+                @ (if log_goal then
                     [Pretty.fbrk,
                       [Pretty.str "Before:", Pretty.brk 1, Thm.major_prem_of t |> Syntax.pretty_term ctxt] |> Pretty.item,
                      Pretty.fbrk,
                       [Pretty.str "After:", Pretty.brk 1] @
                        ([Thm.major_prem_of (Option.valOf t') |> Syntax.pretty_term ctxt]
                         handle THM _ => Pretty.text "Done") |> Pretty.item]
-                   else [])                 
+                   else [])
                  |> Pretty.text_fold |> log
              else ()
       in


### PR DESCRIPTION
Minor speedups in `crush` by avoiding repeated or unnecessary computation.