### PR TITLE
I/R: Add Ir.init_with_header for keyword-aware theory init

### DIFF
--- a/ir/ir.ML
+++ b/ir/ir.ML
@@ -20,6 +20,7 @@ sig
   val get_cfg : unit -> config
 
   val init : string -> string list -> unit
+  val init_with_header : string -> string list -> {clauses: string} -> unit
   val init_from_document : string -> string -> int -> unit
   val fork : string -> string -> int -> unit
   val step : string -> string -> unit
@@ -363,17 +364,53 @@ fun has_pin_dep tab target_id =
 
 (* Create a new REPL.  Theory specs must already be loaded — either present
    in the initial heap or previously loaded via Ir.load_theory.
-   Pin specs ("pin@NAME") reference a pinned REPL's theory snapshot. *)
-fun init id specs =
+   Pin specs ("pin@NAME") reference a pinned REPL's theory snapshot.
+
+   `clauses` is the literal text that would appear between `imports ...`
+   and `begin` in a .thy file (typically a `keywords ...` clause,
+   optionally `abbrevs ...`).  Empty = no header clauses.  Parsed by
+   synthesizing a fake header and reading it via Thy_Header.read.
+   Disallowed for segment-rooted inits: recorded segments already
+   carry the keywords from their original .thy header. *)
+fun init_with_header id specs {clauses} =
   let val _ = if null specs then error "init requires at least one spec" else ()
