### PR TITLE
CI: Cache Isabelle tarball in ip-test, retry curl on download

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -138,6 +138,14 @@ jobs:
         $ISABELLE components -u $AFP_COMPONENT_BASE/Word_Lib
         $ISABELLE build -b HOL
 
+    - name: Cache Isabelle tarballs
+      uses: actions/cache@v4
+      with:
+        path: |
+          /tmp/Isabelle2025-2_linux.tar.gz
+          /tmp/Isabelle2025-2_linux_arm.tar.gz
+        key: isabelle-tarball-2025-2
+
     - name: Configure I/P remote (localhost, fresh install + push heaps)
       run: |
         ip/configure-remote.py setup root@localhost \

--- a/ip/setup_ubuntu.sh
+++ b/ip/setup_ubuntu.sh
@@ -37,11 +37,12 @@ sudo apt-get update -qq && sudo apt-get install -y -qq fontconfig
 if [ -d "$INSTALL_DIR" ]; then
   echo "Already installed: ~/$INSTALL_DIR"
 else
-  echo "Downloading $URL ..."
-  curl -fSL -o "/tmp/$TARBALL" "$URL"
+  if [ ! -f "/tmp/$TARBALL" ]; then
+    echo "Downloading $URL ..."
+    curl -fSL --retry 5 --retry-all-errors --retry-delay 5 -o "/tmp/$TARBALL" "$URL"
+  fi
   echo "Unpacking ..."
   tar xzf "/tmp/$TARBALL" -C /tmp
-  rm "/tmp/$TARBALL"
   mkdir -p "$(dirname "$INSTALL_DIR")"
   mv "/tmp/Isabelle2025-2" "$INSTALL_DIR"
   # Disable SystemOnTPTP


### PR DESCRIPTION
The ip-test job intermittently fails at "Configure I/P remote" because isabelle.in.tum.de occasionally drops the connection during the tarball download in setup_ubuntu.sh.

Cache /tmp/Isabelle2025-2_linux*.tar.gz across runs so the download is skipped on cache hits, and add --retry 5 --retry-all-errors to curl so transient failures on cache misses don't fail the job.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
