### PR TITLE
tutorial: add Beamer slide-deck session

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,6 +42,42 @@ jobs:
             -d $AFP_COMPONENT_BASE/Word_Lib \
             AutoCorrode
 
+  tutorial-build:
+    runs-on: ubuntu-latest
+    container:
+      # _X11_Latex variant ships TeX Live, which is needed because the
+      # tutorial session builds a Beamer PDF.
+      image: makarius/isabelle:Isabelle2025-2_X11_Latex
+      options: --user root
+
+    steps:
+      - name: Checkout AutoCorrode
+        uses: actions/checkout@v3
+
+      - name: Setup Isabelle
+        uses: ./.github/actions/setup-isabelle-action
+
+      - name: Install make and lualatex
+        run: |
+          apt-get update -qq
+          # texlive-luatex provides lualatex, used by Isabelle's document
+          # builder for Beamer documents.
+          apt-get install -y -qq --no-install-recommends make texlive-luatex > /dev/null
+
+      # `make build` builds the AutoCorrode parent heap (which the tutorial
+      # session inherits); `make tutorial` then builds the slide-deck PDF.
+      # The Makefile expects ISABELLE_HOME to point at the bin directory.
+      - name: Build AutoCorrode and tutorial
+        run: |
+          make ISABELLE_HOME=$ISABELLE_HOME/bin AFP_COMPONENT_BASE=$AFP_COMPONENT_BASE build tutorial
+
+      - name: Upload tutorial PDF
+        uses: actions/upload-artifact@v4
+        with:
+          name: autocorrode-tutorial
+          path: tutorial/autocorrode_tutorial.pdf
+          if-no-files-found: error
+
   iq-build:
     runs-on: ubuntu-latest
     container:

--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@
 ######################################################################
 
 .DEFAULT_GOAL: jedit
-.PHONY: register-afp-components build jedit
+.PHONY: register-afp-components build jedit tutorial
 
 # Set this to the directory containing the Isabelle2025-2 binary
 ISABELLE_HOME?=/Applications/Isabelle2025-2.app/bin
@@ -47,3 +47,8 @@ register-afp-components:
 
 build: register-afp-components
 	$(ISABELLE_HOME)/isabelle build $(ISABELLE_FLAGS) -d . AutoCorrode
+
+# Build the slide-deck tutorial in tutorial/. Inherits the AutoCorrode
+# parent heap, so run `make build` first if it isn't built yet.
+tutorial: register-afp-components
+	$(MAKE) -C tutorial ISABELLE_HOME=$(ISABELLE_HOME) build

--- a/tutorial/.gitignore
+++ b/tutorial/.gitignore
@@ -1,0 +1,3 @@
+output/
+autocorrode_tutorial.pdf
+*~

--- a/tutorial/Makefile
+++ b/tutorial/Makefile
@@ -1,0 +1,54 @@
+ISABELLE_VERSION ?= Isabelle2025-2
+ISABELLE_HOME    ?= /Applications/$(ISABELLE_VERSION).app/bin
+ISABELLE         := $(ISABELLE_HOME)/isabelle
+
+AUTOCORRODE_DIR  := $(realpath $(CURDIR)/..)
+TUTORIAL_DIR     := $(CURDIR)
+PDF_NAME         ?= autocorrode_tutorial.pdf
+
+ISABELLE_FLAGS ?= -b
+
+# Parent session image to inherit. Built once via `make heaps`.
+PARENT_IMAGE     := AutoCorrode
+
+# All -d directories so isabelle can resolve sessions.
+DIRS             := -d .. -d .
+
+define CHECK_ISABELLE
+	@if [ ! -x "$(ISABELLE)" ]; then \
+	  echo "error: '$(ISABELLE)' not found or not executable." >&2; \
+	  echo "Set ISABELLE_HOME, e.g. make ISABELLE_HOME=/path/to/Isabelle/bin $@" >&2; \
+	  exit 1; \
+	fi
+endef
+
+.PHONY: all heaps build clean jedit
+
+# Default: build heaps if missing, then build the tutorial.
+all: build
+
+# Build (or refresh) the upstream AutoCorrode parent heap. Slow the first
+# time, fast afterwards. Re-run if upstream theories change.
+heaps:
+	$(CHECK_ISABELLE)
+	$(ISABELLE) build $(DIRS) -b $(PARENT_IMAGE)
+
+# Build the tutorial session, inheriting the AutoCorrode parent image.
+build:
+	$(CHECK_ISABELLE)
+	$(ISABELLE) build $(ISABELLE_FLAGS) $(DIRS) -l $(PARENT_IMAGE) AutoCorrodeTutorial
+	cp output/document.pdf $(PDF_NAME)
+	@echo "Wrote $(PDF_NAME)"
+
+view: build
+	open $(PDF_NAME)
+
+clean:
+	$(CHECK_ISABELLE)
+	$(ISABELLE) build $(DIRS) -c AutoCorrodeTutorial
+	rm -f $(PDF_NAME)
+
+# Open the tutorial in jEdit for interactive editing.
+jedit:
+	$(CHECK_ISABELLE)
+	$(ISABELLE) jedit $(DIRS) -l $(PARENT_IMAGE) *.thy

--- a/tutorial/README.md
+++ b/tutorial/README.md
@@ -1,0 +1,44 @@
+# AutoCorrode Tutorial
+
+A Beamer slide deck generated from formally-checked Isabelle/HOL theories.
+Every slide is a live theory: definitions, types, lemmas, and proofs shown
+in the PDF were type-checked at build time, so the deck cannot compile if a
+referenced fact stops being true.
+
+The deck is intended both as a guided walkthrough of AutoCorrode and as an
+experimentation ground -- open the sources in jEdit, change a definition or
+a contract, and watch which proofs still go through.
+
+## Layout
+
+- `ROOT` -- Isabelle session `AutoCorrodeTutorial`, inheriting the
+  `AutoCorrode` parent session.
+- `Slides.thy` -- outer-syntax commands (`slide`, `end_slide`,
+  `interlude`, ...) that emit Beamer frame markup from `.thy` files.
+- `Tutorial_*.thy` -- one theory per topic (preamble, monads, Hoare logic,
+  separation logic, etc.). Loaded in order from `document/root.tex`.
+- `document/root.tex` -- Beamer document skeleton; chooses which
+  `Tutorial_*.tex` are included and in what order.
+- `Makefile` -- thin wrapper around `isabelle build`. Common targets:
+  `make heaps` (parent image), `make build`, `make view`, `make jedit`,
+  `make clean`.
+- `output/` -- Isabelle's session output directory; `output/document.pdf`
+  is copied to `autocorrode_tutorial.pdf`.
+
+## Build
+
+```
+make heaps    # one-off: build the AutoCorrode parent heap
+make          # build the tutorial PDF -> autocorrode_tutorial.pdf
+make view     # build then open the PDF (macOS)
+make jedit    # open the tutorial theories in jEdit
+```
+
+Override `ISABELLE_HOME` if the Isabelle binary lives somewhere other than
+`/Applications/Isabelle2025-2.app/bin`:
+
+```
+make ISABELLE_HOME=/path/to/Isabelle/bin build
+```
+
+The same target is available from the repository root as `make tutorial`.

--- a/tutorial/ROOT
+++ b/tutorial/ROOT
@@ -1,0 +1,19 @@
+session AutoCorrodeTutorial = AutoCorrode +
+  options [document = pdf, document_output = "output"]
+  theories
+    Slides
+    Tutorial_Preamble
+    Tutorial_Context
+    Tutorial_Agenda
+    Tutorial_Glossary
+    Tutorial_Monads
+    Tutorial_HoareSetup
+    Tutorial_HoareWorked
+    Tutorial_UrustPeek_WP
+    Tutorial_UrustPeek_Eval
+    Tutorial_SepalgIntro
+    Tutorial_UrustPeek_Triple
+    Tutorial_UrustPeek_Call
+    Tutorial_SLWorked
+  document_files
+    "root.tex"

--- a/tutorial/Slides.thy
+++ b/tutorial/Slides.thy
@@ -1,0 +1,67 @@
+theory Slides
+  imports Pure
+  keywords "slide" :: document_raw
+       and "end_slide" :: document_raw
+       and "interlude" :: document_raw
+       and "end_interlude" :: document_raw
+begin
+
+text \<open>
+  \<^bold>\<open>Slide outer-syntax commands.\<close>
+
+  This theory adds two top-level commands so that an \<^verbatim>\<open>.thy\<close> file can
+  drive a beamer slide deck through Isabelle's document preparation system.
+
+  \<^item> \<^verbatim>\<open>slide \<open>Title\<close>\<close> emits a literal \<^verbatim>\<open>\begin{frame}[fragile]{Title}\<close>.
+
+  \<^item> \<^verbatim>\<open>end_slide\<close> emits a literal \<^verbatim>\<open>\end{frame}\<close>.
+
+  Use them as a balanced pair around each slide's content:
+  \begin{quote}\<^verbatim>\<open>
+    slide \<open>Outline\<close>
+      text \<open>...\<close>
+    end_slide
+  \<close>\end{quote}
+
+  \<^bold>\<open>Why two commands and not one?\<close>  Beamer's \<^verbatim>\<open>frame\<close> environment scans
+  for a \<^bold>\<open>literal\<close> \<^verbatim>\<open>\end{frame}\<close> token in the source -- macros are not
+  expanded during the scan, so the close cannot be hidden behind an
+  \<^verbatim>\<open>\isamarkupslide\<close>-style macro.  Both ends must therefore appear in
+  the generated \<^verbatim>\<open>.tex\<close> verbatim.
+\<close>
+
+ML \<open>
+  Outer_Syntax.command \<^command_keyword>\<open>slide\<close> "open a beamer frame"
+    (Parse.opt_target -- Parse.document_source --| Scan.option (Parse.$$$ ";") >>
+      Document_Output.document_output
+        {markdown = false,
+         markup = fn body =>
+           XML.string "%\n\\begin{frame}[fragile]{" @
+           body @
+           XML.string "}%\n"});
+
+  Outer_Syntax.command \<^command_keyword>\<open>end_slide\<close> "close a beamer frame"
+    (Parse.opt_target -- Scan.succeed Input.empty >>
+      Document_Output.document_output
+        {markdown = false, markup = fn _ => XML.string "%\n\\end{frame}\n"});
+
+  \<comment> \<open>\<^verbatim>\<open>interlude\<close>/\<^verbatim>\<open>end_interlude\<close> emit a regular \<^verbatim>\<open>\begin{frame}\<close>/\<^verbatim>\<open>\end{frame}\<close> pair
+       \<^emph>\<open>at the source level\<close> so beamer's \<^verbatim>\<open>[fragile]\<close> token-scanner finds the literal close,
+       and bracket the body with \<^verbatim>\<open>\interludetop\<close>/\<^verbatim>\<open>\interludebottom\<close> dressing macros
+       defined in \<^verbatim>\<open>root.tex\<close>.\<close>
+  Outer_Syntax.command \<^command_keyword>\<open>interlude\<close> "open an interlude frame"
+    (Parse.opt_target -- Parse.document_source --| Scan.option (Parse.$$$ ";") >>
+      Document_Output.document_output
+        {markdown = false,
+         markup = fn body =>
+           XML.string "%\n\\begin{frame}[fragile]{" @
+           body @
+           XML.string "}%\n\\interludetop%\n"});
+
+  Outer_Syntax.command \<^command_keyword>\<open>end_interlude\<close> "close an interlude frame"
+    (Parse.opt_target -- Scan.succeed Input.empty >>
+      Document_Output.document_output
+        {markdown = false, markup = fn _ => XML.string "%\n\\interludebottom%\n\\end{frame}\n"});
+\<close>
+
+end

--- a/tutorial/Tutorial_Agenda.thy
+++ b/tutorial/Tutorial_Agenda.thy
@@ -1,0 +1,30 @@
+theory Tutorial_Agenda
+  imports Main Slides
+begin
+
+slide \<open>Agenda\<close>
+
+text \<open>\<^bold>\<open>Foundations\<close>
+
+  \<^item> HOL-Light \<open>\<leftrightarrow>\<close> Isabelle cheat-sheet
+
+  \<^item> Monads, with several worked instances\<close>
+
+text \<open>\<^bold>\<open>Specs and proofs\<close>
+
+  \<^item> Hoare triples, WP, the frame problem
+
+  \<^item> Separation logic\<close>
+
+text \<open>\<^bold>\<open>AutoCorrode\<close>
+
+  \<^item> The real uRust monad, triple, WP
+
+  \<^item> The \<open>crush\<close> tactic
+
+  \<^item> A real, proven uRust contract\<close>
+
+end_slide
+
+end
+

--- a/tutorial/Tutorial_Context.thy
+++ b/tutorial/Tutorial_Context.thy
@@ -1,0 +1,100 @@
+theory Tutorial_Context
+  imports Slides
+begin
+
+slide \<open>Context: AutoCorrode\<close>
+
+text \<open>\<^bold>\<open>AutoCorrode\<close> provides verification infrastructure for reasoning
+about imperative programs in Isabelle/HOL. Among many other things, it
+encompasses:\<close>
+
+text \<open>
+\<^item> A formalization of \<^bold>\<open>Separation Logic\<close>
+\<^item> A shallow embedding of a Rust dialect, \<open>\<mu>\<close>Rust, as a monad into Isabelle/HOL
+\<^item> A \<^bold>\<open>weakest-precondition calculus\<close> for reasoning about \<open>\<mu>\<close>Rust in SL
+\<^item> Extensible, scalable proof automation (\<open>crush\<close>)
+\<^item> AI \<open>\<leftrightarrow>\<close> Isabelle integration tools (I/Q, I/R, I/P, I/C)
+\<^item> Abstract interfaces for references
+\<^item> Abstract \<^emph>\<open>and\<close> byte-accurate models of references
+\<^item> A ``poor-man's separation logic'' for footprint reasoning in pure HOL
+\<^item> \dots
+\<close>
+
+text \<open>\<^bold>\<open>This talk covers a small slice\<close> -- enough of the foundations
+  (monads, Hoare/WP, separation logic) to read AutoCorrode source.\<close>
+
+end_slide
+
+slide \<open>AutoCorrode at a glance: session structure\<close>
+
+text \<open>Where the pieces live in the upstream tree (arrows = depends on):\<close>
+
+text_raw \<open>
+\begin{center}
+\begin{tikzpicture}[
+  >={Stealth[length=1.6mm]},
+  thick,
+  every node/.style={font=\tiny\sffamily, draw, rounded corners=1pt,
+                     inner sep=2pt, fill=white},
+  hi/.style={fill=blue!15},
+  arr/.style={->, gray!60!black},
+  node distance=2mm and 4mm
+]
+% Layer 0
+\node (DS)    {Data\_Structures};
+\node (Misc)  [right=of DS]    {Misc};
+\node (Lens)  [right=of Misc]  {Lenses\_And\_Other\_Optics};
+\node (PF)    [right=of Lens]  {Micro\_Rust\_Parsing\_Frontend};
+% Layer 1
+\node (BE)    [above=of Misc]  {Byte\_Level\_Encoding};
+\node (Auto)  [above=of Lens, xshift=14mm]  {Autogen};
+% Layer 2 — central
+\node[hi] (SMR)   [above=of Auto]  {Shallow\_Micro\_Rust};
+% Layer 3
+\node[hi] (SSL)   [above=of SMR]   {Shallow\_Separation\_Logic};
+\node (SLens) [right=of SSL]   {Separation\_Lenses};
+\node (MIC)   [left=of SSL]    {Micro\_Rust\_Interfaces\_Core};
+% Layer 4
+\node[hi] (Crush) [above=of SSL]   {Crush};
+\node (Std)   [right=of Crush] {Micro\_Rust\_Std\_Lib};
+% Layer 5
+\node (MI)    [above=of Std]   {Micro\_Rust\_Interfaces};
+% Layer 6
+\node (MR)    [above=of MI]    {Micro\_Rust\_Runtime};
+% Layer 7
+\node (Ex)    [above=of MR]    {Micro\_Rust\_Examples};
+
+% Edges (orthogonal routing only -- no diagonals)
+\tikzset{ortho/.style={arr, rounded corners=2pt}}
+% Same-row / same-column edges
+\draw[arr] (DS)    -- (Misc);
+\draw[arr] (Misc)  -- (Lens);
+\draw[arr] (Lens)  -- (Auto);
+\draw[arr] (Misc)  -- (BE);
+\draw[arr] (Auto)  -- (SMR);
+\draw[arr] (Lens)  -- (SMR);
+\draw[arr] (SMR)   -- (SSL);
+\draw[arr] (SSL)   -- (SLens);
+\draw[arr] (SSL)   -- (MIC);
+\draw[arr] (SSL)   -- (Crush);
+\draw[arr] (Crush) -- (Std);
+\draw[arr] (Std)   -- (MI);
+\draw[arr] (MI)    -- (MR);
+\draw[arr] (MR)    -- (Ex);
+% Off-grid edges, routed vertical-then-horizontal
+\draw[ortho] (Lens.north) |- (BE.east);
+\draw[ortho] (PF.north)   |- (SMR.east);
+\draw[ortho] (MIC.north)  |- (Crush.west);
+\draw[ortho] (Crush.north) |- (MI.west);
+% Crush -> Ex: up then right
+\draw[ortho] (Crush.north) |- (Ex.west);
+% BE -> MR: route well around the LEFT, outside the whole node cluster
+\draw[ortho]
+  (BE.west) -- ++(-15mm,0) |- (MR.west);
+\end{tikzpicture}
+\end{center}
+\<close>
+
+end_slide
+
+end