+      val parsed = map parse_spec specs
+      val has_segment = exists (fn (_, opt) => is_some opt) parsed
+      val _ =
+        if clauses <> "" andalso has_segment then
+          error "init_with_header: clauses cannot be combined with segment \
+                \specs (\"Thy:idx\"); recorded segments already carry their \
+                \theory's keywords"
+        else ()
+      (* Parse the user's clauses by synthesizing a complete theory
+         header and feeding it to Thy_Header.read.  The grammar accepts
+         keywords and abbrevs clauses (see Thy_Header.args at
+         Pure/Thy/thy_header.ML:168-173) but the resulting `header`
+         record carries only `name`, `imports`, `keywords` (lines 44-47).
+         abbrevs is parsed and discarded — it's editor-tooling only,
+         consumed by Isabelle/Scala for jEdit autocomplete and has no
+         effect on ML-level theory state.  So extracting #keywords here
+         is exhaustive: it captures everything Isabelle itself would
+         apply to the theory at begin_theory time.
+
+         The synthetic name `IrInitHeader` and the `imports Pure` clause
+         are placeholders — Thy_Header.read needs them to satisfy its
+         grammar but we discard #name and #imports. *)
+      fun parse_keywords text =
+        if text = "" then []
+        else
+          let val synth = "theory IrInitHeader imports Pure " ^ text ^ " begin"
+              val {keywords, ...} = Thy_Header.read Position.none synth
+          in keywords end
+      val kws = parse_keywords clauses
       fun from_specs specs =
             let val tab = Synchronized.value repl_tab
                 val resolved = map (resolve_spec tab o string_to_spec) specs
                 val thys = map #1 resolved
                 val spec_list = map #2 resolved
                 val thy = Theory.begin_theory (id, Position.none) thys
+                            |> Thy_Header.add_keywords kws
             in (From_Theory spec_list, Toplevel.make_state (SOME thy)) end
-      val parsed = map parse_spec specs
       val (origin, st) =
         case parsed of
           [(thy_name, SOME idx)] =>
@@ -384,7 +421,7 @@ fun init id specs =
             in (From_Segment (thy_name, idx),
                 #state (seg : Document_Output.segment)) end
         | _ =>
-            let val _ = if exists (fn (_, opt) => is_some opt) parsed
+            let val _ = if has_segment
                         then error "Cannot mix theory and segment specs in multi-theory init"
                         else ()
             in from_specs (map #1 parsed) end
@@ -396,6 +433,8 @@ fun init id specs =
        else ((), Symtab.update (id, Repl r) tab));
      out ("Created REPL " ^ quote id)
   end;
+
+fun init id specs = init_with_header id specs {clauses = ""};
 
 fun init_from_document id node_name command_id =
   let
@@ -776,6 +815,9 @@ fun help () = out
   \\n\
   \  init id [specs]         create REPL from [\"Theory\"], [\"Theory:idx\"],\n\
   \                          [\"pin@A\"], or [\"T1\",\"T2\",...] (merges)\n\
+  \  init_with_header id [specs] {clauses=\"...\"}\n\
+  \                          like init, but parses .thy header clauses\n\
+  \                          (typically `keywords \"foo\" :: thy_decl`)\n\
   \  fork id new_id state_idx  fork sub-REPL from id at state (~1=latest)\n\
   \  step id \"isar text\"    append step to REPL\n\
   \  show id                describe REPL (origin, steps, staleness)\n\

--- a/ir/test_repl.py
+++ b/ir/test_repl.py
@@ -650,6 +650,87 @@ def core_tests(sock, prefix):
         send_recv(sock, f'Ir.remove {q(t)};')
     tests.append(("rebase_no_pins_is_noop", test_rebase_no_pins_is_noop))
 
+    def test_register_keyword_fails_without_header():
+        """Registering an Isar command for an undeclared keyword fails.
+
+        Isar theory headers normally declare new keywords via
+            theory T imports Main keywords "foo" begin
+        Without that, an ML step using @{command_keyword foo} to register
+        a command via Outer_Syntax.local_theory cannot succeed because
+        Ir.init has no way to extend the keyword table of the new theory.
+        Reproduces the underlying limitation that motivates a forthcoming
+        keywords-aware init."""
+        t = f"{prefix}_kw"
+        # Use a unique, otherwise-unknown identifier per test prefix to
+        # avoid collisions across concurrent runs.
+        kw = f"{prefix}_frobnicate"
+        send_recv(sock, f'Ir.init {q(t)} ["Main"];')
+        # The Isar text is: ML "val _ = Outer_Syntax.local_theory
+        #     @{command_keyword <kw>} \"stub\" (Scan.succeed I);"
+        # Wire bytes for the Ir.step argument:
+        #   "ML \"val _ = ... @{command_keyword <kw>} \\\"stub\\\" ...;\""
+        ml_body = (f'val _ = Outer_Syntax.local_theory '
+                   f'@{{command_keyword {kw}}} '
+                   f'\\\\\\"stub\\\\\\" '
+                   f'(Scan.succeed I);')
+        out = send_recv(sock, f'Ir.step {q(t)} "ML \\"{ml_body}\\"";')
+        # The failure surfaces via the protocol-level "ERR" prefix
+        # (parser-level error from @{command_keyword ...}, before the
+        # SML ERROR exception path).
+        assert "ERR" in out and kw in out and (
+            "Bad outer syntax command" in out or
+            "Undeclared outer syntax command" in out), \
+            f"Expected keyword-undeclared error mentioning {kw}, got:\n{out}"
+        send_recv(sock, f'Ir.remove {q(t)};')
+    tests.append(("register_keyword_fails_without_header",
+                  test_register_keyword_fails_without_header))
+
+    def test_init_with_header_succeeds_for_keyword():
+        """Inverse of test_register_keyword_fails_without_header: when
+        the keyword is declared via init_with_header's `clauses`, the
+        same Outer_Syntax.local_theory call succeeds."""
+        t = f"{prefix}_kwh"
+        kw = f"{prefix}_frobnicateh"
+        send_recv(
+            sock,
+            f'Ir.init_with_header {q(t)} ["Main"] '
+            f'{{clauses = "keywords \\"{kw}\\" :: thy_decl"}};')
+        ml_body = (f'val _ = Outer_Syntax.local_theory '
+                   f'@{{command_keyword {kw}}} '
+                   f'\\\\\\"stub\\\\\\" '
+                   f'(Scan.succeed I);')
+        out = send_recv(sock, f'Ir.step {q(t)} "ML \\"{ml_body}\\"";')
+        assert "ERR" not in out, \
+            f"Expected step to succeed with keyword declared, got:\n{out}"
+        send_recv(sock, f'Ir.remove {q(t)};')
+    tests.append(("init_with_header_succeeds_for_keyword",
+                  test_init_with_header_succeeds_for_keyword))
+
+    def test_init_with_header_empty_clauses_is_noop():
+        """Empty clauses behaves identically to plain Ir.init."""
+        t = f"{prefix}_kwe"
+        send_recv(sock, f'Ir.init_with_header {q(t)} ["Main"] {{clauses = ""}};')
+        out = send_recv(sock, f'Ir.step {q(t)} "lemma h: True by simp";')
+        assert "theorem h: True" in out, \
+            f"Expected step to succeed, got:\n{out}"
+        send_recv(sock, f'Ir.remove {q(t)};')
+    tests.append(("init_with_header_empty_clauses_is_noop",
+                  test_init_with_header_empty_clauses_is_noop))
+
+    def test_init_with_header_rejects_segment():
+        """Clauses combined with a segment spec should error."""
+        t = f"{prefix}_kws"
+        out = send_recv(
+            sock,
+            f'Ir.init_with_header {q(t)} ["HOL.HOL:0"] '
+            f'{{clauses = "keywords \\"kw\\" :: thy_decl"}} '
+            f'handle ERROR msg => writeln ("ERR: " ^ msg);')
+        assert "ERR" in out and "segment" in out, \
+            f"Expected segment-rejection error, got:\n{out}"
+
+    tests.append(("init_with_header_rejects_segment",
+                  test_init_with_header_rejects_segment))
+
     # Cleanup: remove the shared REPL
     def cleanup():
         send_recv(sock, f'Ir.remove {q(r)};')


### PR DESCRIPTION
A .thy file may declare new outer-syntax keywords in its header (`theory T imports Main keywords "frobnicate" :: thy_decl begin`). Ir.init has no way to declare such keywords on the new theory, so a subsequent ML step using
Outer_Syntax.local_theory @{command_keyword frobnicate} fails with "Bad outer syntax command". This blocks replaying any .thy that declares new keywords.

Add Ir.init_with_header taking a {clauses: string} record. The clauses text is the literal content between `imports ...` and `begin` in a .thy header — typically a `keywords` clause. We synthesize a fake header, parse it via Thy_Header.read, and chain Thy_Header.add_keywords on the freshly-built theory. The other valid header clause — `abbrevs`, declaring jEdit autocomplete abbreviations — is parsed-and-discarded by Isabelle itself (it has no ML-level effect), so extracting #keywords captures everything that matters at the theory level.

Ir.init becomes a one-line forwarder: no caller breakage. Segment specs are rejected when clauses is non-empty — recorded segments already carry their .thy's keywords.

Tests:
- test_register_keyword_fails_without_header: demonstrates the gap.
- test_init_with_header_succeeds_for_keyword: inverse, with the same ML step succeeding once keywords are declared at init time.
- test_init_with_header_empty_clauses_is_noop and test_init_with_header_rejects_segment.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
