### PR TITLE
I/Q: Implement AutoSave option and make various smaller improvements

### DIFF
--- a/iq/README.md
+++ b/iq/README.md
@@ -166,6 +166,7 @@ The following methods are also always available without authentication: `initial
     - `query='sledgehammer'`: Run sledgehammer (optional `arguments` for prover list)
     - `query='find_theorems'`: Search for theorems (requires `arguments` with the search query, optional `max_results`)
 19. **save_file**: Save one file or all modified open files
+20. **set_auto_save**: Toggle or query auto-save. When enabled (the default), every `write_file` edit is persisted to disk immediately, keeping the jEdit buffer and the file-system contents in sync. Omit `enabled` to query the current state. The setting is shared with the "Auto-save edits" checkbox in the I/Q dockable.
 
 ### I/R REPL tools
 

--- a/iq/scripts/check_docs.sh
+++ b/iq/scripts/check_docs.sh
@@ -22,12 +22,19 @@ awk '
   | sed -nE 's/.*"name"[[:space:]]*->[[:space:]]*"([^"]+)".*/\1/p' \
   | sort -u > "$tmp_server_tools"
 
+# Capture the README's MCP Tools section up to (but excluding) the I/R REPL
+# subsection. The server registry compared below likewise excludes REPL tools
+# (those live in a separate replToolDefinitions val), so the two must match on
+# the non-REPL tools only. Tool entries are matched regardless of whether they
+# are numbered ("1. **name**:") or bulleted ("- **name**:") so the doc style is
+# free to vary without breaking the check.
 awk '
   /^## MCP Tools$/ { in_tools = 1; next }
+  /^### I\/R REPL tools/ && in_tools { in_tools = 0 }
   /^## / && in_tools { in_tools = 0 }
   in_tools { print }
 ' "$IQ_README" \
-  | sed -nE 's/^[[:space:]]*[0-9]+\.[[:space:]]+\*\*([^*]+)\*\*:.*/\1/p' \
+  | sed -nE 's/^[[:space:]]*([0-9]+\.|-)[[:space:]]+\*\*([^*]+)\*\*:.*/\2/p' \
   | sort -u > "$tmp_readme_tools"
 
 if ! diff -u "$tmp_server_tools" "$tmp_readme_tools" >/dev/null; then

--- a/iq/src/IQAutoSave.scala
+++ b/iq/src/IQAutoSave.scala
@@ -1,0 +1,58 @@
+/* Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+   SPDX-License-Identifier: MIT */
+
+import org.gjt.sp.jedit.jEdit
+import scala.jdk.CollectionConverters._
+
+/**
+ * Shared auto-save state for I/Q edits.
+ *
+ * When enabled, `write_file` edits are persisted to disk immediately after the
+ * jEdit buffer is modified, so the buffer contents and the file-system state
+ * never diverge. (Divergence is a frequent source of confusion for agents that
+ * mix I/Q edits with direct file-system edits.)
+ *
+ * This object is the single source of truth for the setting. Both the MCP
+ * `set_auto_save` tool and the I/Q dockable checkbox read and mutate it, and a
+ * listener mechanism keeps the checkbox and the internal state in sync no
+ * matter which side toggles it. The value is persisted across sessions as a
+ * jEdit property.
+ */
+object IQAutoSave {
+  final val EnabledKey = "iq.autosave.enabled"
+  final val DefaultEnabled = true
+
+  private val listeners =
+    new java.util.concurrent.CopyOnWriteArrayList[Boolean => Unit]()
+
+  @volatile private var enabledState: Boolean =
+    jEdit.getBooleanProperty(EnabledKey, DefaultEnabled)
+
+  /** Whether auto-save is currently enabled. */
+  def enabled: Boolean = enabledState
+
+  /**
+   * Update the auto-save state. No-op if unchanged. Persists to jEdit
+   * properties and notifies all listeners (e.g. the dockable checkbox) so the
+   * UI and the internal state never drift apart.
+   */
+  def setEnabled(value: Boolean): Unit = {
+    if (value == enabledState) return
+    enabledState = value
+    jEdit.setBooleanProperty(EnabledKey, value)
+    listeners.asScala.foreach(listener => listener(value))
+  }
+
+  /**
+   * Register a listener invoked whenever the state changes. The listener is
+   * NOT called on registration; callers should initialise their view from
+   * `enabled` first, then keep it in sync via the listener.
+   */
+  def addListener(listener: Boolean => Unit): Unit = {
+    val _ = listeners.add(listener)
+  }
+
+  def removeListener(listener: Boolean => Unit): Unit = {
+    val _ = listeners.remove(listener)
+  }
+}

--- a/iq/src/IQCapabilities.scala
+++ b/iq/src/IQCapabilities.scala
@@ -36,6 +36,7 @@ enum IQToolName(val wire: String) {
   case GetSorryPositions extends IQToolName("get_sorry_positions")
   case Explore extends IQToolName("explore")
   case SaveFile extends IQToolName("save_file")
+  case SetAutoSave extends IQToolName("set_auto_save")
   // I/R REPL tools
   case ReplConnect extends IQToolName("repl_connect")
   case ReplInit extends IQToolName("repl_init")

--- a/iq/src/IQLogDockable.scala
+++ b/iq/src/IQLogDockable.scala
@@ -190,6 +190,33 @@ extends JPanel(new BorderLayout) with DefaultFocusComponent {
   truncateMessagesCheckbox.setMnemonic('T')
   truncateMessagesCheckbox.getAccessibleContext.setAccessibleName("Truncate long messages")
 
+  // Auto-save checkbox: bidirectionally bound to the shared IQAutoSave state so
+  // it stays in sync whether toggled here or via the set_auto_save MCP tool.
+  private val autoSaveCheckbox = new JCheckBox("Auto-save edits", IQAutoSave.enabled)
+  autoSaveCheckbox.setMnemonic('A')
+  autoSaveCheckbox.setToolTipText(
+    "When enabled, every write_file edit is saved to disk immediately, keeping " +
+      "the jEdit buffer and the file system in sync."
+  )
+  autoSaveCheckbox.getAccessibleContext.setAccessibleName("Auto-save edits")
+
+  // UI -> state: user toggling the checkbox updates the shared state.
+  autoSaveCheckbox.addActionListener(new ActionListener {
+    def actionPerformed(e: ActionEvent): Unit = {
+      IQAutoSave.setEnabled(autoSaveCheckbox.isSelected)
+    }
+  })
+
+  // state -> UI: the set_auto_save tool (or any other mutator) updates the
+  // checkbox. setEnabled is a no-op when unchanged, so the UI-driven path above
+  // does not recurse. Marshal onto the EDT since listeners may fire off-thread.
+  private val autoSaveListener: Boolean => Unit = value =>
+    javax.swing.SwingUtilities.invokeLater(new Runnable {
+      def run(): Unit =
+        if (autoSaveCheckbox.isSelected != value) autoSaveCheckbox.setSelected(value)
+    })
+  IQAutoSave.addListener(autoSaveListener)
+
   clearLogButton.addActionListener(new ActionListener {
     def actionPerformed(e: ActionEvent): Unit = {
       outputTextArea.setText("I/Q Server Log:\n" + "=" * 50 + "\n")
@@ -201,6 +228,7 @@ extends JPanel(new BorderLayout) with DefaultFocusComponent {
   buttonPanel.add(clearLogButton)
   buttonPanel.add(logCommunicationCheckbox)
   buttonPanel.add(truncateMessagesCheckbox)
+  buttonPanel.add(autoSaveCheckbox)
 
   // --- Layout: info header + buttons at top, log text area in center ---
 
@@ -316,6 +344,7 @@ extends JPanel(new BorderLayout) with DefaultFocusComponent {
 
   def exit(): Unit = {
     infoRefreshTimer.stop()
+    IQAutoSave.removeListener(autoSaveListener)
     IQCommunicationLogger.clearDockable(this)
   }
 }

--- a/iq/src/IQServer.scala
+++ b/iq/src/IQServer.scala
@@ -679,6 +679,9 @@ class IQServer(
         ),
         IQToolName.SaveFile -> (params =>
           handleSaveFile(params.toMap).map(IQToolResult.fromMap)
+        ),
+        IQToolName.SetAutoSave -> (params =>
+          handleSetAutoSave(params.toMap).map(IQToolResult.fromMap)
         )
       )
       base ++ replToolHandlers
@@ -1931,6 +1934,22 @@ class IQServer(
             "path" -> Map(
               "type" -> "string",
               "description" -> "Optional path to a specific file to save. If omitted, saves all modified dirty buffers that pass mutation-root policy."
+            )
+          ),
+          "additionalProperties" -> false
+        )
+      ),
+      Map(
+        "name" -> "set_auto_save",
+        "description" -> ("Toggle or query I/Q auto-save. When enabled (the default), every write_file edit is " +
+          "persisted to disk immediately, keeping the jEdit buffer and the file-system contents in sync. " +
+          "Omit 'enabled' to query the current state without changing it. Returns the resulting state."),
+        "inputSchema" -> Map(
+          "type" -> "object",
+          "properties" -> Map(
+            "enabled" -> Map(
+              "type" -> "boolean",
+              "description" -> "True to enable auto-save, false to disable. If omitted, the current state is returned unchanged."
             )
           ),
           "additionalProperties" -> false
@@ -3471,6 +3490,18 @@ class IQServer(
 
     // Wait until the edit has been processed (stable snapshot = no pending edits)
     val _ = IQUtils.blockOnStableSnapshot(buffer_model)
+
+    // Auto-save the buffer to disk so the file-system state never diverges from
+    // the jEdit buffer. Mutation path was already authorized above.
+    if (IQAutoSave.enabled) {
+      GUI_Thread.now {
+        val buffer = buffer_model.buffer
+        if (buffer.isDirty()) {
+          buffer.save(null, null)
+          Output.writeln(s"I/Q Server: Auto-saved file after edit: $filePath")
+        }
+      }
+    }
 
     Output.writeln(s"I/Q Server: Auto-calling get_command for modified range in $filePath")
 
@@ -5447,6 +5478,31 @@ end"""
         Output.writeln(s"I/Q Server: Save file error: ${ex.getMessage}")
         ex.printStackTrace()
         Left(s"Save file error: ${ex.getMessage}")
+    }
+  }
+
+  /**
+   * Handles the set_auto_save tool request.
+   *
+   * Toggles or queries the shared auto-save state. When enabled, write_file
+   * edits are persisted to disk immediately. Omitting the `enabled` parameter
+   * queries the current state without changing it.
+   *
+   * @param params The tool parameters
+   * @return Either error message or result data
+   */
+  private def handleSetAutoSave(params: Map[String, Any]): Either[String, Map[String, Any]] = {
+    params.get("enabled") match {
+      case None =>
+        // Query only
+        Right(Map("enabled" -> IQAutoSave.enabled, "changed" -> false))
+      case Some(value: Boolean) =>
+        val previous = IQAutoSave.enabled
+        IQAutoSave.setEnabled(value)
+        Output.writeln(s"I/Q Server: Auto-save set to $value (was $previous)")
+        Right(Map("enabled" -> value, "changed" -> (value != previous)))
+      case Some(other) =>
+        Left(s"enabled parameter must be a boolean, got: $other")
     }
   }
 }

--- a/iq/src/IQServer.scala
+++ b/iq/src/IQServer.scala
@@ -3632,7 +3632,14 @@ class IQServer(
     val writer = new java.io.FileWriter(file)
     try {
       if (content.nonEmpty) {
-        writer.write(content)
+        // Re-encode Isabelle symbols to named form (\<sym>) before writing.
+        // Incoming text params are Symbol.decode'd on ingest, so without this
+        // the file would contain raw Unicode glyphs. PIDE/jEdit Symbol-decodes
+        // on read and so tolerates either form, but Isabelle's batch loader
+        // (isabelle build) is symbol-strict and only accepts named tokens on
+        // disk. Encoding here keeps this direct-write path symmetric with the
+        // jEdit buffer.save path (which encodes via UTF-8-Isabelle).
+        writer.write(Symbol.encode(content))
       } else if (filePath.endsWith(".thy")) {
         val theoryName = file.getName.stripSuffix(".thy")
         val template = s"""theory $theoryName

--- a/iq/src/test/scala/IQServerAuthTest.scala
+++ b/iq/src/test/scala/IQServerAuthTest.scala
@@ -8,6 +8,21 @@ object IQServerAuthTest {
     if (!condition) throw new RuntimeException(message)
   }
 
+  /** Assert a tool-handler validation failure: a successful JSON-RPC response
+    * carrying an MCP tool result flagged with isError:true (NOT a JSON-RPC
+    * protocol-level "error"). Tool handlers forward their Left(msg) this way so
+    * the message is surfaced to the LLM rather than swallowed by the client. */
+  private def assertToolError(payload: String, context: String): Unit = {
+    assertThat(
+      payload.contains("\"isError\":true"),
+      s"$context: expected tool error result (isError:true): $payload"
+    )
+    assertThat(
+      !payload.contains("\"error\""),
+      s"$context: handler validation should not be a JSON-RPC error: $payload"
+    )
+  }
+
   private val TestToken = "test-token"
 
   private def mkServer(
@@ -126,9 +141,9 @@ object IQServerAuthTest {
     val request =
       """{"jsonrpc":"2.0","id":"req-resolve-invalid","method":"tools/call","params":{"name":"resolve_command_target","arguments":{"command_selection":"bogus"}}}"""
     val response = server.processRequestForTest(request)
-    assertThat(response.nonEmpty, "invalid selection should return JSON-RPC error")
+    assertThat(response.nonEmpty, "invalid selection should return a response")
     val payload = response.get
-    assertThat(payload.contains("\"error\""), s"expected error payload: $payload")
+    assertToolError(payload, "resolve_command_target invalid selection")
     assertThat(payload.contains("Invalid target"), s"expected invalid target message: $payload")
   }
 
@@ -138,9 +153,9 @@ object IQServerAuthTest {
     val request =
       """{"jsonrpc":"2.0","id":"req-resolve-missing","method":"tools/call","params":{"name":"resolve_command_target","arguments":{"command_selection":"file_offset"}}}"""
     val response = server.processRequestForTest(request)
-    assertThat(response.nonEmpty, "missing file_offset parameters should return JSON-RPC error")
+    assertThat(response.nonEmpty, "missing file_offset parameters should return a response")
     val payload = response.get
-    assertThat(payload.contains("\"error\""), s"expected error payload: $payload")
+    assertToolError(payload, "resolve_command_target file_offset params")
     assertThat(
       payload.contains("file_offset target requires path and offset parameters"),
       s"expected file_offset parameter validation message: $payload"
@@ -153,9 +168,9 @@ object IQServerAuthTest {
     val request =
       """{"jsonrpc":"2.0","id":"req-context-invalid","method":"tools/call","params":{"name":"get_context_info","arguments":{"command_selection":"bogus"}}}"""
     val response = server.processRequestForTest(request)
-    assertThat(response.nonEmpty, "invalid selection should return JSON-RPC error")
+    assertThat(response.nonEmpty, "invalid selection should return a response")
     val payload = response.get
-    assertThat(payload.contains("\"error\""), s"expected error payload: $payload")
+    assertToolError(payload, "get_context_info invalid selection")
     assertThat(payload.contains("Invalid target"), s"expected invalid target message: $payload")
   }
 
@@ -165,9 +180,9 @@ object IQServerAuthTest {
     val request =
       """{"jsonrpc":"2.0","id":"req-context-missing","method":"tools/call","params":{"name":"get_context_info","arguments":{"command_selection":"file_offset"}}}"""
     val response = server.processRequestForTest(request)
-    assertThat(response.nonEmpty, "missing file_offset parameters should return JSON-RPC error")
+    assertThat(response.nonEmpty, "missing file_offset parameters should return a response")
     val payload = response.get
-    assertThat(payload.contains("\"error\""), s"expected error payload: $payload")
+    assertToolError(payload, "get_context_info file_offset params")
     assertThat(
       payload.contains("file_offset target requires path and offset parameters"),
       s"expected file_offset parameter validation message: $payload"
@@ -180,9 +195,9 @@ object IQServerAuthTest {
     val request =
       """{"jsonrpc":"2.0","id":"req-entities-missing","method":"tools/call","params":{"name":"get_entities","arguments":{}}}"""
     val response = server.processRequestForTest(request)
-    assertThat(response.nonEmpty, "missing path should return JSON-RPC error")
+    assertThat(response.nonEmpty, "missing path should return a response")
     val payload = response.get
-    assertThat(payload.contains("\"error\""), s"expected error payload: $payload")
+    assertToolError(payload, "get_entities missing path")
     assertThat(
       payload.contains("Missing required parameter: path"),
       s"expected missing path validation message: $payload"
@@ -195,9 +210,9 @@ object IQServerAuthTest {
     val request =
       """{"jsonrpc":"2.0","id":"req-type-invalid","method":"tools/call","params":{"name":"get_type_at_selection","arguments":{"command_selection":"bogus"}}}"""
     val response = server.processRequestForTest(request)
-    assertThat(response.nonEmpty, "invalid selection should return JSON-RPC error")
+    assertThat(response.nonEmpty, "invalid selection should return a response")
     val payload = response.get
-    assertThat(payload.contains("\"error\""), s"expected error payload: $payload")
+    assertToolError(payload, "get_type_at_selection invalid selection")
     assertThat(payload.contains("Invalid target"), s"expected invalid target message: $payload")
   }
 
@@ -207,9 +222,9 @@ object IQServerAuthTest {
     val request =
       """{"jsonrpc":"2.0","id":"req-proof-blocks-selection-missing","method":"tools/call","params":{"name":"get_proof_blocks","arguments":{"scope":"selection","command_selection":"file_offset"}}}"""
     val response = server.processRequestForTest(request)
-    assertThat(response.nonEmpty, "missing file_offset parameters should return JSON-RPC error")
+    assertThat(response.nonEmpty, "missing file_offset parameters should return a response")
     val payload = response.get
-    assertThat(payload.contains("\"error\""), s"expected error payload: $payload")
+    assertToolError(payload, "get_proof_blocks selection file_offset params")
     assertThat(
       payload.contains("file_offset target requires path and offset parameters"),
       s"expected file_offset parameter validation message: $payload"
@@ -222,9 +237,9 @@ object IQServerAuthTest {
     val request =
       """{"jsonrpc":"2.0","id":"req-proof-blocks-missing","method":"tools/call","params":{"name":"get_proof_blocks","arguments":{"scope":"file"}}}"""
     val response = server.processRequestForTest(request)
-    assertThat(response.nonEmpty, "missing path should return JSON-RPC error")
+    assertThat(response.nonEmpty, "missing path should return a response")
     val payload = response.get
-    assertThat(payload.contains("\"error\""), s"expected error payload: $payload")
+    assertToolError(payload, "get_proof_blocks missing path")
     assertThat(
       payload.contains("scope='file' requires parameter: path"),
       s"expected missing path validation message: $payload"
@@ -237,9 +252,9 @@ object IQServerAuthTest {
     val request =
       """{"jsonrpc":"2.0","id":"req-defs-missing","method":"tools/call","params":{"name":"get_definitions","arguments":{"command_selection":"current"}}}"""
     val response = server.processRequestForTest(request)
-    assertThat(response.nonEmpty, "missing names should return JSON-RPC error")
+    assertThat(response.nonEmpty, "missing names should return a response")
     val payload = response.get
-    assertThat(payload.contains("\"error\""), s"expected error payload: $payload")
+    assertToolError(payload, "get_definitions missing names")
     assertThat(
       payload.contains("Missing required parameter: names"),
       s"expected missing names validation message: $payload"
@@ -252,9 +267,9 @@ object IQServerAuthTest {
     val request =
       """{"jsonrpc":"2.0","id":"req-diag-bad-severity","method":"tools/call","params":{"name":"get_diagnostics","arguments":{"severity":"info"}}}"""
     val response = server.processRequestForTest(request)
-    assertThat(response.nonEmpty, "invalid severity should return JSON-RPC error")
+    assertThat(response.nonEmpty, "invalid severity should return a response")
     val payload = response.get
-    assertThat(payload.contains("\"error\""), s"expected error payload: $payload")
+    assertToolError(payload, "get_diagnostics invalid severity")
     assertThat(
       payload.contains("Parameter 'severity' must be either 'error' or 'warning'"),
       s"expected severity validation message: $payload"
@@ -267,9 +282,9 @@ object IQServerAuthTest {
     val request =
       """{"jsonrpc":"2.0","id":"req-diag-missing-path","method":"tools/call","params":{"name":"get_diagnostics","arguments":{"severity":"error","scope":"file"}}}"""
     val response = server.processRequestForTest(request)
-    assertThat(response.nonEmpty, "file scope without path should return JSON-RPC error")
+    assertThat(response.nonEmpty, "file scope without path should return a response")
     val payload = response.get
-    assertThat(payload.contains("\"error\""), s"expected error payload: $payload")
+    assertToolError(payload, "get_diagnostics file scope missing path")
     assertThat(
       payload.contains("scope='file' requires parameter: path"),
       s"expected missing path validation message: $payload"
@@ -328,9 +343,9 @@ object IQServerAuthTest {
     val request =
       """{"jsonrpc":"2.0","id":"req-open-bool","method":"tools/call","params":{"name":"open_file","arguments":{"path":"demo.thy","create_if_missing":"maybe"}}}"""
     val response = server.processRequestForTest(request)
-    assertThat(response.nonEmpty, "invalid boolean parameter should return JSON-RPC error")
+    assertThat(response.nonEmpty, "invalid boolean parameter should return a response")
     val payload = response.get
-    assertThat(payload.contains("\"error\""), s"expected error payload: $payload")
+    assertToolError(payload, "open_file invalid boolean param")
     assertThat(
       payload.contains("Invalid parameter 'create_if_missing': expected boolean"),
       s"expected boolean validation message: $payload"

--- a/iq/src/test/scala/IQServerAuthTest.scala
+++ b/iq/src/test/scala/IQServerAuthTest.scala
@@ -114,6 +114,10 @@ object IQServerAuthTest {
       payload.contains("\"name\":\"get_diagnostics\""),
       s"tools/list should expose get_diagnostics: $payload"
     )
+    assertThat(
+      payload.contains("\"name\":\"set_auto_save\""),
+      s"tools/list should expose set_auto_save: $payload"
+    )
   }
 
   private def testResolveCommandTargetRejectsInvalidSelection(): Unit = {


### PR DESCRIPTION
* Resolves #236 

This PR adds a default-on configuration option for auto-saving files upon edit through I/Q. This is enabled by default because agents can't seem to work out that switching between file-system tools and I/Q otherwise leads to conflicts.

The PR also fixes a unicode issue whereby initial file contents written by `openFile` would not be ascii-encoded, making the Isabelle build fail.

Finally, some smaller fixes to pre-existing test issues.