### PR TITLE
RFC: ir: splice recorded post-proof state to fix mid-proof segment init

### DIFF
--- a/ir/ir.ML
+++ b/ir/ir.ML
@@ -214,12 +214,28 @@ type pin = {
   stale: bool
 };
 
+(* See `splice_step` for what segment_proof_splicer does and why.
+     initial: set once at init from the recorded post-proof-exit segment.
+     armed:   live state — SOME initial while a splice may still fire,
+              NONE after it has fired or been disarmed. *)
+type segment_proof_splicer = {
+  initial: Toplevel.state,
+  armed: Toplevel.state option
+};
+
+fun splicer_armed (NONE : segment_proof_splicer option) = NONE
+  | splicer_armed (SOME s) = #armed s;
+
+fun splicer_set_armed (NONE : segment_proof_splicer option) _ = NONE
+  | splicer_set_armed (SOME s) armed = SOME {initial = #initial s, armed = armed};
+
 type repl = {
   origin: origin,
   base_state: Toplevel.state,
   steps: repl_step list,
   timeout: int,
-  pin: pin option
+  pin: pin option,
+  splicer: segment_proof_splicer option
 };
 
 (* Concurrency guard: repl_tab stores repl_entry values.  A slow mutation
@@ -270,7 +286,8 @@ fun mark_pin_stale (r : repl) : repl =
   case #pin r of
     SOME p => {origin = #origin r, base_state = #base_state r, steps = #steps r,
                timeout = #timeout r,
-               pin = SOME {theory = #theory p, version = #version p, stale = true}}
+               pin = SOME {theory = #theory p, version = #version p, stale = true},
+               splicer = #splicer r}
   | NONE => r;
 
 fun release id r =
@@ -294,21 +311,65 @@ fun map_repl id (f : repl -> repl * 'a) : 'a =
 fun timeout id secs =
   (map_repl id (fn r =>
     ({origin = #origin r, base_state = #base_state r,
-      steps = #steps r, timeout = secs, pin = #pin r}, ()));
+      steps = #steps r, timeout = secs, pin = #pin r,
+      splicer = #splicer r}, ()));
    out ("Timeout for " ^ quote id ^ " set to " ^
         (if secs = 0 then "unlimited" else string_of_int secs ^ "s")));
 
-(* Execute Isar text against a state *)
-fun exec_text timeout_secs text st =
+(* When a theory is built with record_theories=true AND parallel proofs enabled,
+   Toplevel.element_result (Pure/Isar/toplevel.ML:752) forks each lemma body
+   via Proof.future_proof (Pure/Isar/proof.ML:1310), which rewrites the goal's
+   after_qed to a stub that does NOT call Local_Theory.notes_kind.  Every
+   segment recorded inside that future captures the stubbed Proof.state.
+   This is intentional from Isabelle's point of view (segments are for
+   document presentation, not for re-running a proof from the middle), but
+   it means initing a REPL at a mid-proof segment and stepping through qed
+   fails to register the theorem.
+
+   The splicer compensates: at init we stash the recorded state of the next
+   segment that exits the proof.  When the user's stepping crosses the
+   proof-exit boundary via a non-oops finisher — i.e., the proof was closed
+   successfully — we splice that recorded state in for the post-state.  oops
+   at the outermost proof level disarms the splicer without firing,
+   preserving "abandon proof, no theorem" semantics.
+
+   We detect oops via Keyword.is_qed_global on the transition's keyword name.
+   This is brittle: keyword classification is decoupled from semantic effect.
+     - A custom command not classified as qed_global can still wrap
+       Toplevel.forget_proof (semantically an oops); the splicer would fire
+       spuriously, registering the heap theorem despite the proof being
+       discarded.
+     - A custom command classified as qed_global can wrap a real
+       Isar_Cmd.qed; the splicer would disarm and trust the user's empty
+       post-state, losing the theorem.
+   Stock Pure/HOL ships only `oops` as qed_global, so for typical sessions
+   these limitations are deemed acceptable.  A more robust detection would
+   need to inspect the Toplevel.transition's primitive `trans` list, but
+   this is not exported / not inspectable. *)
+fun splice_step kws (tr : Toplevel.transition) pre post splicer =
+  case splicer of
+    NONE => (post, NONE)
+  | SOME splice_st =>
+      let val exited_proof = Toplevel.is_proof pre andalso not (Toplevel.is_proof post)
+          val is_oops = Keyword.is_qed_global kws (Toplevel.name_of tr)
+      in if exited_proof andalso not is_oops then (splice_st, NONE)
+         else if exited_proof then (post, NONE)
+         else (post, splicer)
+      end;
+
+(* Execute Isar text against a state, threading the splicer's `armed` state
+   through each transition. *)
+fun exec_text timeout_secs text st armed =
   let val thy = Toplevel.theory_of st
       val transitions = Outer_Syntax.parse_text thy (fn () => thy) Position.none text
-      fun run (tr, s) =
+      val kws = Thy_Header.get_keywords thy
+      fun run (tr, (s, sp)) =
         let val old = !Multithreading.parallel_proofs
             val _ = Multithreading.parallel_proofs := Int.min (2, old)
             val s' = Toplevel.command_exception false tr s
             val _ = Multithreading.parallel_proofs := old
-        in s' end
-      fun go () = List.foldl (fn (tr, s) => run (tr, s)) st transitions
+        in splice_step kws tr s s' sp end
+      fun go () = List.foldl run (st, armed) transitions
   in if timeout_secs > 0
      then Timeout.apply (Time.fromSeconds (Int.toLarge timeout_secs)) go ()
        handle Timeout.TIMEOUT _ =>
@@ -361,6 +422,22 @@ fun has_pin_dep tab target_id =
                                     | _ => false) specs
     | _ => false) tab;
 
+(* Build a splicer for a mid-proof recorded segment (state is_proof=true).
+   Walks forward to find the next segment whose state is no longer in proof
+   mode — that's the recorded post-qed state we'll splice in later. *)
+fun make_splicer thy_name segs idx : segment_proof_splicer =
+  let val len = length segs
+      fun go j =
+        if j >= len then
+          error ("Ir.init: mid-proof segment " ^ quote thy_name ^ ":" ^
+                 string_of_int idx ^ " has no following segment that exits the \
+                 \proof.  This indicates a malformed/truncated theory record.")
+        else
+          let val st = #state (nth segs j : Document_Output.segment)
+          in if not (Toplevel.is_proof st) then st else go (j + 1) end
+      val post = go (idx + 1)
+  in {initial = post, armed = SOME post} end;
+
 (* Create a new REPL.  Theory specs must already be loaded — either present
    in the initial heap or previously loaded via Ir.load_theory.
    Pin specs ("pin@NAME") reference a pinned REPL's theory snapshot. *)
@@ -372,24 +449,28 @@ fun init id specs =
                 val thys = map #1 resolved
                 val spec_list = map #2 resolved
                 val thy = Theory.begin_theory (id, Position.none) thys
-            in (From_Theory spec_list, Toplevel.make_state (SOME thy)) end
+            in (From_Theory spec_list, Toplevel.make_state (SOME thy), NONE) end
       val parsed = map parse_spec specs
-      val (origin, st) =
+      val (origin, st, splicer) =
         case parsed of
           [(thy_name, SOME idx)] =>
             let val segs = find_source thy_name
                 val seg = nth segs idx
                   handle General.Subscript =>
                     error ("Index " ^ string_of_int idx ^ " out of range")
-            in (From_Segment (thy_name, idx),
-                #state (seg : Document_Output.segment)) end
+                val st = #state (seg : Document_Output.segment)
+                val splicer = if Toplevel.is_proof st
+                             then SOME (make_splicer thy_name segs idx)
+                             else NONE
+            in (From_Segment (thy_name, idx), st, splicer) end
         | _ =>
             let val _ = if exists (fn (_, opt) => is_some opt) parsed
                         then error "Cannot mix theory and segment specs in multi-theory init"
                         else ()
             in from_specs (map #1 parsed) end
       val r : repl = {origin = origin, base_state = st, steps = [],
-                      timeout = default_timeout, pin = NONE}
+                      timeout = default_timeout, pin = NONE,
+                      splicer = splicer}
   in Synchronized.change_result repl_tab (fn tab =>
        if Symtab.defined tab id
        then error ("REPL " ^ quote id ^ " already exists")
@@ -417,7 +498,7 @@ fun init_from_document id node_name command_id =
     val toplevel_st = Command.eval_result_state eval
     val r : repl = {origin = From_Document (node_name, command_id),
                     base_state = toplevel_st, steps = [], timeout = default_timeout,
-                    pin = NONE}
+                    pin = NONE, splicer = NONE}
   in Synchronized.change_result repl_tab (fn tab =>
        if Symtab.defined tab id
        then error ("REPL " ^ quote id ^ " already exists")
@@ -440,17 +521,19 @@ fun fork parent_id new_id state_idx =
                  else error ("State " ^ string_of_int state_idx ^
                              " out of range (0.." ^ string_of_int n ^ ")")
         val r : repl = {origin = From_REPL (parent_id, i), base_state = st,
-                        steps = [], timeout = #timeout parent, pin = NONE}
+                        steps = [], timeout = #timeout parent, pin = NONE,
+                        splicer = #splicer parent}
     in Symtab.update (new_id, Repl r) tab end);
    out ("Forked REPL " ^ quote new_id ^ " from " ^ quote parent_id ^
         " at state " ^ string_of_int state_idx));
 
 fun step_repl timeout_secs text (r : repl) : repl =
   let val pre = last_state r
-      val post = exec_text timeout_secs text pre
+      val (post, armed') = exec_text timeout_secs text pre (splicer_armed (#splicer r))
       val s : repl_step = {text = text, pre_state = pre, post_state = post, stale = false}
   in {origin = #origin r, base_state = #base_state r,
-      steps = #steps r @ [s], timeout = #timeout r, pin = #pin r} end;
+      steps = #steps r @ [s], timeout = #timeout r, pin = #pin r,
+      splicer = splicer_set_armed (#splicer r) armed'} end;
 
 fun step id text =
   with_claim id (fn r =>
@@ -491,7 +574,8 @@ fun pin id =
         val new_v = case #pin r of NONE => 1 | SOME p => #version p + 1
         val p : pin = {theory = thy, version = new_v, stale = false}
     in ({origin = #origin r, base_state = #base_state r, steps = #steps r,
-         timeout = #timeout r, pin = SOME p}, new_v) end)
+         timeout = #timeout r, pin = SOME p,
+         splicer = #splicer r}, new_v) end)
   in out ("Pinned " ^ quote id) end;
 
 fun unpin id =
@@ -502,7 +586,8 @@ fun unpin id =
         if has_pin_dep tab id
         then error ("Cannot unpin " ^ quote id ^ ": other REPLs depend on it")
         else ((), Symtab.update (id, Repl {origin = #origin r, base_state = #base_state r,
-               steps = #steps r, timeout = #timeout r, pin = NONE}) tab));
+               steps = #steps r, timeout = #timeout r, pin = NONE,
+               splicer = #splicer r}) tab));
    out ("Unpinned " ^ quote id));
 
 fun show id =
@@ -533,17 +618,35 @@ fun text id =
   in out (String.concatWith "\n" t) end;
 
 fun replay_repl (r : repl) : repl =
-  let fun go _ [] acc = rev acc
-        | go prev_post (s :: rest) acc =
+  let
+      (* Replay starts from base_state with the splicer freshly armed.  Stale
+         steps are re-executed via exec_text (which threads the splicer for us);
+         kept (non-stale) steps had their post_state computed previously, but
+         we still need to disarm the splicer if such a kept step crossed the
+         proof-exit boundary back then — otherwise a later stale step would
+         spuriously splice. *)
+      fun consume_boundary (s : repl_step) armed =
+        case armed of
+          NONE => NONE
+        | SOME _ =>
+            if Toplevel.is_proof (#pre_state s) andalso
+               not (Toplevel.is_proof (#post_state s))
+            then NONE else armed
+      fun go _ armed [] acc = (rev acc, armed)
+        | go prev_post armed (s :: rest) acc =
             if #stale (s : repl_step) then
-              let val post = exec_text (#timeout r) (#text s) prev_post
+              let val (post, armed') = exec_text (#timeout r) (#text s) prev_post armed
                   val s' : repl_step = {text = #text s, pre_state = prev_post,
                                          post_state = post, stale = false}
-              in go post rest (s' :: acc) end
-            else go (#post_state s) rest (s :: acc)
+              in go post armed' rest (s' :: acc) end
+            else
+              go (#post_state s) (consume_boundary s armed) rest (s :: acc)
+      val initial_armed = Option.map #initial (#splicer r)
+      val (steps', armed') = go (#base_state r) initial_armed (#steps r) []
   in {origin = #origin r, base_state = #base_state r,
-      steps = go (#base_state r) (#steps r) [],
-      timeout = #timeout r, pin = #pin r} end;
+      steps = steps',
+      timeout = #timeout r, pin = #pin r,
+      splicer = splicer_set_armed (#splicer r) armed'} end;
 
 fun replay id =
   with_claim id (fn r =>
@@ -574,12 +677,32 @@ fun rebase id =
                  val n = length (#steps r)
                  val r' = {origin = From_Theory new_specs, base_state = new_base,
                            steps = mark_all_stale (#steps r),
-                           timeout = #timeout r, pin = #pin r}
+                           timeout = #timeout r, pin = #pin r,
+                           splicer = NONE}
              in (r', out ("Rebased " ^ quote id ^ " (" ^
                           string_of_int n ^ " steps marked stale; use replay to re-execute)")) end
         end
     | orig => error ("REPL " ^ quote id ^ " (from " ^ origin_str orig ^
                      ") does not support rebase"));
+
+fun crossed_proof_exit (steps : repl_step list) =
+  exists (fn s => not (#stale s) andalso
+                  Toplevel.is_proof (#pre_state s) andalso
+                  not (Toplevel.is_proof (#post_state s))) steps;
+
+(* Recompute the splicer's armed state from the current step list: armed iff no
+   non-stale step has crossed the proof-exit boundary.  Used after structural
+   edits (truncate, edit without auto-replay) to put the splicer in a coherent
+   state for subsequent steps. *)
+fun rearm_splicer (r : repl) : repl =
+  case #splicer r of
+    NONE => r
+  | SOME s =>
+      let val armed' = if crossed_proof_exit (#steps r) then NONE
+                       else SOME (#initial s)
+      in {origin = #origin r, base_state = #base_state r, steps = #steps r,
+          timeout = #timeout r, pin = #pin r,
+          splicer = SOME {initial = #initial s, armed = armed'}} end;
 
 fun edit_repl idx new_text (r : repl) : repl =
   let val steps = #steps r
@@ -587,15 +710,26 @@ fun edit_repl idx new_text (r : repl) : repl =
               then error ("Step " ^ string_of_int idx ^ " out of range") else ()
       val pre = if idx = 0 then #base_state r
                 else #post_state (nth steps (idx - 1))
-      val post = exec_text (#timeout r) new_text pre
-      val edited : repl_step = {text = new_text, pre_state = pre, post_state = post, stale = false}
       val before_steps = List.take (steps, idx)
+      (* Splicer's armed state for the edited step: armed iff the splicer is
+         active and no kept before-step has already crossed the proof-exit
+         boundary.  exec_text threads it onward through the edited transitions. *)
+      val armed_at_idx =
+        case #splicer r of
+          NONE => NONE
+        | SOME s =>
+            if crossed_proof_exit before_steps
+            then NONE else SOME (#initial s)
+      val (post, _) = exec_text (#timeout r) new_text pre armed_at_idx
+      val edited : repl_step = {text = new_text, pre_state = pre, post_state = post, stale = false}
       val after_steps = List.drop (steps, idx + 1)
         |> map (fn s : repl_step => {text = #text s, pre_state = #pre_state s,
                                       post_state = #post_state s, stale = true})
-      val r' : repl = {origin = #origin r, base_state = #base_state r,
-                        steps = before_steps @ [edited] @ after_steps,
-                        timeout = #timeout r, pin = #pin r}
+      val r' : repl = rearm_splicer
+                        {origin = #origin r, base_state = #base_state r,
+                         steps = before_steps @ [edited] @ after_steps,
+                         timeout = #timeout r, pin = #pin r,
+                         splicer = #splicer r}
   in if #auto_replay (get_cfg ()) andalso not (null after_steps)
      then replay_repl r' else r' end;
 
@@ -628,9 +762,11 @@ fun truncate id raw_idx =
               error ("Cannot truncate: sub-REPL " ^ quote rid ^ " is busy")
           | _ => ()) all_orphans
         val tab' = fold (fn rid => Symtab.delete_safe rid) all_orphans tab
-        val r' : repl = mark_pin_stale {origin = #origin r, base_state = #base_state r,
+        val r' : repl = rearm_splicer (mark_pin_stale
+                         {origin = #origin r, base_state = #base_state r,
                           steps = if idx < 0 then [] else List.take (steps, idx + 1),
-                          timeout = #timeout r, pin = #pin r}
+                          timeout = #timeout r, pin = #pin r,
+                          splicer = #splicer r})
     in (out ("Truncated to step " ^ string_of_int idx ^ ", dropped " ^
              string_of_int dropped ^ " steps"),
         Symtab.update (id, Repl r') tab') end);

--- a/ir/test_repl.py
+++ b/ir/test_repl.py
@@ -819,6 +819,344 @@ def main():
             assert "Loaded theory" in out, f"Expected loaded confirmation, got:\n{out}"
         run_test("load_theory_already_loaded", test_load_theory_already_loaded)
 
+        def test_segment_init_mid_proof_qed():
+            """Regression test for AutoCorrode#230: Ir.init at a
+            heap-recorded mid-proof segment, stepping through qed must
+            register the theorem.
+
+            Background: when a theory is built with record_theories=true AND
+            parallel proofs enabled, Toplevel.element_result forks each
+            lemma body via Proof.future_proof, which rewrites the goal's
+            after_qed to a stub that does not call Local_Theory.notes_kind.
+            Every segment recorded inside that future captures the stubbed
+            Proof.state, so a naive qed against such a state runs the stub
+            and the theorem is never registered.  The splicer compensates
+            by substituting the heap-recorded post-qed state at the
+            proof-exit transition.
+
+            Uses HOL-Library.Multiset (already loaded by test_load_theory).
+            Lemma `in_countE` has segments:
+              183: lemma in_countE (declaration)
+              185: proof -
+              187: from assms (mid-proof)
+              ...
+              207: qed
+
+            Init at seg 187 (mid-proof, chain mode after `from assms`),
+            step the remainder through qed, assert `thm in_countE` resolves.
+            """
+            send_recv(sock,
+                      'Ir.init "seg_bug" ["HOL-Library.Multiset:187"];')
+            send_recv(sock, 'Ir.step "seg_bug" '
+                      '"have \\"count M x > 0\\" by simp";', timeout=10)
+            send_recv(sock, 'Ir.step "seg_bug" '
+                      '"then obtain n where \\"count M x = Suc n\\" '
+                      'using gr0_conv_Suc by blast";', timeout=10)
+            send_recv(sock, 'Ir.step "seg_bug" '
+                      '"with that show thesis .";', timeout=10)
+            qed_out = send_recv(sock, 'Ir.step "seg_bug" "qed";',
+                                timeout=10)
+            thm_out = send_recv(sock,
+                                'Ir.step "seg_bug" "thm in_countE";',
+                                timeout=10)
+            send_recv(sock, 'Ir.remove "seg_bug";')
+            assert "Undefined fact" not in thm_out, (
+                "REGRESSION: Ir.init at a heap-recorded mid-proof segment "
+                "(HOL-Library.Multiset:187), then stepping through qed, "
+                "did not register the theorem.  The splicer should have "
+                "substituted the recorded post-qed state.  "
+                f"qed output: {qed_out!r}.  thm output: {thm_out!r}")
+        run_test("segment_init_mid_proof_qed",
+                 test_segment_init_mid_proof_qed)
+
+        def test_segment_init_mid_proof_oops():
+            """oops at the outermost proof exit must NOT splice in the
+            recorded post-qed state — it should leave the theorem unregistered.
+            """
+            def thm_resolves(repl_id, name):
+                out = send_recv(sock,
+                                f'Ir.step {q(repl_id)} "thm {name}";',
+                                timeout=10)
+                return "Undefined fact" not in out
+
+            send_recv(sock,
+                      'Ir.init "seg_oops" ["HOL-Library.Multiset:187"];')
+            # Step the body but use oops to abandon, not qed.
+            send_recv(sock, 'Ir.step "seg_oops" '
+                      '"have \\"count M x > 0\\" by simp";', timeout=10)
+            send_recv(sock, 'Ir.step "seg_oops" "oops";', timeout=10)
+            resolves = thm_resolves("seg_oops", "in_countE")
+            send_recv(sock, 'Ir.remove "seg_oops";')
+            assert not resolves, (
+                "BUG: after oops at mid-proof segment init, in_countE was "
+                "spuriously registered. Splice should have been disarmed by "
+                "the oops transition.")
+        run_test("segment_init_mid_proof_oops",
+                 test_segment_init_mid_proof_oops)
+
+        def test_segment_init_mid_proof_subproof():
+            """A sub-proof inside the body (have ... proof ... qed) must
+            not consume the splice; the splice should only fire on the
+            outermost qed.  Init at seg 185 (post `proof -`, before chain)
+            so we can interleave a sub-proof cleanly.
+            """
+            def thm_resolves(repl_id, name):
+                out = send_recv(sock,
+                                f'Ir.step {q(repl_id)} "thm {name}";',
+                                timeout=10)
+                return "Undefined fact" not in out
+
+            send_recv(sock,
+                      'Ir.init "seg_sub" ["HOL-Library.Multiset:185"];')
+            # First a structured sub-proof for an irrelevant fact — its
+            # internal qed must NOT consume the splice.
+            send_recv(sock, 'Ir.step "seg_sub" '
+                      '"have helper: \\"True\\" proof show ?thesis '
+                      'by simp qed";', timeout=30)
+            # Now the actual proof body.
+            send_recv(sock, 'Ir.step "seg_sub" '
+                      '"from assms have \\"count M x > 0\\" by simp";', timeout=10)
+            send_recv(sock, 'Ir.step "seg_sub" '
+                      '"then obtain n where \\"count M x = Suc n\\" '
+                      'using gr0_conv_Suc by blast";', timeout=10)
+            send_recv(sock, 'Ir.step "seg_sub" '
+                      '"with that show thesis .";', timeout=10)
+            send_recv(sock, 'Ir.step "seg_sub" "qed";', timeout=10)
+            resolves = thm_resolves("seg_sub", "in_countE")
+            send_recv(sock, 'Ir.remove "seg_sub";')
+            assert resolves, (
+                "BUG: outer qed after a structured sub-proof failed to "
+                "splice. The inner qed must not consume the splice.")
+        run_test("segment_init_mid_proof_subproof",
+                 test_segment_init_mid_proof_subproof)
+
+        def test_segment_init_mid_proof_truncate_replay():
+            """Truncate past the spliced qed and step a different finisher;
+            the splice must re-arm and the new qed must register the theorem.
+            """
+            def thm_resolves(repl_id, name):
+                out = send_recv(sock,
+                                f'Ir.step {q(repl_id)} "thm {name}";',
+                                timeout=10)
+                return "Undefined fact" not in out
+
+            send_recv(sock,
+                      'Ir.init "seg_tr" ["HOL-Library.Multiset:187"];')
+            send_recv(sock, 'Ir.step "seg_tr" '
+                      '"have \\"count M x > 0\\" by simp";', timeout=10)
+            send_recv(sock, 'Ir.step "seg_tr" '
+                      '"then obtain n where \\"count M x = Suc n\\" '
+                      'using gr0_conv_Suc by blast";', timeout=10)
+            send_recv(sock, 'Ir.step "seg_tr" '
+                      '"with that show thesis .";', timeout=10)
+            send_recv(sock, 'Ir.step "seg_tr" "qed";', timeout=10)
+            assert thm_resolves("seg_tr", "in_countE"), \
+                "Initial qed should have spliced and registered."
+            # Truncate past qed, leaving the body steps but not qed.
+            send_recv(sock, 'Ir.truncate "seg_tr" ~2;')
+            # After truncation the splice should be re-armed.  A fresh qed
+            # must register the theorem again.
+            send_recv(sock, 'Ir.step "seg_tr" "qed";', timeout=10)
+            resolves = thm_resolves("seg_tr", "in_countE")
+            send_recv(sock, 'Ir.remove "seg_tr";')
+            assert resolves, (
+                "BUG: after truncating past the spliced qed and stepping "
+                "a fresh qed, the theorem was not registered. The splice "
+                "should have re-armed.")
+        run_test("segment_init_mid_proof_truncate_replay",
+                 test_segment_init_mid_proof_truncate_replay)
+
+        def test_segment_init_mid_proof_edit_replay():
+            """Edit an early step in the body of a spliced proof.  With the
+            default auto_replay=true, Ir.edit invokes replay_repl on the
+            trailing stale steps, which must re-arm the splicer from initial
+            and thread it through so that the terminating qed splices in again.
+            """
+            def thm_resolves(repl_id, name):
+                out = send_recv(sock,
+                                f'Ir.step {q(repl_id)} "thm {name}";',
+                                timeout=10)
+                return "Undefined fact" not in out
+
+            # This test relies on auto_replay being on (the default) so that
+            # Ir.edit drives replay_repl.  Bail out if the global was flipped.
+            cfg = send_recv(sock,
+                            'writeln (Bool.toString (#auto_replay (Ir.get_cfg ())));')
+            assert "true" in cfg, (
+                "Test precondition failed: auto_replay must be true (default) "
+                f"to exercise replay via Ir.edit. Got: {cfg!r}")
+
+            send_recv(sock,
+                      'Ir.init "seg_er" ["HOL-Library.Multiset:187"];')
+            send_recv(sock, 'Ir.step "seg_er" '
+                      '"have h: \\"count M x > 0\\" by simp";', timeout=10)
+            send_recv(sock, 'Ir.step "seg_er" '
+                      '"then obtain n where \\"count M x = Suc n\\" '
+                      'using gr0_conv_Suc by blast";', timeout=10)
+            send_recv(sock, 'Ir.step "seg_er" '
+                      '"with that show thesis .";', timeout=10)
+            send_recv(sock, 'Ir.step "seg_er" "qed";', timeout=10)
+            assert thm_resolves("seg_er", "in_countE"), \
+                "Initial qed should have spliced and registered."
+            # Edit step 0; auto_replay drives replay_repl on stale steps 1-3,
+            # which must re-arm the splicer so the trailing qed splices again.
+            send_recv(sock, 'Ir.edit "seg_er" 0 '
+                      '"have h2: \\"0 < count M x\\" by simp";', timeout=10)
+            resolves = thm_resolves("seg_er", "in_countE")
+            send_recv(sock, 'Ir.remove "seg_er";')
+            assert resolves, (
+                "BUG: after edit-triggered replay, the qed splice did not "
+                "re-fire. replay_repl must re-arm the splicer from initial "
+                "and thread it through stale steps.")
+        run_test("segment_init_mid_proof_edit_replay",
+                 test_segment_init_mid_proof_edit_replay)
+
+        def test_segment_init_mid_proof_deep_oops():
+            """oops nested inside a structured sub-proof must disarm the
+            splicer just like a top-level oops.  In Isabelle, `oops` (via
+            Toplevel.forget_proof) always pops to the original outer theory
+            regardless of nesting depth — the entire proof is forgotten.
+            So `is_proof` transitions true -> false on that one command, and
+            our splicer must treat it like a top-level oops: disarm without
+            firing.
+            """
+            def thm_resolves(repl_id, name):
+                out = send_recv(sock,
+                                f'Ir.step {q(repl_id)} "thm {name}";',
+                                timeout=10)
+                return "Undefined fact" not in out
+
+            send_recv(sock,
+                      'Ir.init "seg_doops" ["HOL-Library.Multiset:187"];')
+            # Consume the chain with a real have so we end in proof state.
+            send_recv(sock, 'Ir.step "seg_doops" '
+                      '"have h: \\"count M x > 0\\" by simp";', timeout=10)
+            # Open a sub-proof for an irrelevant fact, then oops from inside.
+            send_recv(sock, 'Ir.step "seg_doops" '
+                      '"have helper: \\"True\\" proof -";', timeout=10)
+            # The oops here pops the WHOLE proof, not just the sub-proof —
+            # forget_proof always exits to the outer theory.
+            send_recv(sock, 'Ir.step "seg_doops" "oops";', timeout=10)
+            resolves = thm_resolves("seg_doops", "in_countE")
+            # A subsequent qed would have nothing to close; verify we are no
+            # longer in proof mode by attempting one and expecting an error.
+            qed_out = send_recv(sock, 'Ir.step "seg_doops" "qed";',
+                                timeout=10)
+            send_recv(sock, 'Ir.remove "seg_doops";')
+            assert not resolves, (
+                "BUG: deep oops at mid-proof segment init spuriously "
+                "registered in_countE. The inner-block oops still pops to "
+                "bare theory and must disarm the splicer.")
+            assert "ERR" in qed_out, (
+                "After deep oops, expected `qed` to fail (we should be at "
+                f"theory level, not in a proof). Got:\n{qed_out}")
+        run_test("segment_init_mid_proof_deep_oops",
+                 test_segment_init_mid_proof_deep_oops)
+
+        # The two tests below confirm that local-theory state is preserved
+        # through both qed (splicer fires) and oops (splicer disarms) when
+        # initing at a mid-proof segment inside a locale/context/experiment.
+        # We use HOL-Library.Multiset's `context comp_fun_commute` block,
+        # specifically the proof body of `lemma fold_mset_fusion` (state
+        # mode after `interpret comp_fun_commute g by (fact assms)`).
+        # Sibling lemma `fold_mset_fun_left_comm` lives in the same context
+        # and is used as the canary for locale-scoped visibility.
+        FUSION_BODY_SEG = 2419  # post-`interpret ...` inside fold_mset_fusion
+
+        def test_segment_init_mid_proof_oops_in_locale_preserves_locale():
+            """oops mid-proof inside a context block must keep us inside the
+            block.  The current implementation: oops disarms the splicer and
+            uses the user's actual post-state, which comes from
+            Toplevel.forget_proof.  forget_proof returns Theory orig_gthy,
+            and orig_gthy was captured at the original lemma's begin_proof
+            time — inside the context block.  So locale-scoped names remain
+            accessible after oops.
+            """
+            send_recv(sock,
+                      f'Ir.init "loc_oops" ["HOL-Library.Multiset:{FUSION_BODY_SEG}"];')
+            send_recv(sock, 'Ir.step "loc_oops" "oops";', timeout=10)
+            # The proof was discarded — fold_mset_fusion must NOT be registered.
+            test_out = send_recv(sock,
+                                  'Ir.step "loc_oops" "thm fold_mset_fusion";',
+                                  timeout=10)
+            # Pre-existing locale-scoped sibling must still be accessible.
+            sibling_out = send_recv(sock,
+                                     'Ir.step "loc_oops" "thm fold_mset_fun_left_comm";',
+                                     timeout=10)
+            send_recv(sock, 'Ir.remove "loc_oops";')
+            assert "Undefined fact" in test_out, (
+                "After oops the proof should have been discarded; "
+                f"fold_mset_fusion must NOT be registered.  Got:\n{test_out}")
+            assert "Undefined fact" not in sibling_out, (
+                "After oops inside a context block, the sibling lemma "
+                "fold_mset_fun_left_comm should still be accessible (we "
+                f"should remain inside the block).  Got:\n{sibling_out}")
+        run_test("segment_init_mid_proof_oops_in_locale_preserves_locale",
+                 test_segment_init_mid_proof_oops_in_locale_preserves_locale)
+
+        def test_segment_init_mid_proof_qed_in_locale_preserves_locale():
+            """qed mid-proof inside a context block must keep us inside the
+            block AND register the new theorem.  Current behavior: the
+            splicer fires and substitutes the heap-recorded post-qed segment.
+            That segment was recorded after the original qed ran during heap
+            build — its state is still inside the context block (the block
+            wasn't closed yet by `end`).  So both the new theorem and
+            existing locale-scoped names are accessible.
+            """
+            send_recv(sock,
+                      f'Ir.init "loc_qed" ["HOL-Library.Multiset:{FUSION_BODY_SEG}"];')
+            # Step the rest of fold_mset_fusion's body and close it.
+            send_recv(sock, 'Ir.step "loc_qed" '
+                      '"from * show ?thesis by (induct A) auto";',
+                      timeout=10)
+            send_recv(sock, 'Ir.step "loc_qed" "qed";', timeout=10)
+            # Newly registered lemma (via splice)
+            test_out = send_recv(sock,
+                                  'Ir.step "loc_qed" "thm fold_mset_fusion";',
+                                  timeout=10)
+            # Pre-existing locale-scoped sibling
+            sibling_out = send_recv(sock,
+                                     'Ir.step "loc_qed" "thm fold_mset_fun_left_comm";',
+                                     timeout=10)
+            send_recv(sock, 'Ir.remove "loc_qed";')
+            assert "Undefined fact" not in test_out, (
+                "After qed, the splicer should have registered "
+                f"fold_mset_fusion.  Got:\n{test_out}")
+            assert "Undefined fact" not in sibling_out, (
+                "After qed inside a context block, the sibling lemma "
+                "fold_mset_fun_left_comm should still be accessible (we "
+                f"should remain inside the block).  Got:\n{sibling_out}")
+        run_test("segment_init_mid_proof_qed_in_locale_preserves_locale",
+                 test_segment_init_mid_proof_qed_in_locale_preserves_locale)
+
+        def test_segment_init_mid_proof_fork_qed():
+            """Fork from a mid-proof segment-init REPL at the base state,
+            step body + qed in the fork.  The fork inherits the parent's
+            splicer, so the theorem must be registered in the fork.
+            """
+            send_recv(sock,
+                      'Ir.init "seg_fk" ["HOL-Library.Multiset:187"];')
+            send_recv(sock, 'Ir.fork "seg_fk" "seg_fk_child" 0;')
+            send_recv(sock, 'Ir.step "seg_fk_child" '
+                      '"have \\"count M x > 0\\" by simp";', timeout=10)
+            send_recv(sock, 'Ir.step "seg_fk_child" '
+                      '"then obtain n where \\"count M x = Suc n\\" '
+                      'using gr0_conv_Suc by blast";', timeout=10)
+            send_recv(sock, 'Ir.step "seg_fk_child" '
+                      '"with that show thesis .";', timeout=10)
+            send_recv(sock, 'Ir.step "seg_fk_child" "qed";', timeout=10)
+            thm_out = send_recv(sock,
+                                'Ir.step "seg_fk_child" "thm in_countE";',
+                                timeout=10)
+            send_recv(sock, 'Ir.remove "seg_fk";')
+            assert "Undefined fact" not in thm_out, (
+                "After forking from a mid-proof segment-init REPL and "
+                "stepping through qed in the fork, the theorem should be "
+                "registered.  The fork must inherit the parent's splicer.  "
+                f"Got:\n{thm_out}")
+        run_test("segment_init_mid_proof_fork_qed",
+                 test_segment_init_mid_proof_fork_qed)
+
         sock.close()
 
         # -- Multi-client tests --


### PR DESCRIPTION
*Issue #, if available:* #230

*Description of changes:*

When a theory is built with record_theories=true AND parallel proofs enabled, Toplevel.element_result forks each lemma body via Proof.future_proof, which rewrites the goal's after_qed to a stub that does NOT call Local_Theory.notes_kind. Every segment recorded inside that future captures the stubbed Proof.state, so initing a REPL at a mid-proof segment and stepping through qed fails to register the theorem (#230).

The fix introduces a per-REPL "segment_proof_splicer": at init we stash the recorded state of the next segment that exits the proof. When the user's stepping crosses the proof-exit boundary via a non-oops finisher, we splice that recorded state in for the post-state. oops disarms the splicer without firing, preserving "abandon proof, no theorem" semantics. The splicer is correctly re-armed across truncate, edit, and replay. Locale/context/experiment state is preserved through both splice (qed) and disarm (oops) paths.

Detection of oops is keyword-based via Keyword.is_qed_global, which is brittle: keyword classification is decoupled from semantic effects, and custom declared keywords might break this (see the comment on splice_step in ir.ML for details). Stock Pure/HOL ships only `oops` as qed_global, so these limitations are deemed acceptable.

Tests cover the original regression (segment_init_mid_proof_qed), oops behavior (segment_init_mid_proof_oops, _deep_oops), nested sub-proofs, splicer re-arming on truncate and on replay-via-edit, and locale preservation through both finishers.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
