### PR TITLE
Add unreachable!, vec!, matches!, addr_of!, raw pointers, let mut patterns, ref casts

### DIFF
--- a/Micro_Rust_Parsing_Frontend/Micro_Rust_Syntax.thy
+++ b/Micro_Rust_Parsing_Frontend/Micro_Rust_Syntax.thy
@@ -234,6 +234,10 @@ syntax
     ("_'!/ '(')" [1000]999)
   "_urust_macro_with_args" :: "urust_identifier \<Rightarrow> urust_args \<Rightarrow> urust"
     ("_'!/ '(_')" [1000,0]999)
+  "_urust_macro_no_args" :: "urust_identifier \<Rightarrow> urust"
+    ("_'!/ '[]" [1000]999)
+  "_urust_macro_with_args" :: "urust_identifier \<Rightarrow> urust_args \<Rightarrow> urust"
+    ("_'!/ '[_']" [1000,0]999)
   "_urust_funcall_with_args" :: "urust_callable \<Rightarrow> urust_args \<Rightarrow> urust"
     ("_/ '(_')"[1000,0]999)
   "_urust_funcall_no_args" :: "urust_callable \<Rightarrow> urust"
@@ -325,6 +329,12 @@ syntax
   \<comment>\<open>Add mutable binding\<close>
   "_urust_bind_mutable" :: "urust_identifier \<Rightarrow> urust \<Rightarrow> urust \<Rightarrow> urust"
     ("let/ mut/ _/ =/ _;// _" [1000,20,10]10)
+  \<comment>\<open>Mutable binding with tuple pattern: \<^verbatim>\<open>let mut (x, y) = expr\<close>.
+      Rust's local-variable mutability is not modelled by the shallow embedding, so this desugars
+      to an immutable tuple destructure. The \<^verbatim>\<open>mut\<close> annotation is accepted for syntactic
+      correspondence with Rust source code.\<close>
+  "_urust_bind_mutable_pattern" :: "urust_let_pattern_args \<Rightarrow> urust \<Rightarrow> urust \<Rightarrow> urust"
+    ("let/ mut/ '(_')/ =/ _;// _" [1000,20,10]10)
   \<comment>\<open>Boolean literals as expressions\<close>
   "_urust_true" :: \<open>urust\<close>
     ("true" 1000)
@@ -521,6 +531,11 @@ syntax
   "_urust_match_pattern_range_eq" :: \<open>urust_pattern \<Rightarrow> urust_pattern \<Rightarrow> urust_pattern\<close>
     (infix \<open>..=\<close> 41)
 
+  \<comment>\<open>The \<^verbatim>\<open>matches!\<close> macro: \<^verbatim>\<open>matches!(expr, pattern)\<close>. The second argument is parsed in
+      \<^verbatim>\<open>urust_pattern\<close> position so that constructor patterns and disjunctions are handled correctly.\<close>
+  "_urust_matches_macro" :: \<open>urust \<Rightarrow> urust_pattern \<Rightarrow> urust\<close>
+    ("matches'!/ '(_, _')" [0, 100] 999)
+
   \<comment> \<open>See the rust documentation for a list of expression precedences and fixities:
        https://doc.rust-lang.org/reference/expressions.html\<close>
 
@@ -535,6 +550,10 @@ syntax
     ("&_" [200]100)
   "_urust_borrow_mut" :: \<open>urust \<Rightarrow> urust\<close>
     ("& mut _" [200]100)
+  "_urust_raw_ptr_const" :: \<open>urust \<Rightarrow> urust\<close>
+    ("& raw const _" [200]100)
+  "_urust_raw_ptr_mut" :: \<open>urust \<Rightarrow> urust\<close>
+    ("& raw mut _" [200]100)
   "_urust_deref" :: \<open>urust \<Rightarrow> urust\<close>
     ("*_" [200]100)
   "_urust_double_deref" :: \<open>urust \<Rightarrow> urust\<close>

--- a/Micro_Rust_Std_Lib/StdLib_References.thy
+++ b/Micro_Rust_Std_Lib/StdLib_References.thy
@@ -331,6 +331,25 @@ no_adhoc_overloading store_update_const \<rightleftharpoons>
 
 (*<*)
 end
+(*>*)
 
