### PR TITLE
Misc: add `in_set_cons` lemma

### DIFF
--- a/Misc/SetAdditional.thy
+++ b/Misc/SetAdditional.thy
@@ -124,6 +124,10 @@ lemma LetE:
     shows \<open>Q\<close>
   using assms by simp
 
+lemma in_set_cons:
+  shows \<open>(x \<in> set (Cons y zs)) = (x = y \<or> x \<in> set zs)\<close>
+  by auto
+
 (*<*)
 end
 (*>*)


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Add an `in_set_cons` lemma, which can be useful in combination with `simp only:` to prove list membership of concrete values in concrete lists.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