--- a/tutorial/Tutorial_Glossary.thy
+++ b/tutorial/Tutorial_Glossary.thy
@@ -1,0 +1,312 @@
+theory Tutorial_Glossary
+  imports Main Slides
+begin
+
+slide \<open>HOL-Light \<open>\<rightarrow>\<close> Isabelle: the logical core\<close>
+
+text \<open>HOL-Light and Isabelle/HOL share the \<^bold>\<open>same logical core\<close>:
+  classical, polymorphic higher-order logic. Both build the
+  propositional connectives and quantifiers from equality and \<open>\<lambda>\<close>.
+  The literal kernel definitions, side by side (HOL-Light
+  \<^verbatim>\<open>bool.ml\<close> vs.\ Isabelle \<^verbatim>\<open>HOL.thy\<close>):\<close>
+
+text_raw \<open>
+\begin{center}\scriptsize
+\begin{tabular}{c l l}
+       & \textbf{HOL-Light} & \textbf{Isabelle/HOL} \\
+\hline
+$\top$ & \texttt{T = ($\lambda$p. p) = ($\lambda$p. p)} & \texttt{True $\equiv$ ($\lambda$x. x) = ($\lambda$x. x)} \\
+$\land$ & \texttt{$\land$ = $\lambda$p q. ($\lambda$f. f p q) = ($\lambda$f. f T T)} & \texttt{P $\land$ Q $\equiv$ $\forall$R. (P $\to$ Q $\to$ R) $\to$ R} \\
+$\to$ & \texttt{$\to$ = $\lambda$p q. p $\land$ q $\Leftrightarrow$ p} & \emph{axiomatised (\texttt{impI}, \texttt{mp})} \\
+$\forall$ & \texttt{$\forall$ = $\lambda$P. P = $\lambda$x. T} & \texttt{All P $\equiv$ (P = ($\lambda$x. True))} \\
+$\exists$ & \texttt{$\exists$ = $\lambda$P. $\forall$q. ($\forall$x. P x $\to$ q) $\to$ q} & \texttt{Ex P $\equiv$ $\forall$Q. ($\forall$x. P x $\to$ Q) $\to$ Q} \\
+$\bot$ & \texttt{F = $\forall$p. p} & \texttt{False $\equiv$ ($\forall$P. P)} \\
+$\lnot$ & \texttt{$\lnot$ = $\lambda$p. p $\to$ F} & \texttt{$\lnot$ P $\equiv$ P $\to$ False} \\
+$\lor$ & \texttt{$\lor$ = $\lambda$p q. $\forall$r. (p $\to$ r) $\to$ (q $\to$ r) $\to$ r} & \texttt{P $\lor$ Q $\equiv$ $\forall$R. (P $\to$ R) $\to$ (Q $\to$ R) $\to$ R} \\
+\end{tabular}
+\end{center}
+\<close>
+
+text \<open>\<^bold>\<open>Differences.\<close> Only \<open>\<and>\<close> and \<open>\<longrightarrow>\<close> diverge.
+  HOL-Light uses Andrews' \<^emph>\<open>pairing trick\<close> for \<open>\<and>\<close>; Isabelle uses
+  the impredicative \<open>\<forall>R. \<dots>\<close> encoding (cleaner to reason with).
+  HOL-Light defines \<open>\<longrightarrow>\<close> from \<open>\<and>\<close>; Isabelle introduces it as an
+  uninterpreted \<open>bool \<Rightarrow> bool \<Rightarrow> bool\<close> constant via \<^verbatim>\<open>axiomatization\<close>
+  in \<open>HOL.thy\<close>, governed by the rules \<^verbatim>\<open>impI\<close> and \<^verbatim>\<open>mp\<close>.\<close>
+
+end_slide
+
+
+slide \<open>What Isabelle adds on top\<close>
+
+text \<open>Same logical kernel, \<^emph>\<open>but\<close> Isabelle layers more conveniences
+  on top:
+
+  \<^item> \<^bold>\<open>Isar\<close>: a structured proof language;
+
+  \<^item> \<^bold>\<open>locales\<close> -- parametrised theory sections;
+
+  \<^item> \<^bold>\<open>code generation\<close> to OCaml / Haskell / Scala / SML;
+
+  \<^item> \<^bold>\<open>interactive editing\<close> (PIDE) with continuous proof checking;
+
+  \<^item> a \<^bold>\<open>document preparation\<close> system (these slides are an example).\<close>
+
+text \<open>None of these enlarge the trust base -- they all reduce to the same
+underlying axioms -- but they change the day-to-day experience of
+writing proofs.\<close>
+
+end_slide
+
+
+slide \<open>HOL-Light \<open>\<rightarrow>\<close> Isabelle: types and terms\<close>
+
+text \<open>\<^bold>\<open>Type variables.\<close>
+  HOL-Light: \<^verbatim>\<open>`!x:A. P x ==> P x`\<close>.
+  Isabelle: \<open>\<forall>x::'a. P x \<longrightarrow> P x\<close>.
+
+  \<^bold>\<open>Function type.\<close>
+  HOL-Light: \<^verbatim>\<open>`:A->B`\<close>.
+  Isabelle: @{typ \<open>'a \<Rightarrow> 'b\<close>}.
+
+  \<^bold>\<open>Polymorphism.\<close>
+  As in HOL-Light, type parameters are written \<^emph>\<open>on the left\<close>:
+  @{typ \<open>'a list\<close>} is the type of lists over \<open>'a\<close>.
+
+  \<^bold>\<open>Equality, iff.\<close>
+  HOL-Light: \<^verbatim>\<open>`x = y`\<close>, \<^verbatim>\<open>`P <=> Q`\<close>.
+  Isabelle: \<open>x = y\<close>, \<open>P \<longleftrightarrow> Q\<close>. The two are equal on \<open>bool\<close>;
+  the \<open>\<longleftrightarrow>\<close> form just marks intent.
+
+  \<^bold>\<open>Schematic variables.\<close>
+  HOL-Light: shown as plain free variables in goals.
+  Isabelle: shown with a question mark in stored facts; e.g.\
+  the elimination rule
+  @{thm [show_question_marks] conjE}.\<close>
+
+end_slide
+
+
+slide \<open>HOL-Light \<open>\<rightarrow>\<close> Isabelle: definitions\<close>
+
+text \<open>\<^bold>\<open>Plain definition.\<close> HOL-Light:
+
+  \<^verbatim>\<open>let double = new_definition `double x = x + x`;;\<close>
+
+  Isabelle:\<close>
+
+definition double :: \<open>nat \<Rightarrow> nat\<close>
+    \<comment> \<open>type may be omitted; the most general type is inferred\<close>
+  where \<open>double x = x + x\<close>
+
+text \<open>\<^bold>\<open>Recursive function.\<close> HOL-Light:
+
+  \<^verbatim>\<open>let LEN = define `LEN [] = 0 /\ LEN (CONS x xs) = SUC (LEN xs)`;;\<close>
+
+  Isabelle:\<close>
+
+fun len :: \<open>'a list \<Rightarrow> nat\<close> where
+  \<open>len [] = 0\<close>
+| \<open>len (x # xs) = Suc (len xs)\<close>
+
+text %internal \<open>Inductive definition (kept in the .thy as an example
+  but hidden from the slide -- already crowded).\<close>
+
+inductive %internal even' :: \<open>nat \<Rightarrow> bool\<close> where
+  even_zero: \<open>even' 0\<close>
+| even_step: \<open>even' n \<Longrightarrow> even' (Suc (Suc n))\<close>
+
+end_slide
+
+
+slide \<open>HOL-Light \<open>\<rightarrow>\<close> Isabelle: data\<close>
+
+text \<open>\<^bold>\<open>Algebraic datatypes.\<close> HOL-Light:
+
+  \<^verbatim>\<open>let option_INDUCT,option_RECURSION =
+    define_type "option = NONE | SOME A";;\<close>
+
+  Isabelle:\<close>
+
+datatype 'a opt = NONE | SOME 'a
+
+text \<open>\<^bold>\<open>Records.\<close> Recent HOL-Light has them too (J.\ Harrison,
+  2023); Isabelle's are older and slightly fancier (anonymous
+  functional update built in). Field accessors and a functional
+  update operator come from one declaration:\<close>
+
+record point =
+  px :: int
+  py :: int
+
+text \<open>The functional update \<open>p\<lparr>px := 7\<rparr>\<close> reads ``\<open>p\<close> with \<open>px\<close>
+  set to \<open>7\<close>''. We use this throughout the Hoare-logic worked example.\<close>
+
+end_slide
+
+
+slide \<open>HOL-Light \<open>\<rightarrow>\<close> Isabelle: tactic proofs\<close>
+
+text \<open>\<^bold>\<open>Tactic-only\<close>: same content, different syntax. HOL-Light:
+
+  \<^verbatim>\<open>let DOUBLE_THM = prove(`double x = 2 * x`,
+    REWRITE_TAC[double] THEN ARITH_TAC);;\<close>
+
+  Isabelle equivalent:\<close>
+
+text_raw \<open>\isakeeptag{proof}\<close>
+
+lemma double_thm: \<open>double x = 2 * x\<close>
+    \<comment> \<open>\<open>simp\<close>: Isabelle's simplifier\<close>
+    \<comment> \<open>\<open>add: double_def\<close>: register the defining equation as a rewrite rule\<close>
+  by (simp add: double_def)
+
+text_raw \<open>\isadroptag{proof}\<close>
+
+text \<open>\<^bold>\<open>Case expressions.\<close> HOL-Light: \<^verbatim>\<open>match x with NONE -> 0 | SOME y -> y\<close>.
+  Isabelle:\<close>
+
+definition unopt :: \<open>nat option \<Rightarrow> nat\<close> where
+  \<open>unopt x = (case x of None \<Rightarrow> 0 | Some y \<Rightarrow> y)\<close>
+
+end_slide
+
+
+slide \<open>HOL-Light \<open>\<rightarrow>\<close> Isabelle: structured proofs\<close>
+
+text \<open>Apply-style and HOL-Light tactics are \<^bold>\<open>backward\<close> reasoning:
+  start from the goal, peel rules off until the trivial.
+
+  \<^bold>\<open>Structured (Isar)\<close>, by contrast, is \<^bold>\<open>forward\<close> reasoning -- the
+  way humans write proofs on paper.\<close>
+
+text \<open>\<^bold>\<open>Example:\<close>\<close>
+
+text_raw \<open>\isakeeptag{proof}\<close>
+
+lemma len_append: \<open>len (xs @ ys) = len xs + len ys\<close>
+proof (induction xs)
+  case Nil
+  show \<open>len ([] @ ys) = len [] + len ys\<close> by simp
+next
+  case (Cons x xs)
+  have \<open>len ((x # xs) @ ys) = Suc (len (xs @ ys))\<close> by simp
+  also have \<open>\<dots> = Suc (len xs + len ys)\<close> using Cons.IH by simp
+  also have \<open>\<dots> = len (x # xs) + len ys\<close> by simp
+  finally show ?case .
+qed
+
+text_raw \<open>\isadroptag{proof}\<close>
+
+end_slide
+
+(*<*)
+slide \<open>HOL-Light analogue: \<^verbatim>\<open>LIST_INDUCT_TAC\<close>\<close>
+
+text \<open>HOL-Light has no \<open>induction\<close> keyword, but the same proof goes
+  through with the corresponding induction tactic:\<close>
+
+text \<open>\<^verbatim>\<open>let LEN_APPEND = prove
+ (`!xs ys. LEN (APPEND xs ys) = LEN xs + LEN ys`,
+  LIST_INDUCT_TAC THEN ASM_REWRITE_TAC [LEN; APPEND; ADD; ADD_SUC]);;\<close>\<close>
+
+text \<open>\<^verbatim>\<open>LIST_INDUCT_TAC\<close> splits the goal into a \<open>Nil\<close> case and a
+  \<open>Cons\<close> case (with induction hypothesis available);
+  \<^verbatim>\<open>ASM_REWRITE_TAC\<close> rewrites with \<open>LEN\<close>/\<open>APPEND\<close> and the
+  hypothesis, playing the role of Isar's calculational chain.\<close>
+
+end_slide
+(*>*)
+
+slide \<open>Locales: parametrised theory sections\<close>
+
+text \<open>A \<^bold>\<open>locale\<close> is a named, reusable bundle of \<^bold>\<open>parameters\<close> and
+  \<^bold>\<open>assumptions\<close>. Example:\<close>
+
+locale toy_monoid =
+  fixes mul :: \<open>'a \<Rightarrow> 'a \<Rightarrow> 'a\<close>  (infixl \<open>\<otimes>\<close> 70)
+    and one :: \<open>'a\<close>
+  assumes assoc:    \<open>(x \<otimes> y) \<otimes> z = x \<otimes> (y \<otimes> z)\<close>
+      and ident_l:  \<open>one \<otimes> x = x\<close>
+      and ident_r:  \<open>x \<otimes> one = x\<close>
+
+text \<open>Inside \<open>context toy_monoid begin \<dots> end\<close> the parameters and
+  assumptions are in scope; outside, every \<open>toy_monoid\<close>-statement is
+  implicitly universally quantified over them.\<close>
+
+text \<open>Alternatively, use \<open>(in locale)\<close> to enter a locale context for
+  a single command. E.g.:\<close>
+
+text_raw \<open>\isakeeptag{proof}\<close>
+
+lemma (in toy_monoid) example: \<open>(x \<otimes> one) \<otimes> y = x \<otimes> y\<close>
+  by (simp add: ident_r)
+
+text_raw \<open>\isadroptag{proof}\<close>
+
+end_slide
+
+
+slide \<open>Locales vs. type classes\<close>
+
+text \<open>Isabelle has both. Both are mechanisms for parametrised
+  reasoning; they differ in what they parametrise over.
+
+  \<^bold>\<open>Type classes\<close> parametrise over a \<^bold>\<open>single type variable\<close> and use
+  automatic resolution: \<open>'a :: monoid\<close> means ``\<open>'a\<close> happens to be a
+  monoid'', and the typechecker dispatches operations like \<open>\<otimes>\<close>
+  silently. Good for hierarchies of types (\<open>monoid\<close>, \<open>group\<close>, \<open>ring\<close>, ...).
+
+  \<^bold>\<open>Locales\<close> parametrise over \<^bold>\<open>an arbitrary signature\<close>: any number
+  of fixes plus assumptions, no automatic resolution. Better for
+  abstract interfaces with multiple parameters of unrelated types.
+
+  Convenient, though HOL-Light proves one can be successful
+  without them.\<close>
+
+end_slide
+
+
+slide \<open>Locales in AutoCorrode\<close>
+
+text \<open>AutoCorrode involves various locale interfaces; a few
+  representative examples:
+
+  \<^item> \<open>sepalg\<close> -- the abstract \<^bold>\<open>separation algebra\<close>: a partial
+    commutative monoid. Carrier type, \<open>+\<close>, \<open>0\<close>, disjointness.
+    Almost all SL theorems are stated in this locale.
+
+  \<^item> \<open>reference\<close> -- the abstract \<^bold>\<open>heap interface\<close>: allocate,
+    dereference, update typed references. Multiple interpretations
+    ship (abstract heap, physical-memory byte arrays, ...).\<close>
+
+text \<open>\<^bold>\<open>Pattern.\<close> State the verification once in the abstract locale;
+  \<^bold>\<open>interpret\<close> it for each concrete heap. The same proof works against
+  the abstract heap and against the physical-memory model.\<close>
+
+end_slide
+
+
+slide \<open>Document preparation\<close>
+
+text \<open>Isabelle ships a \<^bold>\<open>document preparation system\<close>: every \<open>.thy\<close>
+  file is also a typeset document. \<open>text \<open>...\<close>\<close> blocks are prose;
+  \<^bold>\<open>antiquotations\<close> like \<open>@{thm name}\<close>, \<open>@{term \<dots>}\<close>, \<open>@{datatype t}\<close>
+  splice the \<^emph>\<open>real, type-checked\<close> theorem / term / datatype into the
+  prose at build time.\<close>
+
+text \<open>Concretely: this slide's source contains the antiquotation
+  \<open>@{thm double_thm}\<close>, and yields\<close>
+
+text \<open>@{thm double_thm}\<close>
+
+text \<open>-- the proven statement, type-checked at build time. If
+  \<open>double\<close> is renamed, the slide breaks. If the lemma stops being
+  true, the slide doesn't build. \<^bold>\<open>These slides were produced this
+  way\<close>: every formal artifact you have seen and will see is live.\<close>
+
+end_slide
+
+
+end
+

--- a/tutorial/Tutorial_HoareSetup.thy
+++ b/tutorial/Tutorial_HoareSetup.thy
@@ -1,0 +1,95 @@
+theory Tutorial_HoareSetup
+  imports Main "HOL-Library.Monad_Syntax" Slides
+begin
+
+(*<*)
+\<comment> \<open>A dedicated entailment constant for state-set assertions.
+  Wrapping \<open>\<subseteq>\<close> in a fresh definition means the parser/printer never
+  confuses entailment with boolean implication or subset.\<close>
+
+definition entails :: \<open>'s set \<Rightarrow> 's set \<Rightarrow> bool\<close>
+  where \<open>entails P Q \<equiv> P \<subseteq> Q\<close>
+
+lemma entailsI: \<open>P \<subseteq> Q \<Longrightarrow> entails P Q\<close>
+  by (simp add: entails_def)
+
+lemma entailsD: \<open>entails P Q \<Longrightarrow> P \<subseteq> Q\<close>
+  by (simp add: entails_def)
+
+bundle hoare_set_syntax
+begin
+  \<comment> \<open>Lattice-style notation for sets: \<open>\<sqinter>\<close> for intersection (the
+    \<open>HOL.lattice_syntax\<close> glyph, bound directly to \<open>inter\<close> so it
+    both parses \<^emph>\<open>and\<close> prints), and \<open>\<longlongrightarrow>\<close> for the dedicated
+    entailment constant \<open>entails\<close>.\<close>
+  no_notation inter (infixl \<open>\<inter>\<close> 70)
+  notation    inter (infixl \<open>\<sqinter>\<close> 70)
+  notation    entails (infix  \<open>\<longlongrightarrow>\<close> 50)
+end
+
+(*>*)
+
+
+slide \<open>A toy non-deterministic state monad\<close>
+
+text \<open>To make the next few slides concrete, we set up a small
+  state-monad playground. We pick the \<^bold>\<open>non-deterministic\<close>
+  variant: from one state, a program can produce \<^emph>\<open>several\<close>
+  possible \<open>(result, end-state)\<close> outcomes. This matches the shape
+  uRust uses upstream.\<close>
+
+datatype ('s, 'a) m = M (run: \<open>'s \<Rightarrow> ('a \<times> 's) set\<close>)
+
+definition return :: \<open>'a \<Rightarrow> ('s, 'a) m\<close> where
+  \<open>return x = M (\<lambda>s. {(x, s)})\<close>
+
+definition mbind :: \<open>('s, 'a) m \<Rightarrow> ('a \<Rightarrow> ('s, 'b) m) \<Rightarrow> ('s, 'b) m\<close> where
+  \<open>mbind c k = M (\<lambda>s. \<Union>(x, s')\<in>run c s. run (k x) s')\<close>
+
+text \<open>Hook into \<open>HOL-Library.Monad_Syntax\<close> for \<open>do\<close>-notation:\<close>
+
+adhoc_overloading bind \<rightleftharpoons> mbind
+
+end_slide
+
+
+slide \<open>The evaluation relation \<open>\<leadsto>\<close>: in our toy example\<close>
+
+text \<open>One primitive: ``from \<open>s\<close>, program \<open>e\<close> can produce result \<open>x\<close>
+  and end in state \<open>s'\<close>''.\<close>
+
+definition evals :: \<open>'s \<Rightarrow> ('s, 'a) m \<Rightarrow> ('a \<times> 's) \<Rightarrow> bool\<close>
+    (\<open>_ \<leadsto>\<langle>_\<rangle> _\<close> [60, 0, 60] 60)
+      \<comment> \<open>the numbers fix operator precedence (binding strength)\<close>
+  where \<open>s \<leadsto>\<langle>e\<rangle> xs' \<equiv> xs' \<in> run e s\<close>
+
+text \<open>(This is the same shape uRust uses -- see later.)\<close>
+
+text \<open>Characterisations of \<open>\<leadsto>\<close> on \<open>return\<close>, \<open>do\<close>-bind, and plain
+  sequencing that we'll need below:\<close>
+
+lemma evals_simps:
+  shows evals_return: \<open>s \<leadsto>\<langle>return x\<rangle> (y, s') \<longleftrightarrow> y = x \<and> s' = s\<close>
+    and evals_bind: \<open>s \<leadsto>\<langle>do { x \<leftarrow> e; k x }\<rangle> (y, s'')
+                 \<longleftrightarrow> (\<exists>x s'. s \<leadsto>\<langle>e\<rangle> (x, s') \<and> s' \<leadsto>\<langle>k x\<rangle> (y, s''))\<close>
+    and evals_seq: \<open>s \<leadsto>\<langle>do { e\<^sub>1; e\<^sub>2 }\<rangle> (y, s'')
+       \<longleftrightarrow> (\<exists>x s'. s \<leadsto>\<langle>e\<^sub>1\<rangle> (x, s') \<and> s' \<leadsto>\<langle>e\<^sub>2\<rangle> (y, s''))\<close>
+
+  by %visible (auto simp: evals_def return_def mbind_def)+
+
+end_slide
+
+
+interlude \<open>A peek ahead: real uRust evaluation rules\<close>
+
+text_raw \<open>%
+\begingroup
+\renewenvironment{isabellebody}{}{}%
+\renewcommand{\setisabellecontext}[1]{}%
+\input{Tutorial_UrustPeek_Eval.tex}%
+\endgroup
+\<close>
+
+end_interlude
+
+end

--- a/tutorial/Tutorial_HoareWorked.thy
+++ b/tutorial/Tutorial_HoareWorked.thy
@@ -1,0 +1,540 @@
+theory Tutorial_HoareWorked
+  imports Tutorial_HoareSetup
+begin
+
+(*<*)
+unbundle hoare_set_syntax
+(*>*)
+
+slide \<open>Hoare triples\<close>
+
+text \<open>For a program \<open>e\<close> in our monad, a contract is a pair of:
+
+  \<^item> a \<^bold>\<open>precondition\<close> \<open>P\<close>: a predicate on the state \<^emph>\<open>before\<close> running \<open>e\<close>.
+
+  \<^item> a \<^bold>\<open>postcondition\<close> \<open>Q\<close>: a predicate on the result \<^emph>\<open>and\<close> the state \<^emph>\<open>after\<close> \<open>e\<close>.\<close>
+
+text \<open>We write \<open>\<lbrace>P\<rbrace> e \<lbrace>Q\<rbrace>\<close> for the claim ``if \<open>P\<close> holds before \<open>e\<close>,
+  then \<open>Q\<close> holds after'' -- a \<^bold>\<open>Hoare triple\<close>. The exact meaning
+  is given case-by-case per monad. \<^bold>\<open>Important:\<close> this is the notion
+  we ultimately use to state correctness of programs.\<close>
+
+text \<open>Whatever the meaning, any sensible triple notion should be
+  \<^emph>\<open>compositional\<close> -- bind two triples sharing an intermediate
+  predicate \<open>R\<close>, get a triple for the composition:\<close>
+
+text_raw \<open>
+\begin{center}
+\AxiomC{$\{P\}\;c_1\;\{R\}$}
+\AxiomC{$\{R\}\;c_2\;\{Q\}$}
+\RightLabel{(\textsc{Seq})}
+\BinaryInfC{$\{P\}\;c_1;\;c_2\;\{Q\}$}
+\DisplayProof
+\end{center}
+\<close>
+
+end_slide
+
+
+slide \<open>Triple and \<open>(SEQ)\<close> for the toy monad\<close>
+
+text \<open>For our toy monad, the triple says ``every reachable
+  outcome satisfies \<open>Q\<close>'' -- expressed via \<open>\<leadsto>\<close>:\<close>
+
+definition triple :: \<open>'s set \<Rightarrow> ('s, 'a) m \<Rightarrow> ('a \<Rightarrow> 's set) \<Rightarrow> bool\<close>
+    (\<open>\<lbrace>_\<rbrace>/ _/ \<lbrace>_\<rbrace>\<close>) where
+  \<open>\<lbrace>P\<rbrace> e \<lbrace>Q\<rbrace> \<equiv> \<forall>s x s'. s \<in> P \<and> s \<leadsto>\<langle>e\<rangle> (x, s') \<longrightarrow> s' \<in> Q x\<close>
+
+text \<open>and \<open>(SEQ)\<close> is then a \<^bold>\<open>theorem\<close>:\<close>
+
+lemma triple_seq:
+  assumes \<open>\<lbrace>P\<rbrace> e\<^sub>1 \<lbrace>\<lambda>x. R x\<rbrace>\<close>
+      and \<open>\<And>x. \<lbrace>R x\<rbrace> e\<^sub>2 x \<lbrace>Q\<rbrace>\<close>
+    shows \<open>\<lbrace>P\<rbrace> do { x \<leftarrow> e\<^sub>1; e\<^sub>2 x } \<lbrace>Q\<rbrace>\<close>
+  using assms by (fastforce simp: triple_def evals_bind)
+
+end_slide
+
+
+slide \<open>The practical question\<close>
+
+text \<open>Recall \<open>(SEQ)\<close>: to chain \<open>c\<^sub>1; c\<^sub>2\<close> we must produce an
+  intermediate \<open>R\<close>.\<close>
+
+text_raw \<open>
+\begin{center}
+\AxiomC{$\{P\}\;c_1\;\{R\}$}
+\AxiomC{$\{R\}\;c_2\;\{Q\}$}
+\RightLabel{(\textsc{Seq})}
+\BinaryInfC{$\{P\}\;c_1;\;c_2\;\{Q\}$}
+\DisplayProof
+\end{center}
+\medskip
+\<close>
+
+text \<open>\<^bold>\<open>Question:\<close> how do we know what to pick as \<open>R\<close>?
+  In a program with many sequenced steps, every \<open>;\<close> introduces
+  one -- and a fresh proof obligation. We need a systematic way
+  to compute it.\<close>
+
+end_slide
+
+
+slide \<open>Weakest preconditions\<close>
+
+text \<open>\<^bold>\<open>Idea:\<close> for each program \<open>e\<close> and postcondition \<open>Q\<close>, define
+  the \<^bold>\<open>weakest precondition\<close> \<open>\<W>\<P> e Q\<close> -- the largest predicate
+  on the start state for which \<open>e\<close> establishes \<open>Q\<close>:\<close>
+
+definition wp :: \<open>('s, 'a) m \<Rightarrow> ('a \<Rightarrow> 's set) \<Rightarrow> 's set\<close> (\<open>\<W>\<P>\<close>) where
+  \<open>\<W>\<P> e Q \<equiv> { s. \<forall>x s'. s \<leadsto>\<langle>e\<rangle> (x, s') \<longrightarrow> s' \<in> Q x }\<close>
+    \<comment> \<open>the set of states from which \<^emph>\<open>every\<close> outcome lands in \<open>Q\<close>\<close>
+
+text_raw \<open>\medskip\<close>
+
+text \<open>\<^bold>\<open>Universal property\<close> -- the triple holds iff its
+  precondition entails \<open>\<W>\<P> e Q\<close>:\<close>
+
+lemma wp_triple_iff: \<open>(\<lbrace>P\<rbrace> e \<lbrace>Q\<rbrace>) \<longleftrightarrow> (P \<longlongrightarrow> \<W>\<P> e Q)\<close>
+  by %visible (auto simp: triple_def wp_def entails_def)
+
+text \<open>This is \<^emph>\<open>functor-representability\<close> of the triple by \<open>\<W>\<P>\<close>.
+  It reduces every triple proof to a single entailment, and turns
+  the intermediate \<open>R\<close>'s of \<open>(SEQ)\<close> into \<^emph>\<open>computations\<close> over
+  \<open>\<W>\<P>\<close>.\<close>
+
+end_slide
+
+
+slide \<open>Weakest precondition calculus\<close>
+
+text \<open>Every statement about triples has a corresponding statement
+  about \<open>\<W>\<P>\<close>. For example, bind:\<close>
+
+lemma %visible wp_bind: 
+  shows \<open>\<W>\<P> (do { x \<leftarrow> e; k x }) Q = \<W>\<P> e (\<lambda>x. \<W>\<P> (k x) Q)\<close>
+  by (auto simp: wp_def evals_bind)
+
+text \<open>With @{thm [source] wp_bind}, the \<^term>\<open>\<W>\<P>\<close> can be broken into individual statements and 
+language's constructs.\<close>
+
+lemma wp_prog:
+  \<open>\<W>\<P> (do { x \<leftarrow> foo; y \<leftarrow> bar x; beef x y; return 42 }) Q
+     = \<W>\<P> foo (\<lambda>x. 
+         \<W>\<P> (bar x) (\<lambda>y. 
+           \<W>\<P> (beef x y) (\<lambda>_. 
+             \<W>\<P> (return 42) Q)))\<close>
+  by %visible (simp add: wp_bind)
+
+text\<open>We then apply dedicated rules per construct. \<^bold>\<open>Weakest Precondition Calculus\<close>.\<close>
+
+end_slide
+
+slide \<open>WP rules: Equation vs. Consequence form\<close>
+
+text\<open>There's a WP rule for every language construct. For example:\<close>
+
+lemma wp_return: \<open>\<W>\<P> (return x) Q = Q x\<close>
+  by (auto simp: wp_def evals_return)
+
+text\<open>For a proof calculus, WP rules are best stated in \<^bold>\<open>consequence form:\<close>\<close>
+
+lemma wp_from_eq: 
+ assumes \<open>\<W>\<P> e Q = \<psi>\<close> \<comment>\<open>Equational form\<close>
+   shows \<open>(\<phi> \<longlongrightarrow> \<psi>) \<Longrightarrow> (\<phi> \<longlongrightarrow> \<W>\<P> e Q)\<close> \<comment>\<open>Rule form\<close>
+  using assms by simp
+
+text\<open>With this, we can easily map one or more equational rules into consequence form:\<close>
+
+lemmas wp_returnI = wp_return[THEN wp_from_eq] \<comment>\<open>@{thm [show_question_marks=false, display] wp_returnI}\<close>
+lemmas wp_bindI = wp_bind[THEN wp_from_eq] \<comment>\<open>@{thm [show_question_marks=false, display] wp_bindI}\<close>
+
+end_slide
+
+slide \<open>WP rules, bundled together for automation\<close>
+
+text \<open>We accumulate WP rules in two named bundles -- \<open>wp_simps\<close> and \<open>wp_intros\<close>:\<close>
+
+named_theorems wp_simps  \<comment> \<open>equational WP rewrites for \<open>simp\<close>\<close>
+named_theorems wp_intros \<comment> \<open>consequence-form rules for \<open>intro\<close>/\<open>rule\<close>\<close>
+
+text \<open>Register previously proved lemmas as WP simp/intro rules:\<close>
+
+declare wp_bind[wp_simps] and wp_return[wp_simps]
+declare wp_returnI[wp_intros] and wp_bindI[wp_intros]
+
+text\<open>Note that @{method intro} @{thm [source] wp_intros} will only peel off one statement
+at a time:\<close>
+
+lemma %visible \<open>\<phi> \<longlongrightarrow> \<W>\<P> (do { x \<leftarrow> foo; y \<leftarrow> bar; beef; return (42::int) }) Q\<close>
+ apply (intro wp_intros)
+  \<comment>\<open>@{term \<open>\<phi> \<longlongrightarrow> \<W>\<P> foo (\<lambda>x. \<W>\<P> (bar \<bind> (\<lambda>y. beef \<bind> (\<lambda>_. return 42))) Q)\<close>}\<close>
+  oops \<comment>\<open>Abandon this proof\<close>
+
+text\<open>This is a \<^emph>\<open>feature\<close>, not a bug, because programs can be huge and we don't want to spend time
+on parts of the code we are not yet ready to reason about.\<close>
+
+(*<*)
+lemma %invisible wp_mono:
+  assumes \<open>\<And>x. R x \<longlongrightarrow> Q x\<close>
+    shows \<open>\<W>\<P> e R \<longlongrightarrow> \<W>\<P> e Q\<close>
+  using assms by (auto simp: wp_def entails_def)
+
+\<comment> \<open>Lift an entailment \<open>\<psi> \<longlongrightarrow> \<W>\<P> e Q\<close> into rule form.\<close>
+lemma wp_from_entails:
+  assumes \<open>\<psi> \<longlongrightarrow> \<W>\<P> e Q\<close> 
+      and \<open>\<phi> \<longlongrightarrow> \<psi>\<close>
+    shows \<open>\<phi> \<longlongrightarrow> \<W>\<P> e Q\<close>
+  using assms by (auto simp: entails_def)
+(*>*)
+
+end_slide
+
+
+
+interlude \<open>A peek ahead: real uRust WP rules\<close>
+
+text_raw \<open>%
+\begingroup
+\renewenvironment{isabellebody}{}{}%
+\renewcommand{\setisabellecontext}[1]{}%
+\input{Tutorial_UrustPeek_WP.tex}%
+\endgroup
+\<close>
+
+end_interlude
+
+
+slide \<open>WP calculus: Call-by-contract\<close>
+
+text\<open>If we invoke a (sub)program we have a triple for, we can derive a WP rule
+for "call-by-contact":\<close>
+
+lemma wp_call_by_contractI:
+  assumes \<open>\<lbrace>P\<rbrace> e \<lbrace>Q\<rbrace>\<close> \<comment>\<open>Already proved contract\<close>
+      and \<open>\<phi> \<longlongrightarrow> P\<close> \<comment>\<open>Precondition entailment\<close>
+      and \<open>\<And>x. Q x \<longlongrightarrow> R x\<close> \<comment>\<open>Postcondition entailment\<close>
+    shows \<open>\<phi> \<longlongrightarrow> \<W>\<P> e R\<close>
+  using assms by (force simp: wp_triple_iff wp_def triple_def entails_def)
+
+text\<open>This is crucial for enabling modular verification at the level of functions or even
+sub-programs.\<close>
+
+text \<open>We also register the following basic rules:\<close>
+
+lemma %visible
+  shows entails_refl[wp_intros]: \<open>\<phi> \<longlongrightarrow> \<phi>\<close>
+    and entails_univ[wp_intros]: \<open>\<phi> \<longlongrightarrow> UNIV\<close>
+  by (simp_all add: entails_def)
+
+end_slide
+
+slide \<open>Working example: Setup\<close>
+
+text \<open>To illustrate, we now work through a concrete worked example: a function \<open>foo\<close>
+  that increments the \<open>x\<close>-field of a two-field record, and a
+  caller \<open>bar\<close> that reuses it.\<close>
+
+text \<open>First, our state record:\<close>
+
+record twoint =
+  fx :: int
+  fy :: int
+
+text \<open>Next, get/set primitives for reading/updating the whole state:\<close>
+
+definition get :: \<open>('s, 's) m\<close> 
+  where \<open>get = M (\<lambda>s. {(s, s)})\<close> \<comment>\<open>Return whole state, leave it unchanged\<close>
+
+definition put :: \<open>'s \<Rightarrow> ('s, unit) m\<close> 
+  where \<open>put s' = M (\<lambda>_. {((), s')})\<close> \<comment>\<open>Update whole state, return @{term \<open>()\<close>}\<close>
+
+end_slide
+
+slide \<open>Working example: Per-field reads and writes\<close>
+
+text \<open>Field operations can now be written as monadic programs over \<open>get\<close>/\<open>put\<close>:\<close>
+
+definition get_x :: \<open>(twoint, int) m\<close> where
+  \<open>get_x = do { s \<leftarrow> get; return (fx s) }\<close>
+
+definition get_y :: \<open>(twoint, int) m\<close> where
+  \<open>get_y = do { s \<leftarrow> get; return (fy s) }\<close>
+
+definition put_x :: \<open>int \<Rightarrow> (twoint, unit) m\<close> where
+  \<open>put_x v = do { s \<leftarrow> get; put (s\<lparr>fx := v\<rparr>) }\<close>
+
+definition put_y :: \<open>int \<Rightarrow> (twoint, unit) m\<close> where
+  \<open>put_y v = do { s \<leftarrow> get; put (s\<lparr>fy := v\<rparr>) }\<close>
+
+end_slide
+
+slide \<open>Working example: Two pieces of state-set notation\<close>
+
+text \<open>\<^bold>\<open>Field equality\<close>: Foreshadowing the point-to- notation common from separation logic, we 
+temporarily use \<open>f \<mapsto> v\<close> to denote the set of states whose field \<open>f\<close> equals \<open>v\<close>:\<close>
+
+abbreviation \<open>field_eq f v \<equiv> {s. f s = v}\<close>
+
+bundle field_eq_syntax \<comment>\<open>Define configurable syntax\<close>
+begin
+  notation field_eq (\<open>_ \<mapsto> _\<close> [76, 60] 75)
+end
+unbundle field_eq_syntax \<comment>\<open>Enable the syntax\<close>
+
+text \<open>\<^bold>\<open>Pure assertion\<close> -- \<open>\<langle>\<phi>\<rangle>\<close> lifts state-independent fact \<open>\<phi>\<close> to full or empty set:\<close>
+
+definition pure_assn :: \<open>bool \<Rightarrow> 's set\<close> (\<open>\<langle>_\<rangle>\<close>)
+  where \<open>\<langle>\<phi>\<rangle> \<equiv> if \<phi> then UNIV else {}\<close>
+
+(*<*)
+lemma entails_hoist_pure[wp_intros]: 
+  assumes \<open>P \<Longrightarrow> (\<phi> \<longlongrightarrow> \<psi>)\<close>
+  shows \<open>(\<phi> \<sqinter> \<langle>P\<rangle>) \<longlongrightarrow> \<psi>\<close>
+  using assms by (simp add: entails_def pure_assn_def)
+(*>*)
+
+end_slide
+
+slide \<open>Working example: WP rules for read and write\<close>
+
+text \<open>Let's make an attempt at specifying the get/put operators through contracts:\<close>
+
+(*<*)
+lemma wp_get_put [wp_simps]: shows
+  wp_get:   \<open>\<W>\<P> get        Q = {s. s \<in> Q s}\<close>         and
+  wp_get_x: \<open>\<W>\<P> get_x      P = {s. s \<in> P (fx s)}\<close>    and
+  wp_get_y: \<open>\<W>\<P> get_y      S = {s. s \<in> S (fy s)}\<close>    and
+  wp_put:   \<open>\<W>\<P> (put s')   R = \<langle>s' \<in> R ()\<rangle>\<close>           and
+  wp_put_x: \<open>\<W>\<P> (put_x v) T = {s. s\<lparr>fx := v\<rparr> \<in> T ()}\<close> and
+  wp_put_y: \<open>\<W>\<P> (put_y v) U = {s. s\<lparr>fy := v\<rparr> \<in> U ()}\<close>
+by (auto simp: wp_def evals_def get_def put_def get_x_def pure_assn_def
+      get_y_def put_x_def put_y_def mbind_def return_def)
+(*>*)
+
+lemma %visible put_get_triples_0:
+  shows triple_get_x: "\<lbrace> fx \<mapsto> v \<rbrace> get_x \<lbrace> \<lambda>r. \<langle>r = v\<rangle> \<rbrace>"
+    and triple_get_y: "\<lbrace> fy \<mapsto> v \<rbrace> get_y \<lbrace> \<lambda>r. \<langle>r = v\<rangle> \<rbrace>"
+    and triple_put_x: "\<lbrace> UNIV \<rbrace> put_x v \<lbrace> \<lambda>_. fx \<mapsto> v \<rbrace>"
+    and triple_put_y: "\<lbrace> UNIV \<rbrace> put_y v \<lbrace> \<lambda>_. fy \<mapsto> v \<rbrace>"
+  unfolding wp_triple_iff wp_simps by (simp_all add: entails_def pure_assn_def)
+
+text\<open>Register the derived WP rules in @{thm [source] wp_intros}:\<close>
+
+lemmas put_get_contracts_0 = put_get_triples_0[THEN wp_call_by_contractI]
+
+declare put_get_contracts_0[wp_intros]
+
+end_slide
+
+slide \<open>Working example: Proving increment\<close>
+
+text \<open>A simple program \<open>foo\<close> incrementing @{term \<open>fx\<close>}:\<close>
+
+definition foo :: \<open>(twoint, unit) m\<close> where
+  \<open>foo = do { v \<leftarrow> get_x; put_x (v + 1) }\<close>
+
+text \<open>Let's prove the contract \<open>\<lbrace> fx \<mapsto> v \<rbrace> foo \<lbrace> \<lambda>_. fx \<mapsto> v + 1 \<rbrace>\<close> using our WP calculus:\<close>
+
+lemma %visible shows \<open>\<lbrace> fx \<mapsto> v \<rbrace> foo \<lbrace> \<lambda>_. fx \<mapsto> v + 1 \<rbrace>\<close>
+  unfolding wp_triple_iff foo_def
+  \<comment>\<open>Repeatedly apply WP rules\<close>
+  apply (rule wp_intros)+
+  \<comment>\<open>Goal residue: \<open>\<And>x xa. fx \<mapsto> x + 1 \<longlongrightarrow> fx \<mapsto> v + 1\<close>\<close>
+  oops
+
+ text\<open>\<^bold>\<open>Stuck.\<close> Contract says \<open>\<lbrace>fx \<mapsto> v\<rbrace> get_x \<lbrace>\<lambda>r. \<langle>r = v\<rangle>\<rbrace>\<close> --
+   we learn \<open>r = v\<close> but \<^bold>\<open>loose\<close> the assertion \<open>fx \<mapsto> v\<close>. So we cannot say where \<open>put_x (v + 1)\<close> lands.\<close>
+
+end_slide
+
+slide \<open>Working example: Proving increment -- attempt 2\<close>
+
+text \<open>\<^bold>\<open>Fix:\<close> have \<open>get_x\<close> \<^bold>\<open>re-assert\<close> \<open>fx \<mapsto> v\<close> in its post-condition; same for \<open>get_y\<close>:\<close>
+
+declare put_get_contracts_0 [wp_intros del] \<comment>\<open>Remove previous contracts\<close>
+
+lemma %visible put_get_triples_1:
+  shows triple_get_x_1: \<open>\<lbrace> fx \<mapsto> v \<rbrace> get_x \<lbrace> \<lambda>r. fx \<mapsto> v \<sqinter> \<langle>r = v\<rangle> \<rbrace>\<close>
+    and triple_get_y_1: \<open>\<lbrace> fy \<mapsto> v \<rbrace> get_y \<lbrace> \<lambda>r. fy \<mapsto> v \<sqinter> \<langle>r = v\<rangle> \<rbrace>\<close>
+    and triple_put_x_1: \<open>\<lbrace> UNIV \<rbrace> put_x v \<lbrace> \<lambda>_. fx \<mapsto> v \<rbrace>\<close>
+    and triple_put_y_1: \<open>\<lbrace> UNIV \<rbrace> put_y v \<lbrace> \<lambda>_. fy \<mapsto> v \<rbrace>\<close>
+  unfolding wp_triple_iff wp_simps by (auto simp: entails_def pure_assn_def)
+
+text\<open>Add new contracts:\<close>
+
+lemmas put_get_contracts_1 = put_get_triples_1[THEN wp_call_by_contractI]
+declare put_get_contracts_1 [wp_intros]
+
+text \<open>Now \<open>foo\<close>'s contract goes through, by pure \<open>wp_intros\<close> chaining and simplification:\<close>
+
+lemma %visible foo_spec: shows \<open>\<lbrace> fx \<mapsto> v \<rbrace> foo \<lbrace> \<lambda>_. fx \<mapsto> v + 1 \<rbrace>\<close>
+  unfolding wp_triple_iff foo_def by (rule wp_intros | simp)+
+
+(*<*)
+text\<open>Register the contract:\<close>
+lemmas wp_foo = foo_spec[THEN wp_call_by_contractI]
+declare wp_foo [wp_intros]
+(*>*)
+
+end_slide
+
+slide \<open>Working example: Increment, \<^emph>\<open>and more\<close>\<close>
+
+text \<open>Boosted in confidence, consider a caller that runs \<open>foo\<close> and then reads \<open>fy\<close>:\<close>
+
+definition bar :: \<open>(twoint, int) m\<close> where
+  \<open>bar = do { foo; get_y }\<close>
+
+text \<open>Let's try to specify and prove what @{term bar} does:\<close>
+
+(*<*)                     
+lemma entails_project[wp_intros]: \<open>\<alpha> \<sqinter> \<beta> \<longlongrightarrow> \<alpha>\<close> unfolding entails_def by simp
+(*>*)
+
+lemma \<comment>\<open>Pre value \<open>(x,y)\<close>, post value \<open>(x+1,y)\<close>\<close>
+  shows \<open>\<lbrace> fx \<mapsto> x \<sqinter> fy \<mapsto> y \<rbrace> bar \<lbrace> \<lambda>r. fx \<mapsto> x + 1 \<sqinter> fy \<mapsto> y \<sqinter> \<langle>r = y\<rangle> \<rbrace>\<close>
+  unfolding wp_triple_iff bar_def     
+  apply (rule wp_intros)+        
+  \<comment>\<open>Goal residue: \<open>\<And>xa. fx \<mapsto> x + 1 \<longlongrightarrow> fy \<mapsto> ?v xa\<close> -- \<open>fy\<close> post is unconstrained.\<close>
+  oops
+                                                      
+\<comment>\<open>\<^bold>\<open>Stuck again.\<close> We did not specify that @{term foo} does not change @{term fy}!\<close>
+
+end_slide
+
+slide \<open>Working example: Increment, \<^emph>\<open>and more\<close> -- attempt 2\<close>
+
+text \<open>\<^bold>\<open>Fix:\<close> every contract mentions \<^bold>\<open>every\<close> field -- what it
+  preserves and what it changes.\<close>
+
+declare put_get_contracts_1 [wp_intros del] \<comment>\<open>Remove previous contracts\<close>
+declare wp_foo              [wp_intros del]
+
+lemma %visible put_get_triples_2:
+  shows \<open>\<lbrace> fx \<mapsto> x \<sqinter> fy \<mapsto> y \<rbrace> get_x \<lbrace> \<lambda>r. fx \<mapsto> x \<sqinter> fy \<mapsto> y \<sqinter> \<langle>r = x\<rangle> \<rbrace>\<close>
+    and \<open>\<lbrace> fx \<mapsto> x \<sqinter> fy \<mapsto> y \<rbrace> get_y \<lbrace> \<lambda>r. fx \<mapsto> x \<sqinter> fy \<mapsto> y \<sqinter> \<langle>r = y\<rangle> \<rbrace>\<close>
+    and \<open>\<lbrace> fx \<mapsto> x \<sqinter> fy \<mapsto> y \<rbrace> put_x v \<lbrace> \<lambda>_. fx \<mapsto> v \<sqinter> fy \<mapsto> y \<rbrace>\<close>
+    and \<open>\<lbrace> fx \<mapsto> x \<sqinter> fy \<mapsto> y \<rbrace> put_y v \<lbrace> \<lambda>_. fx \<mapsto> x \<sqinter> fy \<mapsto> v \<rbrace>\<close>
+  unfolding wp_triple_iff wp_simps by (auto simp: entails_def pure_assn_def)
+
+text\<open>Add new contracts:\<close>
+
+lemmas put_get_contracts_2 = put_get_triples_2[THEN wp_call_by_contractI]
+declare put_get_contracts_2 [wp_intros]
+
+end_slide
+
+slide \<open>Working example: Increment, \<^emph>\<open>and more\<close> -- attempt 2 (continued)\<close>
+
+text \<open>Re-prove \<open>foo\<close>'s contract under the new bundle, with \<open>fy\<close> in
+  pre and post, then lift it for callers:\<close>
+
+lemma %visible foo_spec_framed:
+  shows \<open>\<lbrace> fx \<mapsto> x \<sqinter> fy \<mapsto> y \<rbrace> foo \<lbrace> \<lambda>_. fx \<mapsto> x + 1 \<sqinter> fy \<mapsto> y \<rbrace>\<close>
+  unfolding wp_triple_iff foo_def by (rule wp_intros | simp)+
+
+(*<*)
+text\<open>Add new contracts:\<close>
+lemmas wp_foo_framed = foo_spec_framed[THEN wp_call_by_contractI]
+declare wp_foo_framed [wp_intros]
+(*>*)
+
+text \<open>Now \<open>bar\<close> goes through:\<close>
+
+lemma %visible bar_spec:
+  shows \<open>\<lbrace> fx \<mapsto> x \<sqinter> fy \<mapsto> y \<rbrace> bar \<lbrace> \<lambda>r. fx \<mapsto> x + 1 \<sqinter> fy \<mapsto> y \<sqinter> \<langle>r = y\<rangle> \<rbrace>\<close>
+  unfolding wp_triple_iff bar_def
+  apply (rule wp_intros)
+  apply (rule wp_intros)
+  apply (rule wp_intros)
+  apply (rule wp_intros)
+  apply (rule wp_intros)
+  apply (rule wp_intros)
+  done
+
+end_slide
+
+
+slide \<open>Reflection\<close>
+
+text \<open>\<^bold>\<open>What worked.\<close> We pushed through the proof by repeatedly applying
+  generic WP rules. It's clear that this is, in principle, amenable to a high
+  degree of automation -- crucial for large-scale program verification. This is
+exactly what AutoCorrode's \<open>crush\<close> does.\<close>
+
+text \<open>\<^bold>\<open>What didn't work (well):\<close> To re-use \<open>foo\<close> inside \<open>bar\<close> we re-stated
+  \<open>foo\<close>'s contract with \<open>fy \<mapsto> y\<close> in pre and post -- even though
+  \<open>foo\<close> does not look at \<open>fy\<close>. That clause is pure \<^bold>\<open>framing
+  noise\<close>: information about state \<open>foo\<close> did not touch, added by
+  hand to make composition go through.\<close>
+
+text \<open>With \<open>n\<close> fields and one untouched, every contract grows by \<open>n - 1\<close>
+  such clauses, every caller adding another. \<^bold>\<open>This is the frame
+  problem.\<close>\<close>
+
+end_slide
+
+
+slide \<open>The frame problem: approaches\<close>
+
+text \<open>Three approaches in active use:\<close>
+
+text \<open>\<^bold>\<open>1. Explicit modifies-clauses (s2n-bignum).\<close>  Each spec
+  carries a \<open>MAYCHANGE\<close> clause listing the memory, registers, or flags
+  it may alter. Composition discharges a syntactic ``mine-fits-yours''
+  side condition. Used in AWS's HOL-Light bignum verification.\<close>
+
+text \<open>\<^bold>\<open>2. AutoCorrode's \<open>AutoLocality\<close> autogen.\<close>  Driven by
+  \<^emph>\<open>record footprints\<close>: declare which fields each operation touches,
+  and \<open>locality_autoderive\<close> produces all pairwise commutativity lemmas
+  automatically. Plain HOL; no SL connectives.\<close>
+
+text \<open>\<^bold>\<open>3. Separation logic.\<close> \<^emph>\<open>What AutoCorrode picks -- see next section...\<close>\<close>
+
+end_slide
+
+(*<*)
+
+slide \<open>WP for any monad: the CPS view\<close>
+
+text \<open>Our toy \<open>wp\<close> took a program and a postcondition. Generally,
+  \<^bold>\<open>WP is a function\<close> \<open>('a \<Rightarrow> 'state \<Rightarrow> bool) \<Rightarrow> 'state \<Rightarrow> bool\<close>. That
+  is the \<^bold>\<open>continuation monad\<close> with answer type \<open>'state \<Rightarrow> bool\<close>:\<close>
+
+type_synonym ('s, 'a) cwp = \<open>('a \<Rightarrow> 's \<Rightarrow> bool) \<Rightarrow> 's \<Rightarrow> bool\<close>
+  \<comment> \<open>continuations into state-predicates\<close>
+
+definition %internal cps_wp ::
+    \<open>('s, 'a) cwp \<Rightarrow> ('a \<Rightarrow> 's \<Rightarrow> bool) \<Rightarrow> 's \<Rightarrow> bool\<close>
+  where \<open>cps_wp m Q \<equiv> m Q\<close>
+
+definition %internal cps_triple ::
+    \<open>('s \<Rightarrow> bool) \<Rightarrow> ('s, 'a) cwp \<Rightarrow> ('a \<Rightarrow> 's \<Rightarrow> bool) \<Rightarrow> bool\<close> where
+  \<open>cps_triple P m Q \<equiv> \<forall>s. P s \<longrightarrow> cps_wp m Q s\<close>
+
+lemma %internal cps_wp_universal:
+  shows \<open>cps_triple P m Q \<longleftrightarrow> (\<forall>s. P s \<longrightarrow> cps_wp m Q s)\<close>
+  by (simp add: cps_triple_def)
+
+text \<open>Punchline: \<open>('s, 'a) cwp\<close> \<^bold>\<open>is\<close> the type of WP transformers
+  for \<open>'a\<close>-valued state computations. CPS \<open>bind\<close> = WP for sequencing;
+  CPS \<open>return\<close> = WP for pure values.\<close>
+
+text \<open>The actual programs sit inside this type as the \<^bold>\<open>healthy\<close>
+  fragment (monotone in \<open>Q\<close>, conjunctive -- Dijkstra's healthiness);
+  the wider type also accommodates refinement-calculus features like
+  demonic and angelic choice.\<close>
+
+end_slide
+(*>*)
+
+text %internal \<open>Release the toy \<open>\<lbrace>...\<rbrace>\<close> notation so the SepLogic
+  slides can use the real \<open>Shallow_Separation_Logic.Triple\<close> mixfix
+  with the same brackets without ambiguity.\<close>
+
+no_notation %internal triple (\<open>\<lbrace>_\<rbrace>/ _/ \<lbrace>_\<rbrace>\<close>)
+
+unbundle %internal no hoare_set_syntax
+
+end

--- a/tutorial/Tutorial_Monads.thy
+++ b/tutorial/Tutorial_Monads.thy
@@ -1,0 +1,572 @@
+theory Tutorial_Monads
+  imports
+    Main
+    "HOL-Library.Monad_Syntax"
+    Slides
+    Shallow_Micro_Rust.Core_Expression
+begin
+
+slide \<open>Why monads?\<close>
+
+text \<open>\<^bold>\<open>Goal:\<close> model imperative programs in HOL -- a pure, total,
+  logical setting -- without losing:\<close>
+
+text \<open>
+  \<^item> sequential composition (``do this, then that'');
+
+  \<^item> intermediate values getting \<^bold>\<open>named\<close>;
+
+  \<^item> separation of concerns: the threading of effects (state,
+    exceptions, ...) does not pollute the program's logic.\<close>
+
+text \<open>\<^bold>\<open>Monads\<close> are the abstraction that makes this work.\<close>
+
+end_slide
+
+
+slide \<open>Pure computation: just \<open>let\<close>-binding\<close>
+
+text \<open>Suppose our toy language has \<^emph>\<open>no state, no errors, no
+  side-effects\<close> -- just pure computation with immutable variables.
+  Then a program can be modeled as a sequence of \<open>let\<close>-bindings, with
+  each \<open>let\<close> playing the role of a semicolon:\<close>
+
+text_raw \<open>%
+\begin{minipage}[t]{0.48\linewidth}\centering
+\textbf{Imperative}\\[1mm]
+\begin{minipage}{\linewidth}\small\ttfamily
+const T0 a = head(xs);\\
+const T1 b = encrypt(k, a);\\
+const T2 c = encode(b);\\
+return c;
+\end{minipage}
+\end{minipage}\hfill
+\begin{minipage}[t]{0.48\linewidth}\centering
+\textbf{HOL}\\[1mm]
+\begin{minipage}{\linewidth}\small\ttfamily
+\<open>let a = head xs in\<close>\\
+\<open>let b = encrypt k a in\<close>\\
+\<open>let c = encode b in\<close>\\
+\<open>c\<close>
+\end{minipage}
+\end{minipage}%
+\<close>
+
+text \<open>\<^bold>\<open>Type:\<close> a program with input \<open>'a\<close> and output \<open>'b\<close> is just
+  @{typ \<open>'a \<Rightarrow> 'b\<close>}.\<close>
+
+end_slide
+
+
+slide \<open>+ scratch state: thread it through\<close>
+
+text \<open>Now suppose programs may \<^bold>\<open>read and write\<close> a global
+  ``scratch space'' \<open>'s\<close>. Each step receives the previous step's
+  state and returns an updated one:\<close>
+
+text_raw \<open>%
+\begin{minipage}[t]{0.48\linewidth}\centering
+\textbf{Imperative}\\[1mm]
+\begin{minipage}{\linewidth}\small\ttfamily
+const T0 a = read();\\
+write(hash(a));\\
+const T0 b = read();\\
+return b;
+\end{minipage}
+\end{minipage}\hfill
+\begin{minipage}[t]{0.48\linewidth}\centering
+\textbf{HOL (let-threaded)}\\[1mm]
+\begin{minipage}{\linewidth}\scriptsize\ttfamily
+\<open>let (a, s\<^sub>1) = read s\<^sub>0   in\<close>\\
+\<open>let (h, s\<^sub>2) = hash a s\<^sub>1 in\<close>\\
+\<open>let ((), s\<^sub>3) = write h s\<^sub>2 in\<close>\\
+\<open>let (b, s\<^sub>4) = read s\<^sub>3   in\<close>\\
+\<open>(b, s\<^sub>4)\<close>
+\end{minipage}
+\end{minipage}%
+\<close>
+
+text \<open>\<^bold>\<open>Type:\<close> a program with input \<open>'a\<close>, output \<open>'b\<close>, threading state
+  \<open>'s\<close> is @{typ \<open>'a \<Rightarrow> 's \<Rightarrow> 's \<times> 'b\<close>}.\<close>
+
+text \<open>\<^bold>\<open>Question:\<close> Can we hide the threading of the state?\<close>
+
+end_slide
+
+
+slide \<open>+ scratch state: hiding the threading\<close>
+
+text \<open>Define combinator \<open>state_bind\<close> that runs a step and threads the
+  result into the next:\<close>
+
+(*<*)experiment begin(*>*) (* Local; re-stated later for the example slide *)
+definition state_return :: \<open>'a \<Rightarrow> 's \<Rightarrow> 'a \<times> 's\<close> where
+  \<open>state_return x s = (x, s)\<close>
+
+definition state_bind ::
+    \<open>('s \<Rightarrow> 'a \<times> 's) \<Rightarrow> ('a \<Rightarrow> 's \<Rightarrow> 'b \<times> 's) \<Rightarrow> ('s \<Rightarrow> 'b \<times> 's)\<close> where
+  \<open>state_bind f g s = (let (x, s') = f s in g x s')\<close>
+(*<*)end(*>*)
+
+text \<open>The same program in both styles -- the right column has \<^emph>\<open>no\<close> \<open>s\<^sub>i\<close>:\<close>
+
+text_raw \<open>%
+\begin{minipage}[t]{0.48\linewidth}\centering
+\textbf{HOL (let-threaded)}\\[1mm]
+\begin{minipage}{\linewidth}\scriptsize\ttfamily
+\<open>let (a, s\<^sub>1) = read s\<^sub>0   in\<close>\\
+\<open>let (h, s\<^sub>2) = hash a s\<^sub>1 in\<close>\\
+\<open>let ((), s\<^sub>3) = write h s\<^sub>2 in\<close>\\
+\<open>let (b, s\<^sub>4) = read s\<^sub>3   in\<close>\\
+\<open>(b, s\<^sub>4)\<close>
+\end{minipage}
+\end{minipage}\hfill
+\begin{minipage}[t]{0.48\linewidth}\centering
+\textbf{Compact (\<open>state_bind\<close>)}\\[1mm]
+\begin{minipage}{\linewidth}
+\begin{alltt}\scriptsize
+\<open>state_bind read       (\<lambda>a.\<close>
+\<open>state_bind (hash a)   (\<lambda>h.\<close>
+\<open>state_bind (write h)  (\<lambda>_.\<close>
+\<open>state_bind read       (\<lambda>b.\<close>
+\<open>state_return b))))\<close>
+\end{alltt}
+\end{minipage}
+\end{minipage}%
+\<close>
+
+end_slide
+
+
+slide \<open>+ errors: \<open>None\<close> short-circuits\<close>
+
+text \<open>Drop the state again. Suppose programs may \<^bold>\<open>abort\<close> -- e.g.\
+  divide-by-zero, missing key. Represent ``maybe a result'' by
+  @{typ \<open>'b option\<close>}. Chaining means: if the previous step
+  succeeded, continue; otherwise propagate the abort:\<close>
+
+text_raw \<open>%
+\begin{minipage}[t]{0.26\linewidth}\centering
+\textbf{Imperative}\\[1mm]
+\begin{minipage}{\linewidth}\scriptsize\ttfamily
+const T0 a = lookup(k);\\
+const T1 b = decrypt(a, ct);\\
+return verify(b);
+\end{minipage}
+\end{minipage}\hfill
+\begin{minipage}[t]{0.32\linewidth}\centering
+\textbf{HOL (case)}\\[1mm]
+\begin{minipage}{\linewidth}
+\begin{alltt}\tiny
+\<open>case lookup k of\<close>
+  \<open>None \<Rightarrow> None\<close>
+\<open>|\<close> \<open>Some a \<Rightarrow>\<close>
+    \<open>case decrypt a ct of\<close>
+      \<open>None \<Rightarrow> None\<close>
+    \<open>|\<close> \<open>Some b \<Rightarrow> Some (verify b)\<close>
+\end{alltt}
+\end{minipage}
+\end{minipage}\hfill
+\begin{minipage}[t]{0.40\linewidth}\centering
+\textbf{Compact (\<open>option_bind\<close>)}\\[1mm]
+\begin{minipage}{\linewidth}
+\begin{alltt}\tiny
+\<open>option_bind (lookup k) (\<lambda>a.\<close>
+\<open>option_bind (decrypt a ct) (\<lambda>b.\<close>
+\<open>Some (verify b)))\<close>
+\end{alltt}
+\end{minipage}
+\end{minipage}%
+\<close>
+
+text \<open>\<^bold>\<open>Type:\<close> @{typ \<open>'a \<Rightarrow> 'b option\<close>}. Combinator hides case-bookkeeping
+  (also available in HOL as @{const Option.bind}):\<close>
+
+(*<*)experiment begin(*>*) (* Local; re-stated later if needed *)
+definition option_bind :: \<open>'a option \<Rightarrow> ('a \<Rightarrow> 'b option) \<Rightarrow> 'b option\<close> where
+  \<open>option_bind f g = (case f of None \<Rightarrow> None | Some x \<Rightarrow> g x)\<close>
+(*<*)end(*>*)
+
+end_slide
+
+
+slide \<open>+ non-determinism: a list of outcomes\<close>
+
+text \<open>Drop state and errors. Suppose programs may \<^bold>\<open>fork\<close> -- i.e.\
+  return any of several possible results. Represent ``possible
+  outcomes'' as a \<^emph>\<open>list\<close>:\<close>
+
+text_raw \<open>%
+\begin{minipage}[t]{0.30\linewidth}\centering
+\textbf{Imperative}\\[1mm]
+\begin{minipage}{\linewidth}\scriptsize\ttfamily
+let a = pick \{1,2\};\\
+let b = pick \{10,20\};\\
+return a + b
+\end{minipage}
+\end{minipage}\hfill
+\begin{minipage}[t]{0.36\linewidth}\centering
+\textbf{HOL (\<open>concat \<circ> map\<close>)}\\[1mm]
+\begin{minipage}{\linewidth}
+\begin{alltt}\scriptsize
+\<open>concat (map\<close>
+  \<open>(\<lambda>a. concat (map\<close>
+    \<open>(\<lambda>b. [a + b])\<close>
+    \<open>[10,20]))\<close>
+  \<open>[1,2])\<close>
+\end{alltt}
+\end{minipage}
+\end{minipage}\hfill
+\begin{minipage}[t]{0.32\linewidth}\centering
+\textbf{Compact (\<open>list_bind\<close>)}\\[1mm]
+\begin{minipage}{\linewidth}
+\begin{alltt}\scriptsize
+\<open>list_bind [1,2]   (\<lambda>a.\<close>
+\<open>list_bind [10,20] (\<lambda>b.\<close>
+\<open>[a + b]))\<close>
+\end{alltt}
+\end{minipage}
+\end{minipage}%
+\<close>
+
+text \<open>\<^bold>\<open>Type:\<close> @{typ \<open>'a \<Rightarrow> 'b list\<close>}. The combinator hides flattening
+  (also available in HOL as @{const List.bind}):\<close>
+
+(*<*)experiment begin(*>*) (* Local; re-stated later for the example slide *)
+definition list_bind :: \<open>'a list \<Rightarrow> ('a \<Rightarrow> 'b list) \<Rightarrow> 'b list\<close> where
+  \<open>list_bind f g = concat (map g f)\<close>
+(*<*)end(*>*)
+
+end_slide
+
+
+slide \<open>The common shape\<close>
+
+text \<open>All four cases share the \<^bold>\<open>same skeleton\<close>:
+  programs are \<open>'a \<Rightarrow> 'b M\<close> for some wrapper \<open>M\<close>; sequencing is
+  ``unwrap previous, run next, re-wrap''. Reading down the column \<open>'b M\<close>:\<close>
+
+text_raw \<open>%
+\begin{center}\small
+\begin{tabular}{l l l l}
+\textbf{Effect} & \textbf{Wrapper \<open>'b M\<close>} & \textbf{Sequencing} & \textbf{Combinator} \\\hline
+none            & \<open>'b\<close>          & nothing -- just \<open>let\<close>          & \<open>let\<close> \\
+state \<open>'s\<close>      & \<open>'s \<Rightarrow> 's \<times> 'b\<close> & thread the state              & \<open>state_bind\<close> \\
+errors          & \<open>'b option\<close>   & short-circuit on \<open>None\<close>     & \<open>Option.bind\<close> \\
+non-determinism & \<open>'b list\<close>     & flatten over outcomes          & \<open>List.bind\<close> \\
+\end{tabular}
+\end{center}
+\<close>
+
+text \<open>Each row hides bookkeeping behind a single combinator. \<^bold>\<open>That
+  combinator -- one \<open>return\<close>, one \<open>bind\<close>, three laws -- is a
+  monad.\<close>\<close>
+
+end_slide
+
+
+slide \<open>What a monad is\<close>
+
+text %internal \<open>Abstract shape -- a type constructor with two operations,
+  declared so the antiquotations on this slide are type-checked.\<close>
+
+typedecl %internal 'a M
+
+consts %internal m_return :: \<open>'a \<Rightarrow> 'a M\<close>
+consts %internal m_bind   :: \<open>'a M \<Rightarrow> ('a \<Rightarrow> 'b M) \<Rightarrow> 'b M\<close>  (infixl \<open>\<bind>\<close> 54)
+
+text \<open>\<^bold>\<open>The shape:\<close> a type constructor @{typ \<open>'a M\<close>} -- ``a composable
+  operation that produces a value of type @{typ \<open>'a\<close>}''.\<close>
+
+text \<open>Two operations:
+
+  \<^item> \<open>m_return\<close> \<open>::\<close> @{typeof \<open>m_return\<close>} \<comment> \<open>inject a pure value\<close>
+
+  \<^item> \<open>(\<bind>)\<close> \<open>::\<close> @{typeof \<open>(\<bind>) :: 'a M \<Rightarrow> ('a \<Rightarrow> 'b M) \<Rightarrow> 'b M\<close>}
+    \<comment> \<open>run, then hand the result to the next\<close>\<close>
+
+text \<open>\<^bold>\<open>Special case:\<close> when the first result is \<open>()\<close>, \<open>\<bind>\<close> drops
+  it -- pure \<^bold>\<open>sequencing\<close> \<open>f ; g\<close>.\<close>
+
+text \<open>\<^bold>\<open>Monad laws.\<close> Three equational laws govern \<open>return\<close> and \<open>\<bind>\<close>
+  -- left unit, right unit, associativity. The first reads:\<close>
+
+text \<open>\quad @{term \<open>m_return x \<bind> g = g x\<close>}\<close>
+
+text \<open>We prove all three for each instance below.\<close>
+
+end_slide
+
+
+slide \<open>do-notation\<close>
+
+text \<open>Isabelle's \<open>HOL-Library.Monad_Syntax\<close> gives us a Haskell-style
+  \<open>do\<close>-block once we register a \<open>bind\<close> for our monad. Schematically:
+
+  \<^item> \<open>do { x \<leftarrow> f; g x }\<close> means \<open>f \<bind> (\<lambda>x. g x)\<close>.
+
+  \<^item> \<open>do { f; g }\<close> drops the result -- pure sequencing.
+
+  \<^item> \<open>do { return x }\<close> = \<open>return x\<close>.\<close>
+
+text \<open>We will write all monadic programs in this notation.\<close>
+
+end_slide
+
+
+slide \<open>Example: state monad\<close>
+
+text \<open>Threads a read/write state of type \<open>'s\<close>:\<close>
+
+type_synonym ('s, 'a) state = \<open>'s \<Rightarrow> 'a \<times> 's\<close>
+
+text \<open>The combinators we introduced earlier, retyped via this synonym:\<close>
+
+definition state_return :: \<open>'a \<Rightarrow> ('s, 'a) state\<close> where
+  \<open>state_return x s = (x, s)\<close>
+    \<comment> \<open>\<open>s\<close> unchanged; result \<open>x\<close>\<close>
+
+definition state_bind :: 
+  \<open>('s, 'a) state \<Rightarrow> ('a \<Rightarrow> ('s, 'b) state) \<Rightarrow> ('s, 'b) state\<close>
+  where \<open>state_bind f g s = (let (x, s') = f s in g x s')\<close>
+    \<comment> \<open>run \<open>f\<close> on \<open>s\<close>; thread the resulting \<open>s'\<close> into \<open>g\<close>\<close>
+
+lemma %internal state_left_unit: \<open>state_bind (state_return x) g = g x\<close>
+  by (simp add: state_return_def state_bind_def fun_eq_iff)
+
+lemma %internal state_right_unit: \<open>state_bind f state_return = f\<close>
+  by (auto simp: state_return_def state_bind_def split: prod.splits)
+
+lemma %internal state_assoc:
+  \<open>state_bind (state_bind f g) h = state_bind f (\<lambda>x. state_bind (g x) h)\<close>
+  by (auto simp: state_bind_def split: prod.splits)
+
+end_slide
+
+
+slide \<open>Example: list monad\<close>
+
+text \<open>The motivating non-determinism case from earlier, fully formalised
+  -- ``a program returning \<open>'a\<close> is a list of possible outcomes'':\<close>
+
+definition list_return :: \<open>'a \<Rightarrow> 'a list\<close> where
+  \<open>list_return x = [x]\<close>
+    \<comment> \<open>exactly one outcome\<close>
+
+definition list_bind :: \<open>'a list \<Rightarrow> ('a \<Rightarrow> 'b list) \<Rightarrow> 'b list\<close> where
+  \<open>list_bind f g = concat (map g f)\<close>
+    \<comment> \<open>for every outcome of \<open>f\<close>, run \<open>g\<close>; flatten the lists\<close>
+
+lemma %internal list_left_unit: \<open>list_bind (list_return x) g = g x\<close>
+  by (simp add: list_return_def list_bind_def)
+
+lemma %internal list_right_unit: \<open>list_bind f list_return = f\<close>
+  by (induction f) (auto simp: list_return_def list_bind_def)
+
+lemma %internal list_assoc:
+  \<open>list_bind (list_bind f g) h = list_bind f (\<lambda>x. list_bind (g x) h)\<close>
+  by (induction f) (auto simp: list_bind_def)
+
+end_slide
+
+
+slide \<open>Example: reader monad\<close>
+
+text \<open>Threads a read-only environment of type \<open>'r\<close>:\<close>
+
+type_synonym ('r, 'a) reader = \<open>'r \<Rightarrow> 'a\<close>
+  \<comment> \<open>an \<open>'a\<close>-valued op in the reader monad for \<open>'r\<close> produces an \<open>'a\<close>
+      given access to the read-only environment \<open>'r\<close>\<close>
+
+definition reader_return :: \<open>'a \<Rightarrow> ('r, 'a) reader\<close> where
+  \<open>reader_return x r = x\<close>
+    \<comment> \<open>ignore the environment \<open>r\<close>; return \<open>x\<close>\<close>
+
+definition reader_bind ::
+    \<open>('r, 'a) reader \<Rightarrow> ('a \<Rightarrow> ('r, 'b) reader) \<Rightarrow> ('r, 'b) reader\<close> where
+  \<open>reader_bind f g r = g (f r) r\<close>
+    \<comment> \<open>read \<open>r\<close>, run \<open>f\<close> on it, hand the result \<^emph>\<open>and the same \<open>r\<close>\<close> to \<open>g\<close>\<close>
+
+lemma %internal reader_left_unit: \<open>reader_bind (reader_return x) g = g x\<close>
+  by (simp add: reader_return_def reader_bind_def fun_eq_iff)
+
+lemma %internal reader_right_unit: \<open>reader_bind f reader_return = f\<close>
+  by (simp add: reader_return_def reader_bind_def fun_eq_iff)
+
+lemma %internal reader_assoc:
+  \<open>reader_bind (reader_bind f g) h = reader_bind f (\<lambda>x. reader_bind (g x) h)\<close>
+  by (simp add: reader_bind_def fun_eq_iff)
+
+end_slide
+
+
+slide \<open>Example: error monad\<close>
+
+text \<open>Aborts computation once an error (\<open>Inr\<close>) is hit; chains
+  values (\<open>Inl\<close>) otherwise:\<close>
+
+type_synonym ('e, 'a) error = \<open>'a + 'e\<close>
+
+definition error_return :: \<open>'a \<Rightarrow> ('e, 'a) error\<close> where
+  \<open>error_return x = Inl x\<close>
+    \<comment> \<open>success, value \<open>x\<close>\<close>
+
+definition error_bind ::
+    \<open>('e, 'a) error \<Rightarrow> ('a \<Rightarrow> ('e, 'b) error) \<Rightarrow> ('e, 'b) error\<close> where
+  \<open>error_bind f g = (case f of Inl x \<Rightarrow> g x | Inr e \<Rightarrow> Inr e)\<close>
+    \<comment> \<open>continue with \<open>g\<close> on success; propagate the error otherwise\<close>
+
+text \<open>Specialising \<open>'e = unit\<close> recovers the familiar \<open>'a option\<close>:
+  \<open>Inl x = Some x\<close>, \<open>Inr () = None\<close>. A richer \<open>'e\<close> lets you
+  distinguish multiple error reasons.\<close>
+
+lemma %internal error_left_unit: \<open>error_bind (error_return x) g = g x\<close>
+  by (simp add: error_return_def error_bind_def)
+
+lemma %internal error_right_unit: \<open>error_bind f error_return = f\<close>
+  by (auto simp: error_return_def error_bind_def split: sum.splits)
+
+lemma %internal error_assoc:
+  \<open>error_bind (error_bind f g) h = error_bind f (\<lambda>x. error_bind (g x) h)\<close>
+  by (auto simp: error_bind_def split: sum.splits)
+
+end_slide
+
+
+slide \<open>Example: non-determinism + state\<close>
+
+text \<open>State monad, but each step may return \<^bold>\<open>several\<close> possible
+  outcomes -- a set of (value, next-state) pairs instead of a single
+  pair:\<close>
+
+type_synonym ('s, 'a) nondet = \<open>'s \<Rightarrow> ('a \<times> 's) set\<close>
+
+definition nondet_return :: \<open>'a \<Rightarrow> ('s, 'a) nondet\<close> where
+  \<open>nondet_return x s = {(x, s)}\<close>
+    \<comment> \<open>exactly one outcome: \<open>x\<close>, state unchanged\<close>
+
+definition nondet_bind ::
+    \<open>('s, 'a) nondet \<Rightarrow> ('a \<Rightarrow> ('s, 'b) nondet) \<Rightarrow> ('s, 'b) nondet\<close> where
+  \<open>nondet_bind f g s = (\<Union>(x, s')\<in>f s. g x s')\<close>
+    \<comment>\<open>pick one outcome \<open>(x, s')\<close> of \<open>f\<close> from \<open>s\<close>;\<close>
+    \<comment>\<open>then one outcome \<open>(y, s'')\<close> of \<open>g x\<close> from \<open>s'\<close>;\<close>
+    \<comment>\<open>keep all such \<open>(y, s'')\<close>\<close>
+
+lemma %internal nondet_left_unit: \<open>nondet_bind (nondet_return x) g = g x\<close>
+  by (simp add: nondet_return_def nondet_bind_def fun_eq_iff)
+
+lemma %internal nondet_right_unit: \<open>nondet_bind f nondet_return = f\<close>
+  by (auto simp: nondet_return_def nondet_bind_def fun_eq_iff)
+
+lemma %internal nondet_assoc:
+  \<open>nondet_bind (nondet_bind f g) h
+     = nondet_bind f (\<lambda>x. nondet_bind (g x) h)\<close>
+  by (auto simp: nondet_bind_def fun_eq_iff)
+
+end_slide
+
+
+slide \<open>Example: state + error monad\<close>
+
+text \<open>Monads compose. A program that both threads a state \<^emph>\<open>and\<close>
+  may abort with an error: combine state with error in the
+  result type.\<close>
+
+type_synonym ('s, 'e, 'a) state_err = \<open>'s \<Rightarrow> ('a \<times> 's) + 'e\<close>
+  \<comment> \<open>given a state, either return a value with an updated state
+      (\<open>Inl\<close>) or fail with an error and discard the state (\<open>Inr\<close>)\<close>
+
+definition state_err_return :: \<open>'a \<Rightarrow> ('s, 'e, 'a) state_err\<close> where
+  \<open>state_err_return x s = Inl (x, s)\<close>
+    \<comment> \<open>state \<open>s\<close> unchanged; success with value \<open>x\<close>\<close>
+
+definition state_err_bind where
+  \<open>state_err_bind f g s = (case f s of Inl (x, s') \<Rightarrow> g x s' | Inr e \<Rightarrow> Inr e)\<close>
+    \<comment> \<open>run \<open>f\<close> on \<open>s\<close>; on success thread \<open>(x, s')\<close> into \<open>g\<close>; on error propagate\<close>
+
+text \<open>\<^bold>\<open>Foreshadow:\<close> this is the shape AutoCorrode's
+  \<open>continuation\<close> datatype generalises -- \<open>Inl\<close> = \<open>Success\<close>,
+  \<open>Inr\<close> = \<open>Abort\<close>, plus a third \<open>Return\<close> branch for early-return,
+  plus a \<open>Yield\<close> for system calls.\<close>
+
+lemma %internal state_err_left_unit:
+    \<open>state_err_bind (state_err_return x) g = g x\<close>
+  by (simp add: state_err_return_def state_err_bind_def fun_eq_iff)
+
+lemma %internal state_err_right_unit:
+    \<open>state_err_bind f state_err_return = f\<close>
+  by (auto simp: state_err_return_def state_err_bind_def
+           fun_eq_iff split: sum.splits)
+
+lemma %internal state_err_assoc:
+    \<open>state_err_bind (state_err_bind f g) h
+       = state_err_bind f (\<lambda>x. state_err_bind (g x) h)\<close>
+  by (auto simp: state_err_bind_def fun_eq_iff split: sum.splits)
+
+end_slide
+
+
+slide \<open>Example: continuation (CPS) monad\<close>
+
+text_raw \<open>\begin{center}\<close>
+
+text \<open>``\<^emph>\<open>Tell me how you continue once you have the return value,
+  and I'll tell you the result\<close>''\<close>
+
+text_raw \<open>\end{center}\<close>
+
+text \<open>The computation only sees its caller's continuation; the
+  eventual answer has type \<open>'r\<close>:\<close>
+
+type_synonym ('r, 'a) cps = \<open>('a \<Rightarrow> 'r) \<Rightarrow> 'r\<close>
+
+definition cps_return :: \<open>'a \<Rightarrow> ('r, 'a) cps\<close> where
+  \<open>cps_return x k = k x\<close>
+    \<comment> \<open>hand \<open>x\<close> to the continuation \<open>k\<close>\<close>
+
+definition cps_bind :: \<open>('r, 'a) cps \<Rightarrow> ('a \<Rightarrow> ('r, 'b) cps) \<Rightarrow> ('r, 'b) cps\<close>
+  where \<open>cps_bind f g k = f (\<lambda>x. g x k)\<close>
+    \<comment> \<open>run \<open>f\<close> with the continuation: ``name its result \<open>x\<close>, then run \<open>g x\<close> with \<open>k\<close>''\<close>
+
+text \<open>CPS is normally introduced for compilers (passing
+  ``what-to-do-next'' explicitly). We will see another use: when
+  \<open>'r\<close> is specialised to a state-predicate type, the CPS monad
+  becomes a weakest-precondition transformer.\<close>
+
+lemma %internal cps_left_unit: \<open>cps_bind (cps_return x) g = g x\<close>
+  by (simp add: cps_return_def cps_bind_def fun_eq_iff)
+
+lemma %internal cps_right_unit: \<open>cps_bind f cps_return = f\<close>
+  by (simp add: cps_return_def cps_bind_def fun_eq_iff)
+
+lemma %internal cps_assoc:
+  \<open>cps_bind (cps_bind f g) h = cps_bind f (\<lambda>x. cps_bind (g x) h)\<close>
+  by (simp add: cps_bind_def fun_eq_iff)
+
+end_slide
+
+
+
+
+interlude \<open>Putting it together: the uRust monad\<close>
+
+text \<open>AutoCorrode's uRust packs state, two notions of completion,
+  abort, and a callback into one datatype. Verbatim, from
+  \<open>Shallow_Micro_Rust.Core_Expression\<close>:\<close>
+
+text \<open>@{datatype [display] continuation}\<close>
+
+text \<open>And the corresponding expression type:\<close>
+
+text \<open>@{datatype [display] expression}\<close>
+
+text \<open>\<^bold>\<open>Two notions of success.\<close> \<open>Success\<close> and \<open>Return\<close> both end with
+  value+state -- but \<open>;\<close> threads through \<open>Success\<close>, while \<open>Return\<close> short-circuits the enclosing function body.\<close>
+
+text \<open>\<^bold>\<open>Abort\<close> is the error-monad case: uncaught, bubbles all the way
+  up. \<^bold>\<open>Yield\<close> models system calls -- prompt \<open>\<pi>\<close> out, response in via \<open>k\<close>.\<close>
+
+end_interlude
+
+end
+

--- a/tutorial/Tutorial_Preamble.thy
+++ b/tutorial/Tutorial_Preamble.thy
@@ -1,0 +1,32 @@
+theory Tutorial_Preamble
+  imports
+    Slides
+    Micro_Rust_Examples.Linked_List
+begin
+
+slide \<open>About these slides\<close>
+
+text_raw \<open>\begin{center}\itshape
+These slides are as much a talk as an experimentation ground.
+\end{center}\<close>
+
+text \<open>Every slide in this deck is generated from a formally-checked
+  Isabelle/HOL theory file. Definitions, types, lemmas, and proofs
+  shown here are \<^bold>\<open>live\<close>: they were type-checked at build time and
+  the slide will not compile if a referenced fact stops being true.
+
+  The sources live next to this PDF, organised one theory per
+  topic (\<open>Tutorial_Glossary.thy\<close>, \<open>Tutorial_Monads.thy\<close>, etc.).
+
+  Open them in jEdit (\<^verbatim>\<open>make jedit\<close>) to step through every
+  proof, inspect intermediate goal states, and experiment with
+  variants.\<close>
+
+text \<open>\<^bold>\<open>Task for \<^emph>\<open>you\<close>:\<close> open the sources, change a
+  definition or a contract, and watch which proofs still go through
+  -- and which break, and why. That is the fastest way to build a
+  feel for the machinery.\<close>
+
+end_slide
+
+end

--- a/tutorial/Tutorial_SLWorked.thy
+++ b/tutorial/Tutorial_SLWorked.thy
@@ -1,0 +1,627 @@
+(* Toy separation logic, built on the first half's monad and reusing
+   AutoCorrode's separation-algebra + assertion-language infrastructure
+   (Apartness, Separation_Algebra, Assertion_Language). The toy state
+   `twoint_sl = field \<rightharpoonup> int` is automatically a sepalg via
+   `'b option :: apart` and `('a \<Rightarrow> 'b) :: apart` instances. *)
+
+theory Tutorial_SLWorked
+  imports
+    Tutorial_HoareSetup
+    Shallow_Separation_Logic.Assertion_Language
+begin
+
+slide \<open>The frame problem, recap\<close>
+
+text \<open>To make \<open>bar\<close> go through in the first half, we strengthened
+  \<open>foo\<close>'s contract by hand to mention \<open>fy\<close>:\<close>
+
+text \<open>\quad \<open>\<lbrace> \<lambda>s. fx s = v \<and> fy s = w \<rbrace>
+            foo
+         \<lbrace> \<lambda>_ s. fx s = v + 1 \<and> fy s = w \<rbrace>\<close>\<close>
+
+text \<open>The \<open>fy s = w\<close> conjunct is \<^bold>\<open>framing noise\<close> -- it adds nothing
+  local to \<open>foo\<close>; it just witnesses ``\<open>fy\<close> is unchanged''. With \<open>n\<close>
+  fields, every contract grows by \<open>n-1\<close> such clauses.\<close>
+
+text \<open>\<^bold>\<open>What we want:\<close> a logic where a contract mentions only the
+  cells a function touches, and any "disjoint" fragment is preserved
+  by a \<^emph>\<open>structural rule\<close>.\<close>
+
+text\<open>\<^bold>\<open>Question:\<close> What does "disjoint" mean?\<close>
+
+end_slide
+
+slide \<open>Separation algebras\<close>
+
+text \<open>The notion of ``state with disjointness'' is captured by a
+  \<^bold>\<open>separation algebra\<close>: a structure with an \<^bold>\<open>empty state\<close> \<open>0\<close>,
+  a \<^bold>\<open>disjointness predicate\<close> \<open>\<sharp>\<close>, and the ability to \<^bold>\<open>join disjoint
+  pieces\<close> \<open>+\<close>. AutoCorrode encodes this as a typeclass and provides
+  several models. Verbatim, from
+  \<open>Shallow_Separation_Logic.Separation_Algebra\<close>:\<close>
+
+text_raw \<open>%
+\begingroup
+\renewenvironment{isabellebody}{}{}%
+\renewcommand{\setisabellecontext}[1]{}%
+\input{Tutorial_SepalgIntro.tex}%
+\endgroup
+\<close>
+
+text \<open>\<^bold>\<open>Reusable\<close>: every SL connective below will be defined once,
+  generically, for any type in this class.\<close>
+
+end_slide
+
+
+slide \<open>Examples of separation algebras\<close>
+
+text \<open>AutoCorrode ships sepalg instances for a stack of constructions.
+  Each row gives the disjointness and join, both antiquoted from
+  \<open>Separation_Algebra.thy\<close>:\<close>
+
+text_raw \<open>%
+\begin{center}\small
+\begin{tabular}{lll}
+\textbf{Type} & \textbf{Disjointness ($\sharp$)} & \textbf{Join (+)} \\\hline
+\isa{{\isacharprime}{\kern0pt}a\ option}
+   & at most one \isa{Some}
+   & take the \isa{Some}, else \isa{None} \\
+\isa{{\isacharprime}{\kern0pt}a\ set}
+   & disjoint sets ($A \cap B = \emptyset$)
+   & union ($A \cup B$) \\
+\isa{{\isacharprime}{\kern0pt}a\ {\isasymRightarrow}\ {\isacharprime}{\kern0pt}b}
+   & pointwise on \isa{{\isacharprime}{\kern0pt}b}
+   & pointwise on \isa{{\isacharprime}{\kern0pt}b} \\
+\isa{{\isacharprime}{\kern0pt}a\ {\isasymtimes}\ {\isacharprime}{\kern0pt}b}
+   & componentwise
+   & componentwise \\
+records
+   & componentwise (lift over fields)
+   & componentwise \\
+\end{tabular}\end{center}\<close>
+
+text \<open>\<^bold>\<open>Read down the table\<close>: each line uses the previous one. A heap
+  \<open>field \<rightharpoonup> int\<close> is the partial-function instance composed with the
+  option instance; a set \<open>'a set\<close> is the function-of-option instance
+  at \<open>'b = unit option\<close> (membership = \<open>Some ()\<close>); a multi-component
+  machine state is the product instance composed over its record fields.\<close>
+
+end_slide
+
+
+slide \<open>Our toy state, as a separation algebra\<close>
+
+text \<open>Earlier, our state was \<open>record twoint = fx :: int, fy :: int\<close>
+  -- both fields \<^emph>\<open>always\<close> present. To get a separation algebra, we
+  loosen this so each field is independently \<^bold>\<open>present or absent\<close>:\<close>
+
+datatype field = FX | FY
+
+type_synonym twoint_sl = \<open>field \<rightharpoonup> int\<close>
+
+text \<open>Equivalently, we could consider a record of \<open>fx :: int option, fy :: int option\<close>.
+  By the table on the previous slide \<open>twoint_sl\<close> \<^bold>\<open>automatically inherits\<close>
+  a separation algebra structure. Isabelle's sort-checker confirms it:\<close>
+
+lemma \<open>OFCLASS(twoint_sl, sepalg_class)\<close>
+  by intro_classes
+
+text_raw\<open>\vspace*{-4mm}\<close>
+text \<open>The atomic assertion \<open>f \<mapsto> v\<close> says the heap contains the cell \<open>f\<close>
+  holding \<open>v\<close>, leaving the rest of the heap unconstrained -- i.e. it is
+  \<^emph>\<open>upwards closed\<close>:\<close>
+
+definition pto :: \<open>field \<Rightarrow> int \<Rightarrow> twoint_sl assert\<close>  (infix \<open>\<mapsto>\<close> 70) where
+  \<open>(f \<mapsto> v) \<equiv> { m. m f = Some v }\<close>
+
+end_slide
+
+
+slide \<open>Lifting disjointness to assertions: introducing \<open>\<star>\<close>\<close>
+
+text \<open>\<^bold>\<open>Goal:\<close> Bake stability under disjoint extension into the triple.\<close>
+
+text \<open>\<^bold>\<open>Need:\<close> Notion of disjoint composition for \<^emph>\<open>assertions\<close> (sets of states), not
+individual states.\<close>
+
+text \<open>@{thm [display, show_question_marks=false] asepconj_def}\<close>
+
+text \<open>So @{term \<open>s \<Turnstile> \<phi> \<star> \<psi>\<close>} if it can
+    be \<^emph>\<open>split\<close> into two \<^bold>\<open>disjoint\<close> pieces
+    @{term \<open>t \<sharp> u\<close>}, where @{term \<open>t \<Turnstile> \<phi>\<close>} and @{term \<open>u \<Turnstile> \<psi>\<close>}.\<close>
+
+text \<open>\<^bold>\<open>Some algebraic laws\<close>:\<close>
+
+text \<open>
+\<^item> @{thm [show_question_marks=false] asepconj_comm} \<comment>\<open>Commutativity\<close>
+\<^item> @{thm [show_question_marks=false] asepconj_assoc} \<comment>\<open>Associativity\<close>
+\<^item> @{thm [show_question_marks=false] asepconj_pure} \<comment>\<open>Ordinary conjunction on pure assertions\<close>\<close>
+
+end_slide
+
+slide \<open>Upwards closure: \<open>\<star> UNIV\<close> and \<open>ucincl\<close>\<close>
+
+text \<open>\<open>P \<star> UNIV\<close> holds on a heap that has \<^emph>\<open>at least\<close> the resources
+  required by \<open>P\<close> -- it is the \<^bold>\<open>upwards closure\<close> of \<open>P\<close> under disjoint
+  extension. An assertion that absorbs further resources, \<open>P \<star> UNIV = P\<close>,
+  is called \<^bold>\<open>upwards closed\<close>:\<close>
+
+text \<open>@{thm [display, show_question_marks=false] ucincl_alt}\<close>
+
+text \<open>The main practical relevance of \<open>ucincl\<close> is that we can \<^bold>\<open>hoist
+  pure assertions\<close> out of an entailment, on either side:\<close>
+
+text \<open>
+\<^item> @{thm [show_question_marks=false] apure_entails_iff}
+\<^item> @{thm [show_question_marks=false] apure_entailsR}\<close>
+
+text \<open>AutoCorrode tracks \<open>ucincl\<close> via a named-theorems bundle
+  \<open>ucincl_intros\<close>; the \<open>ucincl_solve\<close> tactic discharges such side-conditions
+  automatically.\<close>
+
+end_slide
+
+
+slide \<open>Common operations on entailments\<close>
+
+text \<open>Working with \<open>\<longlongrightarrow>\<close> and \<open>\<star>\<close> feels similar to working in Pure logic, except that assertions
+are \<^bold>\<open>resourceful\<close> and cannot be duplicated (but they can be dropped under \<^term>\<open>ucincl\<close>!).\<close>
+
+text \<open>\<^bold>\<open>Cancellation\<close> (drop a shared conjunct on LHS and RHS):\<close>
+text \<open>
+\<^item> @{thm [show_question_marks=false] asepconj_mono2}
+\<^item> @{thm [show_question_marks=false] asepconj_mono}\<close>
+
+text \<open>\<^bold>\<open>Spatial \<open>drule\<close>\<close> -- replace a conjunct on the LHS by something
+  it entails:\<close>
+
+text \<open>
+\<^item> @{lemma [show_question_marks=false]
+    \<open>\<lbrakk> \<phi> \<longlongrightarrow> \<xi>; \<xi> \<star> \<psi> \<longlongrightarrow> \<theta> \<rbrakk> \<Longrightarrow> \<phi> \<star> \<psi> \<longlongrightarrow> \<theta>\<close>
+    by (meson aentails_trans asepconj_mono2)}\<close>
+(*<*)
+text\<open>\<^item> @{lemma [show_question_marks=false]
+    \<open>\<lbrakk> \<psi> \<longlongrightarrow> \<xi>; \<phi> \<star> \<xi> \<longlongrightarrow> \<theta> \<rbrakk> \<Longrightarrow> \<phi> \<star> \<psi> \<longlongrightarrow> \<theta>\<close>
+    by (meson aentails_trans asepconj_mono)}\<close>
+(*>*)
+
+text \<open>\<^bold>\<open>Spatial \<open>rule\<close>\<close> -- back-chain an entailment on the RHS:\<close>
+
+text \<open>
+\<^item> @{lemma [show_question_marks=false]
+    \<open>\<lbrakk> \<phi> \<longlongrightarrow> \<xi> \<star> \<psi>; \<xi> \<longlongrightarrow> \<xi>' \<rbrakk> \<Longrightarrow> \<phi> \<longlongrightarrow> \<xi>' \<star> \<psi>\<close>
+    by (meson aentails_trans asepconj_mono2)}\<close>
+(*<*)
+text\<open>\<^item> @{lemma [show_question_marks=false]
+    \<open>\<lbrakk> \<phi> \<longlongrightarrow> \<xi> \<star> \<psi>; \<psi> \<longlongrightarrow> \<psi>' \<rbrakk> \<Longrightarrow> \<phi> \<longlongrightarrow> \<xi> \<star> \<psi>'\<close>
+    by (meson aentails_trans asepconj_mono)}\<close>
+(*>*)
+
+text \<open>\<^bold>\<open>Spatial \<open>congruence rules\<close>\<close> also exist, but not discussed here.\<close>
+
+end_slide
+
+slide \<open>Hoare triples --- in separation logic\<close>
+
+text\<open>Intuitively, we want any component disjoint from pre/post-condition left unchanged. 
+Concretely, we say that any \<^emph>\<open>assertion\<close> disjoint from pre/post-condition is preserved:\<close>
+
+definition sltriple (\<open>\<lbrace>_\<rbrace>/ _/ \<lbrace>_\<rbrace>\<close>) where 
+   \<open>\<lbrace>P\<rbrace> e \<lbrace>Q\<rbrace> \<equiv> 
+      \<forall>h x h'. \<comment>\<open>For all states @{term h}, @{term h'} and return values @{term x} ...\<close>
+      h \<leadsto>\<langle>e\<rangle> (x, h') \<comment>\<open>... if @{term e} can tranform @{term h} into @{term h'}, producing @{term x} ...\<close>
+      \<longrightarrow> (\<forall>\<pi>. ucincl \<pi> \<longrightarrow> \<comment>\<open>then for any predicate @{term \<pi>} (disjoint from P)\<close> 
+          \<comment>\<open>if @{term h} satisfies the precondition and, disjointly, @{term \<pi>}\<close>
+          h \<Turnstile> P \<star> \<pi> \<longrightarrow> 
+          \<comment>\<open>then @{term h'} satisfies the postcondition and, disjointly, still @{term \<pi>}\<close>
+          h' \<Turnstile> Q x \<star> \<pi>)\<close>
+
+text\<open>By definition, we obtain the \<^bold>\<open>frame rule\<close>, which we saw failing in the previous session:\<close>
+
+lemma frame_rule:
+  assumes \<open>\<lbrace>P\<rbrace> e \<lbrace>Q\<rbrace>\<close>
+    shows \<open>\<lbrace>P \<star> S\<rbrace> e \<lbrace>\<lambda>x. Q x \<star> S\<rbrace>\<close>
+  unfolding sltriple_def
+proof (intro allI impI)
+  fix h x h' \<pi>
+  assume step: \<open>h \<leadsto>\<langle>e\<rangle> (x, h')\<close> and uc: \<open>ucincl \<pi>\<close>
+                                and pre: \<open>h \<Turnstile> (P \<star> S) \<star> \<pi>\<close>
+  have \<open>h \<Turnstile> P \<star> (S \<star> \<pi>)\<close> using pre by (simp add: asepconj_assoc)
+  moreover have \<open>ucincl (S \<star> \<pi>)\<close> using uc by (rule ucincl_asepconjR)
+  ultimately have \<open>h' \<Turnstile> Q x \<star> (S \<star> \<pi>)\<close>
+    using assms step by (force simp: sltriple_def)
+  thus \<open>h' \<Turnstile> (\<lambda>x. Q x \<star> S) x \<star> \<pi>\<close>
+    by (simp add: asepconj_assoc)
+qed
+
+end_slide
+
+interlude \<open>A peek ahead: real uRust (weak) triple\<close>
+
+text_raw \<open>%
+\begingroup
+\renewenvironment{isabellebody}{}{}%
+\renewcommand{\setisabellecontext}[1]{}%
+\input{Tutorial_UrustPeek_Triple.tex}%
+\endgroup
+\<close>
+
+end_interlude
+
+slide \<open>WP, and triple-WP equivalence\<close>
+
+text \<open>As in the first half, defining \<open>wp_sl e Q\<close> is the \<^bold>\<open>largest precondition\<close>
+  making the triple hold:\<close>
+
+definition wp_sl (\<open>\<W>\<P>\<close>) where \<open>\<W>\<P> e Q \<equiv> \<Union> {P. \<lbrace>P\<rbrace> e \<lbrace>Q\<rbrace>}\<close>
+
+text \<open>By construction the triple is then \<^bold>\<open>represented\<close> by \<open>wp_sl\<close>:\<close>
+
+lemma sltriple_wp_iff: 
+  shows \<open>\<lbrace>P\<rbrace> e \<lbrace>Q\<rbrace> \<longleftrightarrow> P \<longlongrightarrow> \<W>\<P> e Q\<close>
+proof
+  assume \<open>\<lbrace>P\<rbrace> e \<lbrace>Q\<rbrace>\<close> thus \<open>P \<longlongrightarrow> \<W>\<P> e Q\<close>
+    by (auto simp: wp_sl_def aentails_def asat_def)
+next
+  assume H: \<open>P \<longlongrightarrow> \<W>\<P> e Q\<close>
+  show \<open>\<lbrace>P\<rbrace> e \<lbrace>Q\<rbrace>\<close> unfolding sltriple_def
+  proof (intro allI impI)
+    fix h x h' \<pi>
+    assume st: \<open>h \<leadsto>\<langle>e\<rangle> (x, h')\<close> and uc: \<open>ucincl \<pi>\<close>
+                                  and pre: \<open>h \<Turnstile> P \<star> \<pi>\<close>
+    from pre obtain t u where \<open>h = t + u\<close> \<open>t \<sharp> u\<close> \<open>t \<Turnstile> P\<close> \<open>u \<Turnstile> \<pi>\<close>
+      by (auto simp: asepconj_def asat_def)
+    moreover from \<open>t \<Turnstile> P\<close> H obtain P' where \<open>\<lbrace>P'\<rbrace> e \<lbrace>Q\<rbrace>\<close> \<open>t \<Turnstile> P'\<close>
+      by (auto simp: aentails_def wp_sl_def asat_def)
+    ultimately have \<open>h \<Turnstile> P' \<star> \<pi>\<close>
+      by (auto simp: asepconj_def asat_def)
+    with \<open>\<lbrace>P'\<rbrace> e \<lbrace>Q\<rbrace>\<close> st uc show \<open>h' \<Turnstile> Q x \<star> \<pi>\<close>
+      by (force simp: sltriple_def)
+  qed
+qed
+
+text \<open>As before, weakest precondition rules for \<open>return\<close> and \<open>bind\<close>:\<close>
+
+(*<*)
+lemma wp_sl_return: \<open>Q x \<longlongrightarrow> \<W>\<P> (return x) Q\<close>
+  unfolding sltriple_wp_iff[symmetric] sltriple_def
+  by (auto simp: evals_def return_def)
+
+lemma wp_sl_bind: \<open>\<W>\<P> e (\<lambda>x. \<W>\<P> (k x) Q) \<longlongrightarrow> \<W>\<P> (do { x \<leftarrow> e; k x }) Q\<close>
+proof -
+  have wp_self_e: \<open>\<lbrace>\<W>\<P> e (\<lambda>x. \<W>\<P> (k x) Q)\<rbrace> e \<lbrace>\<lambda>x. \<W>\<P> (k x) Q\<rbrace>\<close>
+    using sltriple_wp_iff aentails_refl by metis
+  have wp_self_k: \<open>\<And>x. \<lbrace>\<W>\<P> (k x) Q\<rbrace> k x \<lbrace>Q\<rbrace>\<close>
+    using sltriple_wp_iff aentails_refl by metis
+  have \<open>\<lbrace>\<W>\<P> e (\<lambda>x. \<W>\<P> (k x) Q)\<rbrace> do { x \<leftarrow> e; k x } \<lbrace>Q\<rbrace>\<close>
+    using wp_self_e wp_self_k by (auto simp: sltriple_def evals_bind)
+  thus ?thesis using sltriple_wp_iff by blast
+qed
+
+text \<open>\<^bold>\<open>Consequence form\<close> (rule shape, useful for back-chaining):\<close>
+(*>*)
+
+lemma wp_sl_returnI:
+  assumes \<open>\<phi> \<longlongrightarrow> Q x\<close>
+    shows \<open>\<phi> \<longlongrightarrow> \<W>\<P> (return x) Q\<close>
+  using assms by (rule aentails_trans[OF _ wp_sl_return])
+
+text\<open>\<close>
+
+lemma wp_sl_bindI:
+  assumes \<open>\<phi> \<longlongrightarrow> \<W>\<P> e (\<lambda>x. \<W>\<P> (k x) Q)\<close>
+    shows \<open>\<phi> \<longlongrightarrow> \<W>\<P> (do { x \<leftarrow> e; k x }) Q\<close>
+  using assms by (rule aentails_trans[OF _ wp_sl_bind])
+
+end_slide
+
+slide \<open>The magic wand: spatial subtraction\<close>
+
+text \<open>We need one more SL connective: the \<^bold>\<open>magic wand\<close> \<open>\<phi> \<Zsurj> \<psi>\<close>,
+  intuitively ``the resources you'd need to add to \<open>\<phi>\<close>
+  in order to obtain \<open>\<psi>\<close>'' -- \<^bold>\<open>spatial subtraction\<close>
+  \<open>\<psi> - \<phi>\<close>.\<close>
+
+text \<open>It's determined by its \<^bold>\<open>universal property\<close>: \<open>\<Zsurj>\<close> is
+  right-adjoint to \<open>\<star>\<close>.\<close>
+
+text \<open>@{thm [display, show_question_marks=false] awand_adjoint}\<close>
+
+text \<open>Read left-to-right: to entail \<open>\<psi> \<Zsurj> \<xi>\<close>, it suffices to entail \<open>\<xi>\<close>
+  after gluing on a \<open>\<psi>\<close>. Read right-to-left: anything entailed by
+  \<open>\<phi> \<star> \<psi>\<close> can be ``factored'' as \<open>\<phi>\<close> entailing \<open>\<psi> \<Zsurj> ...\<close>. We use this
+  in call-by-contract on the next slide.\<close>
+
+end_slide
+
+slide \<open>Call-by-contract, in SL\<close>
+
+text \<open>As in the first half, a contract \<open>\<lbrace>P\<rbrace> e \<lbrace>Q\<rbrace>\<close> yields a WP rule:
+  if the precondition entails \<open>P\<close> and the post can be \<^bold>\<open>swapped\<close> for
+  \<open>R\<close> via the magic wand, the WP follows.\<close>
+
+lemma sl_call_by_contractI:
+  assumes \<open>\<lbrace>P\<rbrace> e \<lbrace>Q\<rbrace>\<close>
+      and \<open>\<phi> \<longlongrightarrow> P \<star> (\<Sqinter>x. Q x \<Zsurj> R x)\<close>
+    shows \<open>\<phi> \<longlongrightarrow> wp_sl e R\<close>
+proof -
+  let ?W = \<open>\<Sqinter>x. Q x \<Zsurj> R x\<close>
+  have step1: \<open>\<lbrace>P \<star> ?W\<rbrace> e \<lbrace>\<lambda>x. Q x \<star> ?W\<rbrace>\<close>
+    using \<open>\<lbrace>P\<rbrace> e \<lbrace>Q\<rbrace>\<close> frame_rule by blast
+  have step2: \<open>\<And>x. Q x \<star> ?W \<longlongrightarrow> R x\<close>
+    by (meson aentails_forallL aentails_trans' asepconj_mono awand_counit)
+  have step4: \<open>\<lbrace>P \<star> ?W\<rbrace> e \<lbrace>R\<rbrace>\<close>
+    by (smt (verit, ccfv_threshold) aentails_def asat_def asepconj_def
+        mem_Collect_eq sltriple_def step1 step2)
+  from step4 \<open>\<phi> \<longlongrightarrow> P \<star> (\<Sqinter>x. Q x \<Zsurj> R x)\<close> show \<open>\<phi> \<longlongrightarrow> wp_sl e R\<close>
+    using sltriple_wp_iff aentails_trans by metis
+qed
+
+text \<open>\<^bold>\<open>Intuition:\<close> Practically, the rule is applied as follows:
+ \<^item> Find the pre-condition \<open>P\<close> in the LHS \<open>\<phi>\<close>
+ \<^item> Cancel it, leaving \<open>\<Sqinter>x. Q x \<Zsurj> R x\<close> on the RHS.
+ \<^item> Move the post-condition \<open>Q x\<close> over to the LHS by adjunction.
+ \<^item> Continue, with \<open>P\<close> now being a new assumption.
+
+In effect, one has simply "swapped" the precondition \<open>P\<close> for the post-condition \<open>Q\<close>.
+This usage pattern for the magic wand is extremely common.\<close>
+
+end_slide
+
+interlude \<open>A peek ahead: real uRust call-by-contract\<close>
+
+text_raw \<open>%
+\begingroup
+\renewenvironment{isabellebody}{}{}%
+\renewcommand{\setisabellecontext}[1]{}%
+\input{Tutorial_UrustPeek_Call.tex}%
+\endgroup
+\<close>
+
+end_interlude
+
+slide \<open>Working example: Setup\<close>
+
+text \<open>We rerun the increment example, this time with SL contracts. The
+  state monad over \<open>twoint_sl\<close> is exactly the toy monad from the first
+  half; the only new ingredient is the SL triple.\<close>
+
+text \<open>Generic \<open>get\<close>/\<open>put\<close> on the heap:\<close>
+
+definition get :: \<open>(twoint_sl, twoint_sl) m\<close> where
+  \<open>get = M (\<lambda>h. {(h, h)})\<close>
+
+definition put :: \<open>twoint_sl \<Rightarrow> (twoint_sl, unit) m\<close> where
+  \<open>put h' = M (\<lambda>_. {((), h')})\<close>
+
+end_slide
+
+slide \<open>Working example: Per-field reads and writes\<close>
+
+text \<open>Per-field operations follow the same shape as in the Hoare chapter:\<close>
+
+definition get_x :: \<open>(twoint_sl, int) m\<close> where
+  \<open>get_x = M (\<lambda>h. {(the (h FX), h)})\<close>
+
+definition put_x :: \<open>int \<Rightarrow> (twoint_sl, unit) m\<close> where
+  \<open>put_x v = M (\<lambda>h. {((), h(FX \<mapsto> v))})\<close>
+
+definition get_y :: \<open>(twoint_sl, int) m\<close> where
+  \<open>get_y = M (\<lambda>h. {(the (h FY), h)})\<close>
+
+definition put_y :: \<open>int \<Rightarrow> (twoint_sl, unit) m\<close> where
+  \<open>put_y v = M (\<lambda>h. {((), h(FY \<mapsto> v))})\<close>
+
+end_slide
+
+slide \<open>Working example: Local SL contracts for get/put\<close>
+
+text \<open>Each operation gets a contract that mentions \<^emph>\<open>only\<close> the cell it
+  touches -- no \<open>fy\<close>-conjunct on a \<open>get_x\<close> spec, no framing noise. The
+  frame rule will absorb whatever else is in the heap.\<close>
+
+(*<*)
+lemma ucincl_pto[ucincl_intros]: \<open>ucincl (f \<mapsto> v)\<close>
+  unfolding pto_def ucincl_def ucpred_def derived_order_def
+  by (clarsimp simp: plus_fun_def plus_option_def disjoint_fun_def disjoint_option_def
+                split: option.splits)
+
+lemma get_x_triple: \<open>\<lbrace>FX \<mapsto> v\<rbrace> get_x \<lbrace>\<lambda>r. \<langle>r = v\<rangle> \<star> FX \<mapsto> v\<rbrace>\<close>
+  unfolding sltriple_def
+proof (intro allI impI)
+  fix h x h' \<pi>
+  assume step: \<open>h \<leadsto>\<langle>get_x\<rangle> (x, h')\<close> and uc: \<open>ucincl \<pi>\<close>
+                                       and pre: \<open>h \<Turnstile> FX \<mapsto> v \<star> \<pi>\<close>
+  from step have h_eq: \<open>h' = h\<close> and x_eq: \<open>x = the (h FX)\<close>
+    by (auto simp: evals_def get_x_def)
+  from pre obtain t u where \<open>h = t + u\<close> \<open>t \<sharp> u\<close> \<open>t FX = Some v\<close> \<open>u \<Turnstile> \<pi>\<close>
+    by (auto simp: asepconj_def asat_def pto_def)
+  hence \<open>h FX = Some v\<close>
+    by (auto simp: plus_fun_def plus_option_def
+                   disjoint_fun_def disjoint_option_def split: option.splits)
+  hence pure_eq: \<open>\<langle>x = v\<rangle> = (UNIV :: twoint_sl assert)\<close>
+    using x_eq by (simp add: apure_def)
+  have \<open>ucincl ((FX \<mapsto> v) :: twoint_sl assert)\<close> by (rule ucincl_pto)
+  thus \<open>h' \<Turnstile> (\<langle>x = v\<rangle> \<star> FX \<mapsto> v) \<star> \<pi>\<close>
+    using pre h_eq pure_eq by (simp add: asepconj_simp asepconj_assoc)
+qed
+
+lemma put_x_triple: \<open>\<lbrace>FX \<mapsto> u\<rbrace> put_x v \<lbrace>\<lambda>_. FX \<mapsto> v\<rbrace>\<close>
+  unfolding sltriple_def
+proof (intro allI impI)
+  fix h x h' \<pi>
+  assume step: \<open>h \<leadsto>\<langle>put_x v\<rangle> (x, h')\<close> and uc: \<open>ucincl \<pi>\<close>
+                                         and pre: \<open>h \<Turnstile> FX \<mapsto> u \<star> \<pi>\<close>
+  from step have h'_eq: \<open>h' = h(FX \<mapsto> v)\<close>
+    by (auto simp: evals_def put_x_def)
+  from pre obtain t r where split: \<open>h = t + r\<close> and disj: \<open>t \<sharp> r\<close>
+                          and tFX: \<open>t FX = Some u\<close> and rR: \<open>r \<Turnstile> \<pi>\<close>
+    by (auto simp: asepconj_def asat_def pto_def)
+  from disj tFX have rFX: \<open>r FX = None\<close>
+    by (force simp: disjoint_fun_def disjoint_option_def split: option.splits)
+  define t' where t'_def: \<open>t' = t(FX \<mapsto> v)\<close>
+  have t'FX: \<open>t' FX = Some v\<close> by (simp add: t'_def)
+  have disj': \<open>t' \<sharp> r\<close>
+    using disj rFX unfolding t'_def disjoint_fun_def disjoint_option_def
+    by (clarsimp split: option.splits)
+  have h'_split: \<open>h' = t' + r\<close>
+    using h'_eq split rFX
+    unfolding t'_def plus_fun_def fun_eq_iff
+    by (auto simp: plus_option_def split: option.splits)
+  show \<open>h' \<Turnstile> (\<lambda>_. FX \<mapsto> v) x \<star> \<pi>\<close>
+    using disj' h'_split t'FX rR
+    unfolding asepconj_def asat_def pto_def by blast
+qed
+
+lemma get_y_triple: \<open>\<lbrace>FY \<mapsto> v\<rbrace> get_y \<lbrace>\<lambda>r. \<langle>r = v\<rangle> \<star> FY \<mapsto> v\<rbrace>\<close>
+  unfolding sltriple_def
+proof (intro allI impI)
+  fix h x h' \<pi>
+  assume step: \<open>h \<leadsto>\<langle>get_y\<rangle> (x, h')\<close> and uc: \<open>ucincl \<pi>\<close>
+                                       and pre: \<open>h \<Turnstile> FY \<mapsto> v \<star> \<pi>\<close>
+  from step have h_eq: \<open>h' = h\<close> and x_eq: \<open>x = the (h FY)\<close>
+    by (auto simp: evals_def get_y_def)
+  from pre obtain t u where \<open>h = t + u\<close> \<open>t \<sharp> u\<close> \<open>t FY = Some v\<close> \<open>u \<Turnstile> \<pi>\<close>
+    by (auto simp: asepconj_def asat_def pto_def)
+  hence \<open>h FY = Some v\<close>
+    by (auto simp: plus_fun_def plus_option_def
+                   disjoint_fun_def disjoint_option_def split: option.splits)
+  hence pure_eq: \<open>\<langle>x = v\<rangle> = (UNIV :: twoint_sl assert)\<close>
+    using x_eq by (simp add: apure_def)
+  have \<open>ucincl ((FY \<mapsto> v) :: twoint_sl assert)\<close> by (rule ucincl_pto)
+  thus \<open>h' \<Turnstile> (\<langle>x = v\<rangle> \<star> FY \<mapsto> v) \<star> \<pi>\<close>
+    using pre h_eq pure_eq by (simp add: asepconj_simp asepconj_assoc)
+qed
+
+lemma put_y_triple: \<open>\<lbrace>FY \<mapsto> u\<rbrace> put_y v \<lbrace>\<lambda>_. FY \<mapsto> v\<rbrace>\<close>
+  unfolding sltriple_def
+proof (intro allI impI)
+  fix h x h' \<pi>
+  assume step: \<open>h \<leadsto>\<langle>put_y v\<rangle> (x, h')\<close> and uc: \<open>ucincl \<pi>\<close>
+                                         and pre: \<open>h \<Turnstile> FY \<mapsto> u \<star> \<pi>\<close>
+  from step have h'_eq: \<open>h' = h(FY \<mapsto> v)\<close>
+    by (auto simp: evals_def put_y_def)
+  from pre obtain t r where split: \<open>h = t + r\<close> and disj: \<open>t \<sharp> r\<close>
+                          and tFY: \<open>t FY = Some u\<close> and rR: \<open>r \<Turnstile> \<pi>\<close>
+    by (auto simp: asepconj_def asat_def pto_def)
+  from disj tFY have rFY: \<open>r FY = None\<close>
+    by (force simp: disjoint_fun_def disjoint_option_def split: option.splits)
+  define t' where t'_def: \<open>t' = t(FY \<mapsto> v)\<close>
+  have t'FY: \<open>t' FY = Some v\<close> by (simp add: t'_def)
+  have disj': \<open>t' \<sharp> r\<close>
+    using disj rFY unfolding t'_def disjoint_fun_def disjoint_option_def
+    by (clarsimp split: option.splits)
+  have h'_split: \<open>h' = t' + r\<close>
+    using h'_eq split rFY
+    unfolding t'_def plus_fun_def fun_eq_iff
+    by (auto simp: plus_option_def split: option.splits)
+  show \<open>h' \<Turnstile> (\<lambda>_. FY \<mapsto> v) x \<star> \<pi>\<close>
+    using disj' h'_split t'FY rR
+    unfolding asepconj_def asat_def pto_def by blast
+qed
+(*>*)
+
+text \<open>
+\<^item> @{thm [show_question_marks=false] get_x_triple}
+\<^item> @{thm [show_question_marks=false] put_x_triple}
+\<^item> @{thm [show_question_marks=false] get_y_triple}
+\<^item> @{thm [show_question_marks=false] put_y_triple}
+\<close>
+
+text \<open>From each contract, \<open>sl_call_by_contractI\<close> gives a back-chainable
+  WP rule:\<close>
+
+lemma get_x_wp: \<open>\<phi> \<longlongrightarrow> FX \<mapsto> v \<star> (\<Sqinter>r. (\<langle>r = v\<rangle> \<star> FX \<mapsto> v) \<Zsurj> R r) \<Longrightarrow> \<phi> \<longlongrightarrow> \<W>\<P> get_x R\<close>
+  using get_x_triple sl_call_by_contractI by blast
+text\<open>\<close>
+lemma put_x_wp: \<open>\<phi> \<longlongrightarrow> FX \<mapsto> u \<star> (\<Sqinter>r. FX \<mapsto> v \<Zsurj> R r) \<Longrightarrow> \<phi> \<longlongrightarrow> \<W>\<P> (put_x v) R\<close>
+  using put_x_triple sl_call_by_contractI by blast
+
+(*<*)
+lemma get_y_wp: \<open>\<phi> \<longlongrightarrow> FY \<mapsto> v \<star> (\<Sqinter>r. (\<langle>r = v\<rangle> \<star> FY \<mapsto> v) \<Zsurj> R r) \<Longrightarrow> \<phi> \<longlongrightarrow> \<W>\<P> get_y R\<close>
+  using get_y_triple sl_call_by_contractI by blast
+
+lemma put_y_wp: \<open>\<phi> \<longlongrightarrow> FY \<mapsto> u \<star> (\<Sqinter>r. FY \<mapsto> v \<Zsurj> R r) \<Longrightarrow> \<phi> \<longlongrightarrow> \<W>\<P> (put_y v) R\<close>
+  using put_y_triple sl_call_by_contractI by blast
+(*>*)
+
+end_slide
+
+slide \<open>Working example: Proving \<open>foo\<close>\<close>
+
+definition foo :: \<open>(twoint_sl, unit) m\<close> where
+  \<open>foo = do { v \<leftarrow> get_x; put_x (v + 1) }\<close>
+
+lemma %visible foo_spec: \<open>\<lbrace>FX \<mapsto> v\<rbrace> foo \<lbrace>\<lambda>_. FX \<mapsto> (v + 1)\<rbrace>\<close>
+  unfolding sltriple_wp_iff foo_def
+  apply (rule wp_sl_bindI)
+  apply (rule get_x_wp[where v=v])
+  apply (rule asepconj_mono5)
+  apply (rule ucincl_pto)
+  apply (rule aentails_intro(10))
+  apply (subst awand_adjoint)
+  apply (subst asepconj_swap_top)
+  apply (rule apure_entailsL)
+  \<comment>\<open>...\<close>
+  (*<*)
+  subgoal by (auto intro: ucincl_intros)
+  apply simp
+  apply (subst asepconj_comm)
+  apply (subst asepconj_ident2)
+  apply (rule ucincl_pto)
+  apply (rule put_x_wp[where u=v])
+  apply (rule asepconj_mono5)
+  apply (rule ucincl_pto)
+  apply (rule aentails_intro(10))
+  apply (subst awand_adjoint)
+  apply (rule aentails_cancel_l)
+  apply (rule ucincl_pto)
+  done
+  (*>*)
+
+(*<*)
+lemma foo_wp: \<open>\<phi> \<longlongrightarrow> FX \<mapsto> v \<star> (\<Sqinter>r. FX \<mapsto> (v + 1) \<Zsurj> R r) \<Longrightarrow> \<phi> \<longlongrightarrow> \<W>\<P> foo R\<close>
+  using foo_spec sl_call_by_contractI by blast
+(*>*)
+
+end_slide
+
+slide \<open>Working example: Proving \<open>bar\<close> -- by contract\<close>
+
+definition bar :: \<open>(twoint_sl, int) m\<close> where
+  \<open>bar = do { put_y 42; foo; get_y }\<close>
+
+lemma %visible bar_spec: \<open>\<lbrace>FX \<mapsto> x \<star> FY \<mapsto> y\<rbrace> bar \<lbrace>\<lambda>r. \<langle>r = 42\<rangle> \<star> FX \<mapsto> (x + 1) \<star> FY \<mapsto> 42\<rbrace>\<close>
+  unfolding sltriple_wp_iff bar_def
+  apply (rule wp_sl_bindI)
+  apply (rule put_y_wp[where u=y])
+  apply (subst (1) asepconj_comm)
+  apply (rule asepconj_mono)
+  apply (rule aentails_intro(10))
+  apply (subst awand_adjoint)
+  apply (rule wp_sl_bindI)
+  apply (rule foo_wp[where v=x])
+  apply (rule asepconj_mono)
+  \<comment>\<open>...\<close>
+  (*<*)
+  apply (rule aentails_intro(10))
+  apply (subst awand_adjoint)
+  apply (rule get_y_wp[where v=42])
+  apply (rule asepconj_mono)
+  apply (rule aentails_intro(10))
+  apply (subst awand_adjoint)
+  apply (simp add: asepconj_AC)
+  apply (rule aentails_refl)
+  done
+  (*>*)
+
+end_slide
+
+slide \<open>To be continued ...\<close>
+
+text_raw \<open>\vfill\begin{center}\Huge To be continued ...\end{center}\vfill\<close>
+
+end_slide
+
+end

--- a/tutorial/Tutorial_SepalgIntro.thy
+++ b/tutorial/Tutorial_SepalgIntro.thy
@@ -1,0 +1,15 @@
+theory Tutorial_SepalgIntro
+  imports
+    Slides
+    Shallow_Separation_Logic.Separation_Algebra
+begin
+
+text \<open>The class @{class sepalg} extends @{class plus}, @{class zero},
+  and @{class apart} with five axioms, e.g.:\<close>
+
+text \<open>
+\<^item> @{thm [show_question_marks=false] sepalg_class.sepalg_ident2}
+\<^item> @{thm [show_question_marks=false] sepalg_class.sepalg_comm}
+\<^item> @{thm [show_question_marks=false] sepalg_class.sepalg_assoc}\<close>
+
+end

--- a/tutorial/Tutorial_UrustPeek_Call.thy
+++ b/tutorial/Tutorial_UrustPeek_Call.thy
@@ -1,0 +1,21 @@
+theory Tutorial_UrustPeek_Call
+  imports
+    Slides
+    Shallow_Separation_Logic.Weakest_Precondition
+begin
+
+text \<open>uRust's call-by-contract rule has the same shape, but with the
+  three postconditions and a magic-wand encoding of the
+  ``post-implies-frame'' obligation:\<close>
+
+(*<*) context sepalg begin (*>*)
+
+text \<open>@{thm [show_question_marks=false] wp_callI}\<close>
+
+(*<*) end (*>*)
+
+text \<open>Again the wand \<open>\<phi> \<Zsurj> \<psi>\<close> reads ``swap a state satisfying \<open>\<phi>\<close> for one
+  satisfying \<open>\<psi>\<close>'' -- exactly the consequence step the toy version's
+  third premise expresses pointwise.\<close>
+
+end

--- a/tutorial/Tutorial_UrustPeek_Eval.thy
+++ b/tutorial/Tutorial_UrustPeek_Eval.thy
@@ -1,0 +1,23 @@
+theory Tutorial_UrustPeek_Eval
+  imports
+    Slides
+    Shallow_Micro_Rust.Eval
+begin
+
+text \<open>uRust has \<^emph>\<open>three\<close> evaluation relations -- \<open>\<leadsto>\<^sub>v\<close>, \<open>\<leadsto>\<^sub>r\<close>, \<open>\<leadsto>\<^sub>a\<close> for value, return, and abort.\<close>
+
+text \<open>\<^bold>\<open>Early return\<close> -- delivers to the early-return arrow \<open>\<leadsto>\<^sub>r\<close>:
+\<^item> @{thm [show_question_marks=false] urust_eval_predicate_return(1)}
+\<^item> @{thm [show_question_marks=false] urust_eval_predicate_return(2)}
+\<^item> @{thm [show_question_marks=false] urust_eval_predicate_return(3)}\<close>
+
+text \<open>\<^bold>\<open>Word addition\<close> -- the no-overflow guard shows up as a hypothesis on
+  the value arrow \<open>\<leadsto>\<^sub>v\<close>:
+\<^item> @{thm [show_question_marks=false] urust_eval_predicate_add_no_wrap(1)}
+\<^item> @{thm [show_question_marks=false] urust_eval_predicate_add_no_wrap(2)}
+\<^item> @{thm [show_question_marks=false] urust_eval_predicate_add_no_wrap(3)}\<close>
+
+text\<open>\<^bold>\<open>Function calls\<close> merge the value and return paths:
+\<^item> @{thm [show_question_marks=false] urust_eval_predicate_call(1)}\<close>
+
+end

--- a/tutorial/Tutorial_UrustPeek_Triple.thy
+++ b/tutorial/Tutorial_UrustPeek_Triple.thy
@@ -1,0 +1,27 @@
+theory Tutorial_UrustPeek_Triple
+  imports
+    Slides
+    Shallow_Separation_Logic.Weak_Triple
+begin
+
+text \<open>AutoCorrode builds triples in a 3-step fashion. First, for pairs of states ("assertion triple"):\<close>
+
+(*<*) context sepalg begin (*>*)
+
+text \<open>@{thm [display, show_question_marks=false] atriple_def}\<close>
+
+(*<*) end (*>*)
+
+text \<open>Second, the weak triple for uRust expressions, which applies the assertion triple to the
+  value/return/abort transitions associated with the program:\<close>
+
+(*<*) context sepalg begin (*>*)
+
+text \<open>@{thm [display, show_question_marks=false] striple_def}\<close>
+
+(*<*) end (*>*)
+
+text \<open>Finally, there is a \<^emph>\<open>strong\<close> triple which adds \<^bold>\<open>locality\<close>: Anything outside the frame does not
+influence the execution of the program. \<^bold>\<open>This is not automatic!\<close>. We don't consider it here.\<close>
+
+end

--- a/tutorial/Tutorial_UrustPeek_WP.thy
+++ b/tutorial/Tutorial_UrustPeek_WP.thy
@@ -1,0 +1,50 @@
+theory Tutorial_UrustPeek_WP
+  imports
+    Slides
+    Shallow_Separation_Logic.Weakest_Precondition
+begin
+
+(*<*)
+\<comment>\<open>We want to drop the \<^term>\<open>ucincl\<close> premises from the theorems below to avoid visual clutter
+that we don't want to explain at this point. Register a custom term-printing binding to drop the
+first premise of term.\<close>
+  setup \<open>
+    let
+      fun is_ucincl_prem t =
+        (case t of
+          \<^Const_>\<open>Trueprop\<close> $ (\<^Const_>\<open>Separation_Algebra.sepalg.ucincl _\<close> $ _ $ _ $ _) => true
+        | _ => false);
+
+      fun drop_ucincl _ t =
+        Logic.list_implies
+          (filter_out is_ucincl_prem (Logic.strip_imp_prems t),
+           Logic.strip_imp_concl t);
+    in
+      Term_Style.setup \<^binding>\<open>drop_ucincl\<close> (Scan.succeed drop_ucincl)
+    end
+  \<close>
+
+context sepalg begin (*>*)
+
+text \<open>AutoCorrode + uRust heavily rely on a WP calculus along the above lines. Some examples:\<close>
+
+text \<open>\<^bold>\<open>Early return\<close> delivers to the \<^emph>\<open>early-return\<close> post \<open>\<rho>\<close>: @{thm [source] Weakest_Precondition.wp_returnI}\<close>
+
+text \<open>@{thm [display, show_question_marks=false] (drop_ucincl) wp_returnI}\<close>
+
+text \<open>\<^bold>\<open>Panic\<close> delivers to the \<^emph>\<open>abort\<close> post \<open>\<theta>\<close>: @{thm [source] Weakest_Precondition.wp_panicI}\<close>
+
+text \<open>@{thm [display, show_question_marks=false] (drop_ucincl) wp_panicI}\<close>
+
+text \<open>Recall: uRust's \<^emph>\<open>three\<close> postconditions \<open>\<psi>\<close> / \<open>\<rho>\<close> / \<open>\<theta>\<close> separate value/return/abort.\<close>
+
+text \<open>\<^bold>\<open>Word addition\<close> -- arithmetic operators get WP rules, with appropriate constraints:\<close>
+
+text \<open>@{thm [display, show_question_marks=false] (drop_ucincl) wp_word_add_no_wrap}\<close>
+
+text \<open>The full set lives in \<open>Weakest_Precondition.thy\<close> (literals,
+  conditionals, calls, assert, yield, ...).\<close>
+
+(*<*) end (*>*)
+
+end

--- a/tutorial/document/root.tex
+++ b/tutorial/document/root.tex
@@ -1,0 +1,167 @@
+\documentclass[9pt,aspectratio=169]{beamer}
+
+\usepackage[T1]{fontenc}
+\usepackage[utf8]{inputenc}
+\usepackage{isabelle,isabellesym}
+\usepackage{amssymb,amsmath}
+\usepackage[only,bigsqcap,bigparallel,fatsemi,interleave,sslash,llbracket,rrbracket,llparenthesis,rrparenthesis,binampersand,bindnasrepma]{stmaryrd}
+\usepackage{wasysym}
+\usepackage{eurosym}
+\usepackage{textcomp}
+\usepackage{bussproofs}
+\usepackage{tikz}
+\usepackage{alltt}
+\usetikzlibrary{positioning,arrows.meta,fit,shapes.geometric}
+
+% Isabelle's pdfsetup.sty loads hyperref a second time and clashes with
+% beamer's own hyperref setup, so we skip it.
+
+\isabellestyle{tt}
+
+% Syntax highlighting, loosely matching jEdit's default theme (after the
+% Neon NTT paper).
+\usepackage{xcolor}
+\definecolor{kw}{HTML}{6F00E5}     % keywords (proof, qed, by) — violet
+\definecolor{cmd}{HTML}{0000B0}    % outer-syntax commands — blue
+\definecolor{ty}{HTML}{006400}     % type/class names — dark green
+\definecolor{varc}{HTML}{8B4513}   % free variables — brown
+\definecolor{lit}{HTML}{B8860B}    % numeric literals — goldenrod
+\definecolor{cmt}{HTML}{C75300}    % comments — orange
+\renewcommand{\isakeywordONE}[1]{\textcolor{cmd}{\textbf{#1}}}     % theorem/lemma/definition
+\renewcommand{\isakeywordTWO}[1]{\textcolor{kw}{\textbf{#1}}}      % proof/qed/by
+\renewcommand{\isakeywordTHREE}[1]{\textcolor{ty}{\textbf{#1}}}    % where/assumes/shows
+\renewcommand{\isakeyword}[1]{\textcolor{kw}{\textbf{#1}}}         % if/then/else/let/in
+\renewcommand{\isadigit}[1]{\textcolor{lit}{#1}}
+\renewcommand{\isamarkupcmt}[1]{\textcolor{cmt}{\textit{#1}}}
+
+% AutoCorrode uses \<Zsurj> heavily; isabellesym renders it as \mathrel{\rightsquigarrow},
+% which clashes with the \itshape applied inside [fragile] beamer frames.
+% Provide a safe text-mode rendering.
+\providecommand{\isasymZsurj}{\ensuremath{\rightsquigarrow}}
+\renewcommand{\isasymZsurj}{\ensuremath{\rightsquigarrow}}
+
+% Interlude frame dressing: full-height orange bars hugging the left and
+% right page edges, plus a large 5-point star badge with "INTERLUDE"
+% inside, pinned to the upper-right corner. \begin{frame}/\end{frame} are
+% emitted literally by Slides.thy's `interlude`/`end_interlude` outer
+% syntax (beamer's [fragile] scanner requires the close to be a literal
+% token); \interludetop just paints the overlay.
+\newcommand{\interludetop}{%
+  \begin{tikzpicture}[remember picture, overlay]
+    % Full-height vertical bars on each page edge.
+    \fill[cmt] ([xshift=0mm]current page.north west)
+      rectangle ([xshift=1.25mm]current page.south west);
+    \fill[cmt] ([xshift=-1.25mm]current page.north east)
+      rectangle ([xshift=0mm]current page.south east);
+    % Subtle multi-point star: rounder overall, gentle starriness.
+    \node[star, star points=10, star point ratio=1.18,
+          fill=cmt, draw=cmt, line width=0.3mm,
+          text=white, font=\tiny\bfseries\sffamily,
+          minimum size=14mm, inner sep=0pt,
+          xshift=-9mm, yshift=-9mm]
+      at (current page.north east) {INTERLUDE};
+  \end{tikzpicture}%
+  % An [overlay] tikzpicture should take zero vertical space, but
+  % Isabelle's text_raw context emits paragraph glue afterwards. Pull
+  % the first body line back up so it sits flush with the frametitle.
+  \vskip-\baselineskip\vskip-1mm%
+}
+\newcommand{\interludebottom}{}
+
+% Drop theory/imports/begin/end boilerplate from the slides.
+\isadroptag{theory}
+
+% Drop proof bodies entirely — no <proof> placeholder, no vertical space,
+% no trailing newline. Same trick as for %internal blocks below.
+\isadroptag{proof}
+
+% Drop helper material tagged %internal.
+\isadroptag{internal}
+
+% Opt-in: a single step tagged %visible overrides the default %proof drop
+% for that one command, so its body is shown in the slide.
+\isakeeptag{visible}
+
+% After \isadroptag{...}, the comment package leaves \isadelim<tag> /
+% \endisadelim<tag> tokens around each dropped block. These are no-ops by
+% default but cause the slide to keep the surrounding \isanewline tokens,
+% leaving a blank line where the dropped block was. Override the delim
+% macros to swallow following newlines so the elision is invisible.
+\makeatletter
+\def\isabelle@swallow@nl{%
+  \@ifnextchar\isanewline
+    {\expandafter\isabelle@swallow@nl\@gobble}
+    {}}
+\@namedef{isadelimproof}{\isabelle@swallow@nl}
+\@namedef{endisadelimproof}{\isabelle@swallow@nl}
+\@namedef{isadeliminternal}{\isabelle@swallow@nl}
+\@namedef{endisadeliminternal}{\isabelle@swallow@nl}
+\makeatother
+
+% Allow long Isabelle identifiers to break at underscores inside frames.
+\def\BreakableUnderscore{\discretionary{\textunderscore}{}{\textunderscore}}
+\renewcommand{\isacharunderscore}{\BreakableUnderscore}
+\renewcommand{\isacharunderscorekeyword}{\BreakableUnderscore}
+
+% Slide framing is driven entirely from .thy files via the outer-syntax
+% commands defined in Slides.thy:
+%   start_slides   ─ emits a sacrificial \begin{frame} (suppressed via <0>)
+%   slide ‹Title›  ─ emits \end{frame}\begin{frame}[fragile]{Title}
+%   end_slides     ─ emits the closing \end{frame}
+%
+% \section/\chapter are illegal inside beamer frames, so we strip Isabelle's
+% heading commands.  Use beamer's own \section{...} in this root.tex (between
+% \input lines) if you want a navigation-bar entry.
+\renewcommand{\isamarkupchapter}[1]{}
+\renewcommand{\isamarkupsection}[1]{}
+\renewcommand{\isamarkupsubsection}[1]{}
+\renewcommand{\isamarkupsubsubsection}[1]{}
+
+% Beamer theme
+\usetheme{metropolis}
+
+% Default metropolis sets the gap between frametitle and body very tight;
+% give the body a little room to breathe.
+\addtobeamertemplate{frametitle}{}{\vspace{2mm}}
+% Fall back to a built-in theme if metropolis isn't installed:
+% \usetheme{Madrid}
+
+% metropolis: emit a section divider page automatically when \section{...}
+% is used between slides.
+\AtBeginSection[]{
+  \begin{frame}[plain,noframenumbering]
+    \sectionpage
+  \end{frame}
+}
+
+\title{AutoCorrode}
+\subtitle{Tutorial and Experimentation Ground}
+\author{Hanno Becker}
+\institute{Amazon Web Services}
+\date{}
+
+\begin{document}
+
+\maketitle
+
+\input{Tutorial_Preamble.tex}
+
+\input{Tutorial_Context.tex}
+
+\input{Tutorial_Agenda.tex}
+
+\section{HOL-Light \texorpdfstring{$\leftrightarrow$}{<->} Isabelle cheat-sheet}
+\input{Tutorial_Glossary.tex}
+
+\section{Monads}
+\input{Tutorial_Monads.tex}
+
+\section{Hoare logic and weakest preconditions}
+\input{Tutorial_HoareSetup.tex}
+
+\input{Tutorial_HoareWorked.tex}
+
+\section{Separation logic}
+\input{Tutorial_SLWorked.tex}
+
+\end{document}


### PR DESCRIPTION
Add an `AutoCorrodeTutorial` session under `tutorial/` that builds a Beamer slide deck from formally-checked `Tutorial_*.thy` sources. Topics: HOL-Light ↔ Isabelle glossary, monads, Hoare logic and weakest preconditions, separation logic. To be continued.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