+subsection\<open>Reference kind casts\<close>
+
+definition ref_cast_to_ro :: \<open>('a, 'b, 'v) Global_Store.ref \<Rightarrow>
+  ('s, ('a, 'b, 'v) ro_ref, 'abort, 'i, 'o) function_body\<close> where
+  \<open>ref_cast_to_ro r \<equiv> fun_literal (ro_ref_from_ref r)\<close>
+
+\<comment>\<open>SAFETY: This is the equivalent of an unsafe cast from \<^verbatim>\<open>&T\<close> to \<^verbatim>\<open>&mut T\<close>. Sound only when the
+    caller has exclusive access to the underlying resource (i.e. holds full permission in the
+    separation logic sense). Downstream proofs must discharge the corresponding points-to
+    obligation with unshared permission.\<close>
+definition ref_cast_to_mut :: \<open>('a, 'b, 'v) ro_ref \<Rightarrow>
+  ('s, ('a, 'b, 'v) Global_Store.ref, 'abort, 'i, 'o) function_body\<close> where
+  \<open>ref_cast_to_mut r \<equiv> fun_literal (unsafe_ref_from_ro_ref r)\<close>
+
+notation_nano_rust_function ref_cast_to_ro ("as_ro_ref")
+notation_nano_rust_function ref_cast_to_mut ("as_mut_ref")
+
+(*<*)
 end
 (*>*)

--- a/Shallow_Micro_Rust/Micro_Rust_Shallow_Embedding.thy
+++ b/Shallow_Micro_Rust/Micro_Rust_Shallow_Embedding.thy
@@ -533,6 +533,10 @@ translations
 
   "_shallow (_urust_bind_mutable (_urust_identifier_hol_id var) exp cont)"
     \<rightharpoonup> "CONST bind (Ref::new \<langle>(_shallow exp)\<rangle>) (\<lambda>var. (_shallow cont))"
+  \<comment>\<open>Mutable binding with tuple pattern: \<^verbatim>\<open>let mut (x, y) = expr\<close>. The \<^verbatim>\<open>mut\<close> annotation is
+      dropped since Rust's local-variable mutability is not modelled in the shallow embedding.\<close>
+  "_shallow (_urust_bind_mutable_pattern args exp cont)"
+    \<rightharpoonup> "CONST Core_Expression.bind (_shallow exp) (_abs (_shallow_let_pattern_args args) (_shallow cont))"
   "_shallow (_urust_sequence seqA seqB)"
     \<rightharpoonup> "CONST sequence (_shallow seqA) (_shallow seqB)"
   "_shallow (_urust_sequence_mono seqA)"
@@ -562,6 +566,10 @@ translations
     \<rightharpoonup> "CONST bindlift1 (CONST ro_ref_from_ref) (_shallow exp)"
   "_shallow (_urust_borrow_mut exp)"
     \<rightharpoonup> "CONST bindlift1 (CONST mut_ref_from_ref) (_shallow exp)"
+  "_shallow (_urust_raw_ptr_const exp)"
+    \<rightharpoonup> "CONST bindlift1 (CONST ref_address) (_shallow exp)"
+  "_shallow (_urust_raw_ptr_mut exp)"
+    \<rightharpoonup> "CONST bindlift1 (CONST ref_address) (_shallow exp)"
   "_shallow (_urust_deref exp)"
     \<rightharpoonup> "_urust_shallow_store_dereference (_shallow exp)"
 
@@ -706,6 +714,38 @@ translations
   "_shallow (_urust_macro_with_args
        (URUST_CONST fatal) (_urust_args_single (_urust_string_token str)))"
     \<rightharpoonup> "CONST fatal (_string_token_to_hol str)"
+
+  "_shallow (_urust_macro_no_args (URUST_CONST unreachable))"
+    \<rightharpoonup> "CONST panic (CONST String.implode [])"
+  "_shallow (_urust_macro_with_args
+       (URUST_CONST unreachable) (_urust_args_app first rest))"
+    \<rightharpoonup> "_shallow (_urust_macro_with_args
+       (URUST_CONST unreachable) (_urust_args_single first))"
+  "_shallow (_urust_macro_with_args
+       (URUST_CONST unreachable) (_urust_args_single (_urust_identifier a)))"
+    \<rightharpoonup> "CONST panic (_shallow_identifier_as_literal a)"
+  "_shallow (_urust_macro_with_args
+       (URUST_CONST unreachable) (_urust_args_single (_urust_literal x)))"
+    \<rightharpoonup> "CONST panic (CONST String.implode x)"
+  "_shallow (_urust_macro_with_args
+       (URUST_CONST unreachable) (_urust_args_single (_urust_string_token str)))"
+    \<rightharpoonup> "CONST panic (_string_token_to_hol str)"
+
+  "_shallow (_urust_macro_with_args (URUST_CONST vec) args)"
+    \<rightharpoonup> "_shallow (_urust_array_expr args)"
+  "_shallow (_urust_macro_no_args (URUST_CONST vec))"
+    \<rightharpoonup> "_shallow (_urust_array_expr_empty)"
+
+  "_shallow (_urust_macro_with_args (URUST_CONST addr_of) (_urust_args_single exp))"
+    \<rightharpoonup> "CONST bindlift1 (CONST ref_address) (_shallow exp)"
+  "_shallow (_urust_macro_with_args (URUST_CONST addr_of_mut) (_urust_args_single exp))"
+    \<rightharpoonup> "CONST bindlift1 (CONST ref_address) (_shallow exp)"
+
+  "_shallow (_urust_matches_macro expr pat)"
+    \<rightharpoonup> "_urust_shallow_match (_shallow expr)
+         (_urust_shallow_match2
+           (_urust_shallow_match1 (_shallow_match_pattern pat) (CONST literal (CONST True)))
+           (_urust_shallow_match1 _urust_shallow_match_pattern_other (CONST literal (CONST False))))"
 
  "_shallow (_urust_index exp idx)"
     \<rightharpoonup> "_urust_shallow_index (_shallow exp) (_shallow idx)"

--- a/Shallow_Micro_Rust/Micro_Rust_Shallow_Embedding_Tests.thy
+++ b/Shallow_Micro_Rust/Micro_Rust_Shallow_Embedding_Tests.thy
@@ -1166,9 +1166,9 @@ term\<open>\<lbrakk>
   };
 \<rbrakk>\<close>
 
-subsubsection\<open>Numeric Match (match_switch)\<close>
+subsubsection\<open>Numeric Match (\<^verbatim>\<open>match_switch\<close>)\<close>
 
-text\<open>See Section 21 (Rust Path Expressions) for match_switch examples\<close>
+text\<open>See Section 21 (Rust Path Expressions) for \<^verbatim>\<open>match_switch\<close> examples\<close>
 
 subsection\<open>Control Flow - Loops\<close>
 
@@ -1835,6 +1835,8 @@ subsubsection\<open>Error Macros\<close>
 
 context
   fixes msg :: \<open>String.literal\<close>
+  and idx :: \<open>32 word\<close>
+  and r :: \<open>('a, 'b, 'v) ref\<close>
 begin
 term \<open>\<lbrakk> panic!(msg) \<rbrakk>\<close>
 term \<open>\<lbrakk> fatal!(msg) \<rbrakk>\<close>
@@ -1851,6 +1853,16 @@ term \<open>\<lbrakk> panic!("first", msg) \<rbrakk>\<close>
 term \<open>\<lbrakk> unimplemented!("first", msg) \<rbrakk>\<close>
 term \<open>\<lbrakk> todo!("first", msg) \<rbrakk>\<close>
 term \<open>\<lbrakk> fatal!("first", msg) \<rbrakk>\<close>
+term \<open>\<lbrakk> unreachable!() \<rbrakk>\<close>
+term \<open>\<lbrakk> unreachable!("should not reach here") \<rbrakk>\<close>
+term \<open>\<lbrakk> unreachable!("bad state: {}", msg) \<rbrakk>\<close>
+term \<open>\<lbrakk> panic!("Invalid index: {}", idx) \<rbrakk>\<close>
+term \<open>\<lbrakk> unimplemented!("not done: {} {}", idx, idx) \<rbrakk>\<close>
+term \<open>\<lbrakk> todo!("implement: {}", idx) \<rbrakk>\<close>
+term \<open>\<lbrakk> addr_of!(r) \<rbrakk>\<close>
+term \<open>\<lbrakk> addr_of_mut!(r) \<rbrakk>\<close>
+term \<open>\<lbrakk> & raw const r \<rbrakk>\<close>
+term \<open>\<lbrakk> & raw mut r \<rbrakk>\<close>
 end
 
 subsubsection\<open>Logging\<close>
@@ -1895,6 +1907,27 @@ term\<open>\<lbrakk>
   };
   assert!(s == \<llangle>9 :: 32 word\<rrangle>)
 \<rbrakk>\<close>
+
+subsubsection\<open>Vec Macro\<close>
+
+term \<open>\<lbrakk> vec![\<llangle>1 :: 32 word\<rrangle>, \<llangle>2 :: 32 word\<rrangle>, \<llangle>3 :: 32 word\<rrangle>] \<rbrakk>\<close>
+term \<open>\<lbrakk> vec![] \<rbrakk>\<close>
+
+term\<open>\<lbrakk>
+  let xs = vec![\<llangle>10 :: 32 word\<rrangle>, \<llangle>20 :: 32 word\<rrangle>];
+  assert!(xs[0] == \<llangle>10 :: 32 word\<rrangle>)
+\<rbrakk>\<close>
+
+subsubsection\<open>Matches Macro\<close>
+
+context
+  fixes x :: \<open>nat option\<close>
+  and y :: \<open>bool option\<close>
+begin
+term \<open>\<lbrakk> matches!(x, Some(_)) \<rbrakk>\<close>
+term \<open>\<lbrakk> matches!(x, None) \<rbrakk>\<close>
+term \<open>\<lbrakk> matches!(y, Some(true) | None) \<rbrakk>\<close>
+end
 
 subsubsection\<open>Indexing\<close>
 
@@ -2130,6 +2163,18 @@ term\<open>\<lbrakk>
     (Some(x), Some(y)) | (None, Some(y)) \<Rightarrow> y,
     _ \<Rightarrow> \<llangle>0 :: nat\<rrangle>
   }
+\<rbrakk>\<close>
+
+subsubsection\<open>Mutable Pattern Destructuring\<close>
+
+term\<open>\<lbrakk>
+  let mut (x, y) = (\<llangle>1 :: 32 word\<rrangle>, \<llangle>2 :: 32 word\<rrangle>);
+  x + y
+\<rbrakk>\<close>
+
+term\<open>\<lbrakk>
+  let mut (a, b, c) = (\<llangle>1 :: nat\<rrangle>, \<llangle>2 :: nat\<rrangle>, \<llangle>3 :: nat\<rrangle>);
+  a
 \<rbrakk>\<close>
 
 end

--- a/Shallow_Micro_Rust/Num_Case_Expression.thy
+++ b/Shallow_Micro_Rust/Num_Case_Expression.thy
@@ -21,7 +21,7 @@ term\<open>case (4 :: 64 word) of
 \<close>.
 
 Besides being more readable than nesting if/else statements, this will also be helpful when
-shallowly embedding \<mu>Rust in Isabelle, since Rust \<^emph>\<open>does\<close> support these kinds of matches.
+shallowly embedding \<^verbatim>\<open>\<mu>Rust\<close> in Isabelle, since Rust \<^emph>\<open>does\<close> support these kinds of matches.
 
 This file constructs an \<^verbatim>\<open>ncase\<close> match statement, that does allow you to write the above\<close>
 
@@ -33,7 +33,7 @@ syntax
   \<comment>\<open>Numeral case expressions\<close>
   "_case_num_syntax" :: "['a, case_num_branches] \<Rightarrow> 'b"  ("(ncase _ of/ _)" [20, 20]20)
   \<comment> \<open>We also add a 'functional' version of this, which turns out to be useful when parsing
-      \<mu>Rust. This is because we have to first evaluate the argument before pattern matching,
+      \<^verbatim>\<open>\<mu>Rust\<close>. This is because we have to first evaluate the argument before pattern matching,
       which will be parsed as a \<^verbatim>\<open>bind arg (pattern_match_function)\<close>. By having notation for
       the function, we don't need to introduce an anonymous lambda (which comes with its own problems)\<close>
   "_case_num_fun_syntax" :: "[case_num_branches] \<Rightarrow> 'b"  ("(ncase'_fun of/ _)" [20]20)


### PR DESCRIPTION
Extend the Micro Rust shallow embedding with several new language features:

- unreachable! macro (aliases to panic)
- vec![...] macro (desugars to array literal)
- matches!(expr, pattern) macro (desugars to two-arm match)
- addr_of!(expr) and addr_of_mut!(expr) macros (extract ref address)
- & raw const / & raw mut syntax (raw pointer construction)
- Bracket-style macro delimiters: name![args] in addition to name!(args)
- let mut (x, y) = expr tuple destructure (mut annotation dropped)
- ref_cast_to_ro / ref_cast_to_mut with .as_ro_ref() / .as_mut_ref() notation

Also fix pre-existing LaTeX errors in document generation (bare \<mu> and unescaped underscores in section headings).

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
