### PR TITLE
[I/Q] write_file: surface real status to the caller

### DIFF
--- a/iq/Makefile
+++ b/iq/Makefile
@@ -80,6 +80,10 @@ test: build $(TEST_CLASSES_DIR)/.compiled
 	JAVA_HOME="$(JAVA_HOME)" PATH="$(JAVA_HOME)/bin:$$PATH" $(SCALA) \
 		-classpath "$(TEST_RUN_CLASSPATH)" \
 		IQUISettingsTest
+	echo "Running I/Q scope resolution tests..."
+	JAVA_HOME="$(JAVA_HOME)" PATH="$(JAVA_HOME)/bin:$$PATH" $(SCALA) \
+		-classpath "$(TEST_RUN_CLASSPATH)" \
+		IQScopeResolutionTest
 	echo "Running I/Q bridge framing tests..."
 	python3 -m unittest discover -s test -p 'test_*.py'
 	echo "I/Q tests passed."

--- a/iq/src/IQProtocol.scala
+++ b/iq/src/IQProtocol.scala
@@ -118,6 +118,43 @@ object DiagnosticsScope {
     }
 }
 
+/**
+ * write_file's check_context_scope parameter. Controls how widely the
+ * wait/recheck window extends around the inserted text. The 'commands'
+ * array stays scoped to the inserted text in every case; the scope only
+ * widens what we wait on and what gets reflected in file_summary timing.
+ *
+ * - Command: just the inserted text.
+ * - Block:   the innermost enclosing 'proof ... qed' (the current proof
+ *            layer). If the edit isn't inside any 'proof' keyword (e.g. a
+ *            bare 'lemma … by …', or a lemma statement before its proof
+ *            block), falls back to the surrounding lemma/theorem block and
+ *            is reported as Proof.
+ * - Proof:   the OUTERMOST enclosing 'proof ... qed' (the entire proof of
+ *            the enclosing lemma). For an edit inside a non-nested proof,
+ *            Block and Proof coincide; inside a nested proof, Proof is
+ *            strictly wider than Block. For edits outside any 'proof' it is
+ *            the surrounding lemma/theorem block (same fallback as Block).
+ * - File:    the whole theory.
+ */
+enum CheckContextScope(val wire: String) {
+  case Command extends CheckContextScope("command")
+  case Block   extends CheckContextScope("block")
+  case Proof   extends CheckContextScope("proof")
+  case File    extends CheckContextScope("file")
+}
+
+object CheckContextScope {
+  private val byWire: Map[String, CheckContextScope] =
+    CheckContextScope.values.map(value => value.wire -> value).toMap
+
+  def fromWire(raw: String): Either[String, CheckContextScope] =
+    byWire.get(raw.trim.toLowerCase(java.util.Locale.ROOT)) match {
+      case Some(value) => Right(value)
+      case None => Left(raw)
+    }
+}
+
 object IQProtocol {
   final case class JsonRpcRequest(
     method: String,

--- a/iq/src/IQScopeResolution.scala
+++ b/iq/src/IQScopeResolution.scala
@@ -1,0 +1,218 @@
+/* Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+   SPDX-License-Identifier: MIT */
+
+/**
+ * Pure logic for resolving write_file's check_context_scope to an offset
+ * range over a (post-edit) command stream. Kept free of PIDE / jEdit
+ * dependencies so it can be unit-tested via the regular `make test`
+ * runner without spinning up an Isabelle session.
+ *
+ * The wrapper in IQServer (resolveCheckContextWindow) translates a real
+ * Document.Snapshot into the small ScopeCommand stubs this module
+ * accepts and delegates the actual walk to resolveScope below.
+ */
+object IQScopeResolution {
+
+  /** Minimal projection of a PIDE Command needed by the scope walk. */
+  final case class ScopeCommand(name: String, offset: Int, length: Int)
+
+  // Block-starting keywords. Mirror of IQServer's ProofBlockStarters,
+  // duplicated here on purpose so this module stays free of any
+  // dependency on the IQServer class.
+  val Starters: Set[String] =
+    Set("lemma", "theorem", "corollary", "proposition", "schematic_goal", "proof")
+
+  // Goal-completing keywords. Useful as a set, but NOT all interchangeable
+  // for proof-depth bookkeeping: only 'qed' pairs with 'proof'. The others
+  // close the most recent goal (the lemma's outer goal in 'lemma … by/
+  // sorry/oops/done', or a sub-goal inside an Isar body).
+  val StructuralEnders: Set[String] =
+    Set("qed", "done", "sorry", "oops")
+
+  /**
+   * Resolve a check-context scope to an offset range against the given
+   * command stream and edit position. Returns
+   *   (scopeStart, scopeEnd, resolvedScope)
+   * where the offsets are in the post-edit content and resolvedScope
+   * reflects any degradation:
+   *
+   * - Block: the innermost enclosing 'proof…qed' (the current proof layer).
+   * - Proof: the OUTERMOST enclosing 'proof…qed' (the entire proof of the
+   *   enclosing lemma). For an edit inside a non-nested proof, Block and
+   *   Proof coincide; inside a nested proof, Proof is strictly wider.
+   * - Block or Proof requested with no enclosing 'proof' at all (e.g. a
+   *   bare 'lemma … by …', or a lemma statement before its proof block):
+   *   resolves to the surrounding lemma/theorem block and reports Proof.
+   * - Block or Proof requested but no enclosing block at all, or the
+   *   block we pin to the edit-start doesn't cover editEnd: degrades
+   *   to Command.
+   * - Command and File pass through unchanged.
+   */
+  def resolveScope(
+      commands: IndexedSeq[ScopeCommand],
+      contentLength: Int,
+      editStart: Int,
+      editEnd: Int,
+      scope: CheckContextScope
+  ): (Int, Int, CheckContextScope) = {
+    if (scope == CheckContextScope.Command) return (editStart, editEnd, scope)
+    if (scope == CheckContextScope.File)    return (0, contentLength, scope)
+
+    if (commands.isEmpty) return (editStart, editEnd, CheckContextScope.Command)
+
+    // Anchor on the command containing the start of the edit; the forward
+    // walk below extends the resolved block past editEnd whenever needed
+    // (it stops only at a balanced structural ender), so the start anchor
+    // alone is sufficient for the common cases. Edits that straddle a
+    // structural boundary (one whose end falls outside the block we pin
+    // to its start) hit the coverage guard further down and degrade to
+    // scope=command.
+    def indexAt(offset: Int): Int = {
+      val clamped = math.max(0, math.min(offset, contentLength - 1))
+      commands.indexWhere(c => clamped >= c.offset && clamped < c.offset + c.length)
+    }
+    val startIdx = indexAt(editStart)
+    if (startIdx < 0) return (editStart, editEnd, CheckContextScope.Command)
+
+    // Walk back from `from` to find an enclosing 'proof' that is open at
+    // the edit position. Depth-aware: a 'qed' we cross while walking back
+    // must already have been opened by a 'proof' further back, so
+    // increment `depth` on 'qed' and decrement on 'proof'; a 'proof' is a
+    // true ancestor only when depth == 0 when we reach it. This avoids
+    // latching onto a previous sibling's already-closed 'proof…qed'.
+    //
+    // Pairing rule: 'proof' pairs ONLY with 'qed'. 'by', 'done', 'sorry'
+    // and 'oops' are GOAL closers, not 'proof' closers — they terminate
+    // the lemma's outer goal in a 'lemma … by/sorry/oops' shape, or close
+    // a sub-goal (have/show) inside an Isar proof body. Counting them as
+    // 'proof' closers here would wrongly cancel out the very enclosing
+    // 'proof' we are looking for, e.g. for an edit anchored after an
+    // inner 'by simp' or 'sorry' inside a proof body — see
+    // testInnerByDoesNotShadowEnclosingProof and
+    // testInnerSorryDoesNotShadowEnclosingProof.
+    //
+    // Sibling `lemma … by …` chains are handled by failure: this walk
+    // returns -1 (no enclosing 'proof' found) and the caller falls back
+    // to findOuterStarter, which gives the surrounding lemma block
+    // reported as scope_resolved=Proof.
+    def findInnerProof(from: Int): Int = {
+      var i = from
+      var depth = 0
+      while (i >= 0) {
+        val kw = commands(i).name
+        if (kw == "qed") {
+          depth += 1
+        } else if (kw == "proof") {
+          if (depth == 0) return i
+          depth -= 1
+        }
+        i -= 1
+      }
+      -1
+    }
+    // Walk back to the OUTERMOST enclosing 'proof' that is open at the edit
+    // position -- the start of the entire proof of the enclosing lemma.
+    // Same depth-aware bookkeeping as findInnerProof ('qed' increments,
+    // 'proof' at depth 0 is an ancestor, a balanced 'proof' decrements),
+    // but instead of returning the first ancestor 'proof' we keep walking
+    // and remember the last one seen at depth 0. Because ancestor 'proof's
+    // nest, the last depth-0 'proof' encountered walking back is the
+    // outermost. Closed sibling 'proof…qed' pairs balance out via the depth
+    // counter and are correctly skipped. Returns -1 when the edit is not
+    // inside any 'proof' (e.g. a bare `lemma … by …` or a lemma statement
+    // before its proof block), in which case the caller falls back to the
+    // surrounding lemma/theorem block.
+    def findOutermostProof(from: Int): Int = {
+      var i = from
+      var depth = 0
+      var result = -1
+      while (i >= 0) {
+        val kw = commands(i).name
+        if (kw == "qed") {
+          depth += 1
+        } else if (kw == "proof") {
+          if (depth == 0) result = i
+          else depth -= 1
+        }
+        i -= 1
+      }
+      result
+    }
+    // Walk back to the closest enclosing ProofBlockStarter -- including
+    // 'proof' itself. Used as the fallback for both 'block' and 'proof'
+    // when the edit is not inside any 'proof' body: it yields the
+    // surrounding lemma/theorem block.
+    def findOuterStarter(from: Int): Int = {
+      var i = from
+      while (i >= 0) {
+        if (Starters.contains(commands(i).name)) return i
+        i -= 1
+      }
+      -1
+    }
+
+    // Starter selection by scope:
+    //   - Block: the innermost enclosing 'proof' (the current proof layer).
+    //   - Proof: the outermost enclosing 'proof' (the entire lemma proof).
+    // Both fall back to the surrounding lemma/theorem starter when the edit
+    // is not inside any 'proof' body.
+    val starterIdx = {
+      val proofIdx = scope match {
+        case CheckContextScope.Block => findInnerProof(startIdx)
+        case CheckContextScope.Proof => findOutermostProof(startIdx)
+        case _ => -1
+      }
+      if (proofIdx >= 0) proofIdx else findOuterStarter(startIdx)
+    }
+    if (starterIdx < 0) return (editStart, editEnd, CheckContextScope.Command)
+
+    // Walk forward to the matching block end. Two cases by starter kind:
+    //
+    // Starter == "proof": match its 'qed' by tracking nested 'proof's.
+    // 'by/done/sorry/oops' inside the body close sub-goals (have/show),
+    // not the proof block itself, so they're skipped at any depth.
+    //
+    // Starter == lemma/theorem/etc.: terminate at the lemma's outer
+    // closer at depth 0. That can be 'by'/'done'/'sorry'/'oops' (no
+    // proof block), or the matching 'qed' of an inner 'proof' block.
+    // Inside a 'proof' body (depth >= 1), 'by/done/sorry/oops' close
+    // sub-goals and are skipped; only the balancing 'qed' (which brings
+    // depth back to 0) terminates the lemma.
+    val starterIsProof = commands(starterIdx).name == "proof"
+    var depth = 0
+    var j = starterIdx
+    var foundEnd = false
+    while (j < commands.length && !foundEnd) {
+      val kw = commands(j).name
+      if (kw == "proof") {
+        depth += 1
+      } else if (kw == "qed") {
+        if (depth <= 1) foundEnd = true
+        else depth -= 1
+      } else if (!starterIsProof && depth == 0
+          && (kw == "by" || kw == "done" || kw == "sorry" || kw == "oops")) {
+        foundEnd = true
+      }
+      j += 1
+    }
+    val endCmdIdx = if (foundEnd) j - 1 else commands.length - 1
+
+    val blockStart = commands(starterIdx).offset
+    val blockEnd = commands(endCmdIdx).offset + commands(endCmdIdx).length
+
+    // If the resolved block doesn't actually cover the edit (degenerate
+    // case), fall back to `command` semantics.
+    if (blockStart > editStart || blockEnd < editEnd) {
+      return (editStart, editEnd, CheckContextScope.Command)
+    }
+
+    // For 'block' with no enclosing 'proof', the walk above degraded to
+    // the outer lemma/theorem block: report that as 'proof' so the
+    // caller knows.
+    val resolved =
+      if (scope == CheckContextScope.Block && commands(starterIdx).name != "proof")
+        CheckContextScope.Proof
+      else scope
+    (math.min(editStart, blockStart), math.max(editEnd, blockEnd), resolved)
+  }
+}

--- a/iq/src/IQServer.scala
+++ b/iq/src/IQServer.scala
@@ -1577,7 +1577,15 @@ class IQServer(
       ),
       Map(
         "name" -> "write_file",
-        "description" -> "Write or modify content in an Isabelle theory file. Supports replacement and text insertion. Returns the status of commands affected by the edit, and statistics on how many commands where successful/failed/canceled/unprocessed.",
+        "description" -> ("Write or modify content in an Isabelle theory file. Supports replacement and text insertion. " +
+          "Returns three siblings: 'commands' lists the Isabelle commands inside the inserted text with per-command status; " +
+          "'edit_summary' aggregates that range, the edit metadata (bytes_written, new_line_count), " +
+          "the range-scoped counts (commands_affected, edits_failed, edits_finished, edits_canceled, edits_unprocessed), " +
+          "and 'scope_resolved' (the actual check_context_scope used after any degradation); " +
+          "'file_summary' is theory-scoped (total_commands, commands_failed, commands_finished, " +
+          "commands_unprocessed, any_canceled, errors, warnings, fully_processed, consolidated). " +
+          "An edit reporting edits_failed=0 may still leave the file with file_summary.errors > 0 if commands outside the inserted range broke. " +
+          "Use 'check_context_scope' to widen what wait_until_processed waits on (e.g. 'proof' to also recheck the enclosing lemma)."),
         "inputSchema" -> Map(
           "type" -> "object",
           "properties" -> Map(
@@ -1628,6 +1636,17 @@ class IQServer(
             "timeout_per_command" -> Map(
               "type" -> "integer",
               "description" -> "Per-command running grace period in milliseconds when wait_until_processed=true. Default: 5000."
+            ),
+            "check_context_scope" -> Map(
+              "type" -> "string",
+              "description" -> ("How widely to wait/recheck around the inserted text. " +
+                "'command': just the inserted text. " +
+                "'block' (default): the innermost enclosing 'proof ... qed' (the current proof layer); if the edit is outside any 'proof' keyword the resolver falls back to the surrounding lemma/theorem block and reports scope_resolved=proof. " +
+                "'proof': the outermost enclosing 'proof ... qed' (the entire proof of the enclosing lemma). Inside a non-nested proof this coincides with 'block'; inside a nested proof it is strictly wider. For edits outside any 'proof' it is the surrounding lemma/theorem block. " +
+                "'file': the whole theory. " +
+                "Only affects how long write_file blocks; the 'commands' array stays scoped to the inserted text. " +
+                "If the edit isn't inside any structured block, 'block' and 'proof' degrade to 'command'."),
+              "enum" -> List("command", "block", "proof", "file")
             )
           ),
           "required" -> List("path", "command"),
@@ -2420,6 +2439,24 @@ class IQServer(
     val (startOffset, endOffset) =
       IQLineOffsetUtils.normalizeOffsetRange(startOffsetRaw, endOffsetRaw, content.length)
 
+    // Optional widened wait range: callers (currently only handleWriteFile)
+    // can ask the wait loop to settle a range broader than the one reported
+    // in `commands`. The reported range stays [startOffset, endOffset).
+    val waitStartOffsetOpt = IQArgumentUtils.optionalIntParam(params, "wait_start_offset") match {
+      case Right(v) => v
+      case Left(err) => return Left(err)
+    }
+    val waitEndOffsetOpt = IQArgumentUtils.optionalIntParam(params, "wait_end_offset") match {
+      case Right(v) => v
+      case Left(err) => return Left(err)
+    }
+    val (waitStartOffset, waitEndOffset) =
+      IQLineOffsetUtils.normalizeOffsetRange(
+        waitStartOffsetOpt.getOrElse(startOffset),
+        waitEndOffsetOpt.getOrElse(endOffset),
+        content.length
+      )
+
     val waitUntilProcessed = params.get("wait_until_processed") match {
       case Some(value: Boolean) => value
       case _ => false
@@ -2451,7 +2488,7 @@ class IQServer(
 
     def retrieveStatuses(): List[CommandStatusSummary] = {
       val snapshot = PIDE.session.snapshot(node_name = node_name)
-      getCommandStatusesInOffsetRange(snapshot, node_name, startOffset, endOffset)
+      getCommandStatusesInOffsetRange(snapshot, node_name, waitStartOffset, waitEndOffset)
     }
 
     def allStatusesProcessed(statuses: List[CommandStatusSummary]): Boolean =
@@ -3409,6 +3446,18 @@ class IQServer(
       case Left(err) => return Left(err)
     }
 
+    val checkContextScope: CheckContextScope = params.get("check_context_scope") match {
+      case Some(value: String) if value.trim.nonEmpty =>
+        CheckContextScope.fromWire(value.trim) match {
+          case Right(decoded) => decoded
+          case Left(raw) =>
+            return Left(s"Unknown check_context_scope '$raw'. Expected one of: command, block, proof, file")
+        }
+      case Some(_) =>
+        return Left("Invalid parameter 'check_context_scope': expected string")
+      case None => CheckContextScope.Block
+    }
+
     // Lookup buffer associated with file
     // We currently require that the file is opened in jEdit
     val (content, buffer_model) = getBufferModel(filePath) match {
@@ -3505,7 +3554,10 @@ class IQServer(
 
     Output.writeln(s"I/Q Server: Auto-calling get_command for modified range in $filePath")
 
-    val newEndOffset: Int = endOffset + text.length
+    val newEndOffset: Int = startOffset + text.length
+    val newContent = getFileContent(filePath).getOrElse("")
+    val (waitStartOffset, waitEndOffset, scopeResolved) =
+      resolveCheckContextWindow(buffer_model, newContent, startOffset, newEndOffset, checkContextScope)
 
     // Create parameters for get_command call - use current command mode for now
     val getCommandParams = scala.collection.mutable.Map[String, Any](
@@ -3513,6 +3565,8 @@ class IQServer(
       "mode" -> "offset",
       "start_offset" -> startOffset,
       "end_offset" -> newEndOffset,
+      "wait_start_offset" -> waitStartOffset,
+      "wait_end_offset" -> waitEndOffset,
       "wait_until_processed" -> waitUntilProcessed,
       "timeout" -> timeoutMs.getOrElse(5000L),
       "timeout_per_command" -> timeoutPerCommandMs.getOrElse(5000)
@@ -3524,19 +3578,39 @@ class IQServer(
       case Left(err) => return Left(f"handleGetCommandCore failed with $err")
     }
 
-    // Enhance summary with line count and bytes written
-    val newContent = getFileContent(filePath).getOrElse("")
     val newLineCount = IQLineOffsetUtils.splitLines(newContent).length
     val bytesWritten = text.getBytes("UTF-8").length
-    val linesAffected = math.abs(newEndOffset - startOffset)
-    
-    val enhancedSummary = coreResult.summary ++ Map(
-      "new_line_count" -> newLineCount,
+
+    // edit_summary describes the edit and how the commands inside the
+    // inserted range fared. file_summary is theory-scoped so the caller
+    // sees the state of the whole file, not just the edit window.
+    val rangeSummary = coreResult.summary
+    def rangeCount(key: String): Int = rangeSummary.get(key) match {
+      case Some(v: Int) => v
+      case Some(v: Long) => v.toInt
+      case _ => 0
+    }
+    val editSummary = Map[String, Any](
       "bytes_written" -> bytesWritten,
-      "lines_affected" -> linesAffected
+      "new_line_count" -> newLineCount,
+      "commands_affected" -> rangeCount("total_commands"),
+      "edits_failed" -> rangeCount("commands_failed"),
+      "edits_finished" -> rangeCount("commands_finished"),
+      "edits_canceled" -> rangeCount("commands_canceled"),
+      "edits_unprocessed" -> rangeCount("commands_unprocessed"),
+      "scope_resolved" -> scopeResolved.wire
     )
 
-    Right(Map("commands" -> coreResult.commandsData, "summary" -> enhancedSummary))
+    // Refresh post-edit content for file_summary, since wait may have
+    // updated processing state.
+    val postWaitContent = getFileContent(filePath).getOrElse(newContent)
+    val fileSummary = buildFileSummary(buffer_model, postWaitContent)
+
+    Right(Map(
+      "commands" -> coreResult.commandsData,
+      "edit_summary" -> editSummary,
+      "file_summary" -> fileSummary
+    ))
   }
 
   private def openFileCommon(
@@ -5295,6 +5369,133 @@ end"""
         }
       case _ => Left(s"File not tracked: $filePath")
     }
+  }
+
+  /**
+   * Resolve a check-context scope to an offset range in the post-edit
+   * content. The returned range is the union of the inserted text and the
+   * surrounding scope. The second component of the result is the actually
+   * resolved scope, which may degrade (e.g. 'block' or 'proof' falls back
+   * to 'command' if the edit isn't inside any structured block, or to the
+   * smallest containing block we can pin down).
+   *
+   * The block walk reuses the same keyword-tracking logic as
+   * extractProofBlockAtIndex: ProofBlockStarters open a level, ProofBlock
+   * StructuralEnders (and `by` at depth 0) close one. 'block' returns the
+   * innermost enclosing 'proof ... qed' (the current proof layer); 'proof'
+   * returns the outermost enclosing 'proof ... qed' (the entire lemma
+   * proof). When the edit is inside no 'proof' body, both fall back to the
+   * enclosing 'lemma ... qed/by'.
+   */
+  private def resolveCheckContextWindow(
+      model: Document_Model,
+      content: String,
+      editStart: Int,
+      editEnd: Int,
+      scope: CheckContextScope
+  ): (Int, Int, CheckContextScope) = {
+    if (scope == CheckContextScope.Command) return (editStart, editEnd, scope)
+    if (scope == CheckContextScope.File)    return (0, content.length, scope)
+
+    val node_name = model.node_name
+    val snapshot = PIDE.session.snapshot(node_name = node_name)
+    val node = snapshot.get_node(node_name)
+    if (node == null) return (editStart, editEnd, CheckContextScope.Command)
+
+    // Project the post-edit command stream into a small PIDE-free shape
+    // and delegate the actual walk to IQScopeResolution. The shape and
+    // semantics are covered by the unit tests in
+    // iq/test/IQScopeResolutionTest.scala -- avoid duplicating the walk
+    // here.
+    val stubs: IndexedSeq[IQScopeResolution.ScopeCommand] =
+      node.command_iterator()
+        .map { case (cmd, off) =>
+          IQScopeResolution.ScopeCommand(cmd.span.name, off, cmd.length)
+        }
+        .toIndexedSeq
+
+    IQScopeResolution.resolveScope(stubs, content.length, editStart, editEnd, scope)
+  }
+
+  /**
+   * Build a theory-scoped summary of the current state of a file: command
+   * counts in PIDE states (failed/finished/canceled/unprocessed), error and
+   * warning diagnostic counts across the whole file, and processing flags
+   * (fully_processed, consolidated). Used by handleWriteFile so its response
+   * tells the agent the state of the entire theory, not just the edited
+   * range.
+   */
+  private def buildFileSummary(model: Document_Model, content: String): Map[String, Any] = {
+    val node_name = model.node_name
+    val snapshot = PIDE.session.snapshot(node_name = node_name)
+    val state = snapshot.state
+    val version = snapshot.version
+
+    // PIDE counts every command, including the whitespace/comment "filler"
+    // commands between real ones, so Node_Status.total is roughly twice the
+    // number of meaningful commands. Iterate ourselves and tally only
+    // commands whose source has any non-whitespace content -- this matches
+    // the trimming policy of the `commands` array
+    // (see handleGetCommandCore -> commandInfosTrimmed) and keeps the
+    // file_summary numbers consistent with what the user actually sees.
+    var failed = 0
+    var canceled = false
+    var finished = 0
+    var unprocessed = 0
+    var total = 0
+    var anyTerminated = true
+    val node = snapshot.get_node(node_name)
+    val commandIter =
+      if (node == null) Iterator.empty else node.commands.iterator
+    for (command <- commandIter if command.source.trim.nonEmpty) {
+      val cs = state.command_status(version, command)
+      total += 1
+      if (cs.is_failed) failed += 1
+      else if (cs.is_running || cs.is_unprocessed) unprocessed += 1
+      else if (cs.is_finished || cs.is_warned) finished += 1
+      // A command that is none of the above is not accepted yet: PIDE has
+      // not assigned it execution state in this document version (e.g. the
+      // post-edit invalidation window, where downstream commands of the new
+      // version briefly have accepted=false, touched=false). is_unprocessed
+      // short-circuits on accepted=false and so misses it; PIDE's own
+      // Node_Status.make defaults this state to unprocessed too. Counting it
+      // as finished would over-report progress, so default to unprocessed.
+      // (is_failed stays first above so a failed-but-still-running command is
+      // reported as failed, not unprocessed.)
+      else unprocessed += 1
+      if (cs.is_canceled) canceled = true
+      if (!cs.is_terminated) anyTerminated = false
+    }
+
+    val errorCount =
+      collectDiagnosticsInRange(
+        snapshot,
+        Text.Range(0, content.length),
+        DiagnosticsSeverity.Error,
+        None
+      ).length
+    val warningCount =
+      collectDiagnosticsInRange(
+        snapshot,
+        Text.Range(0, content.length),
+        DiagnosticsSeverity.Warning,
+        None
+      ).length
+
+    val node_status =
+      Document_Status.Node_Status.make(Date.now(), state, version, node_name)
+
+    Map(
+      "total_commands" -> total,
+      "commands_failed" -> failed,
+      "commands_finished" -> finished,
+      "commands_unprocessed" -> unprocessed,
+      "any_canceled" -> canceled,
+      "errors" -> errorCount,
+      "warnings" -> warningCount,
+      "fully_processed" -> (anyTerminated && unprocessed == 0),
+      "consolidated" -> node_status.consolidated
+    )
   }
 
   /**

--- a/iq/test/IQScopeResolutionTest.scala
+++ b/iq/test/IQScopeResolutionTest.scala
@@ -1,0 +1,539 @@
+/* Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+   SPDX-License-Identifier: MIT */
+
+import IQScopeResolution.ScopeCommand
+
+object IQScopeResolutionTest {
+  private def requireThat(condition: Boolean, message: String): Unit = {
+    if (!condition) throw new RuntimeException(message)
+  }
+
+  /**
+   * Helper: build a command stream from a list of (keyword, source) pairs,
+   * laying them out contiguously in offset space starting at 0. Returns
+   * the stream plus the total content length, which the resolver uses for
+   * bounds clamping and for the File scope.
+   */
+  private def stream(pairs: (String, String)*): (IndexedSeq[ScopeCommand], Int) = {
+    var offset = 0
+    val cmds = pairs.toIndexedSeq.map { case (kw, src) =>
+      val c = ScopeCommand(kw, offset, src.length)
+      offset += src.length
+      c
+    }
+    (cmds, offset)
+  }
+
+  /**
+   * Convenience: given the (kw, src) pairs and an anchor source string,
+   * resolve the scope at exactly that command's range.
+   */
+  private def resolveAt(
+      pairs: List[(String, String)],
+      anchorSrc: String,
+      scope: CheckContextScope
+  ): (Int, Int, CheckContextScope) = {
+    val (cmds, total) = stream(pairs *)
+    val anchor = cmds.find(c => pairs(cmds.indexWhere(_ eq c))._2 == anchorSrc)
+      .orElse {
+        // Fallback: match by source via the layout
+        var off = 0
+        var found: Option[ScopeCommand] = None
+        pairs.foreach { case (kw, src) =>
+          if (found.isEmpty && src == anchorSrc) found = Some(ScopeCommand(kw, off, src.length))
+          off += src.length
+        }
+        found
+      }
+      .getOrElse(sys.error(s"no command with src=$anchorSrc"))
+    IQScopeResolution.resolveScope(cmds, total, anchor.offset, anchor.offset + anchor.length, scope)
+  }
+
+  /**
+   * Resolve at the command at the given pairs-index. Use this when the
+   * anchor source string is not unique in the stream (resolveAt picks
+   * first match, which is order-dependent and brittle).
+   */
+  private def resolveAtIndex(
+      pairs: List[(String, String)],
+      anchorIdx: Int,
+      scope: CheckContextScope
+  ): (Int, Int, CheckContextScope) = {
+    val (cmds, total) = stream(pairs *)
+    val anchor = cmds(anchorIdx)
+    IQScopeResolution.resolveScope(cmds, total, anchor.offset, anchor.offset + anchor.length, scope)
+  }
+
+  // ---------- Scenario 1: edit inside a proof…qed body ----------
+
+  private def testInsideProofQed(): Unit = {
+    // lemma A: ... proof - have h: ... by simp thus ?thesis . qed
+    val pairs = List(
+      "lemma" -> "lemma A: \"P\"",
+      "proof" -> "proof -",
+      "have"  -> "have h: \"P\"",
+      "by"    -> "by simp",
+      "thus"  -> "thus ?thesis",
+      "."     -> ".",
+      "qed"   -> "qed"
+    )
+    val (s, e, r) = resolveAt(pairs, "have h: \"P\"", CheckContextScope.Block)
+    requireThat(r == CheckContextScope.Block,
+      s"edit at have inside proof…qed should resolve as Block, got $r")
+    // The scope range should cover proof…qed fully.
+    val (cmds, _) = stream(pairs *)
+    val proofStart = cmds.find(_.name == "proof").get.offset
+    val qedEnd = { val q = cmds.findLast(_.name == "qed").get; q.offset + q.length }
+    requireThat(s <= proofStart && e >= qedEnd,
+      s"Block scope should cover proof($proofStart)..qed($qedEnd), got [$s, $e)")
+  }
+
+  // ---------- Scenario 2: edit inside a `lemma … by …` (no proof block) ----------
+
+  private def testInsideLemmaBy(): Unit = {
+    val pairs = List(
+      "lemma" -> "lemma A: \"P\"",
+      "by"    -> "by simp"
+    )
+    // Edit at the `by` itself with Block.
+    val (s, e, r) = resolveAt(pairs, "by simp", CheckContextScope.Block)
+    requireThat(r == CheckContextScope.Proof,
+      s"edit inside lemma…by should resolve to Proof (lemma block), got $r")
+    val (cmds, _) = stream(pairs *)
+    val lemmaStart = cmds.find(_.name == "lemma").get.offset
+    val byEnd = { val b = cmds.find(_.name == "by").get; b.offset + b.length }
+    requireThat(s == lemmaStart && e == byEnd,
+      s"Proof scope should cover lemma..by, got [$s, $e)")
+  }
+
+  // ---------- Scenario 3: edit at lemma statement after a sibling proof…qed ----------
+
+  private def testAfterSiblingProofQed(): Unit = {
+    // lemma A: ... proof - by simp thus . qed   lemma B: ... by simp
+    val pairs = List(
+      "lemma" -> "lemma A: \"P\"",
+      "proof" -> "proof -",
+      "have"  -> "have h: \"P\"",
+      "by"    -> "by simp",
+      "thus"  -> "thus ?thesis",
+      "."     -> ".",
+      "qed"   -> "qed",
+      "lemma" -> "lemma B: \"Q\"",   // edit anchor
+      "by"    -> "by simp"
+    )
+    val (s, e, r) = resolveAt(pairs, "lemma B: \"Q\"", CheckContextScope.Block)
+    // Previously this latched onto the prior `proof` and degenerated to
+    // command. Depth-aware walk-back must instead recognise the
+    // closed-out sibling and resolve to lemma B's own block.
+    requireThat(r == CheckContextScope.Proof,
+      s"edit at lemma statement after sibling proof…qed should resolve to Proof, got $r")
+    val (cmds, _) = stream(pairs *)
+    val lemmaBStart = cmds.findLast(_.name == "lemma").get.offset
+    requireThat(s == lemmaBStart,
+      s"scope start should be lemma B (offset $lemmaBStart), got $s")
+  }
+
+  // ---------- Scenario 4: edit between two lemmas (top-level, no enclosing block) ----------
+
+  private def testTopLevelBetweenLemmas(): Unit = {
+    val pairs = List(
+      "lemma" -> "lemma A: \"P\"",
+      "by"    -> "by simp",
+      ""      -> "(* between *)",   // pseudo top-level command
+      "lemma" -> "lemma B: \"Q\"",
+      "by"    -> "by simp"
+    )
+    val (s, e, r) = resolveAt(pairs, "(* between *)", CheckContextScope.Block)
+    requireThat(r == CheckContextScope.Command,
+      s"edit between lemmas at top level should degrade to Command, got $r")
+    val (cmds, _) = stream(pairs *)
+    val between = cmds.find(_.name == "").get
+    requireThat(s == between.offset && e == between.offset + between.length,
+      s"degraded scope range should equal the edit range")
+  }
+
+  // ---------- Scenario 5: depth-2 nested proof…qed ----------
+
+  private def testDeepNested(): Unit = {
+    val pairs = List(
+      "lemma" -> "lemma A: \"P\"",
+      "proof" -> "proof -",            // outer
+      "have"  -> "have outer: \"P\"",
+      "proof" -> "proof -",            // inner
+      "have"  -> "have inner: \"P\"",  // edit anchor
+      "by"    -> "by simp",
+      "thus"  -> "thus ?thesis",
+      "."     -> ".",
+      "qed"   -> "qed",                // closes inner
+      "thus"  -> "thus ?thesis",
+      "."     -> ".",
+      "qed"   -> "qed"                 // closes outer
+    )
+    val (s, e, r) = resolveAt(pairs, "have inner: \"P\"", CheckContextScope.Block)
+    requireThat(r == CheckContextScope.Block,
+      s"edit at depth 2 with Block should resolve to Block (innermost), got $r")
+    val (cmds, _) = stream(pairs *)
+    // The innermost proof is at index 3, the matching qed at index 8.
+    val innerProofStart = cmds.zipWithIndex.collect { case (c, 3) => c.offset }.head
+    val innerQedEnd = {
+      val q = cmds.zipWithIndex.collect { case (c, 8) => c }.head
+      q.offset + q.length
+    }
+    requireThat(s == innerProofStart && e == innerQedEnd,
+      s"Block at depth 2 should cover the inner proof…qed, got [$s, $e)")
+  }
+
+  // ---------- Scenario 6: scope=command and scope=file pass-through ----------
+
+  private def testPassThrough(): Unit = {
+    val pairs = List(
+      "lemma" -> "lemma A: \"P\"",
+      "by"    -> "by simp"
+    )
+    val (cmds, total) = stream(pairs *)
+    val anchor = cmds.head
+    val (cs, ce, cr) =
+      IQScopeResolution.resolveScope(cmds, total, anchor.offset, anchor.offset + anchor.length, CheckContextScope.Command)
+    requireThat(cr == CheckContextScope.Command, "Command should pass through")
+    requireThat(cs == anchor.offset && ce == anchor.offset + anchor.length,
+      "Command should not widen the range")
+
+    val (fs, fe, fr) =
+      IQScopeResolution.resolveScope(cmds, total, anchor.offset, anchor.offset + anchor.length, CheckContextScope.File)
+    requireThat(fr == CheckContextScope.File, "File should pass through")
+    requireThat(fs == 0 && fe == total,
+      "File should widen to the whole content")
+  }
+
+  // ---------- Scenario 7: empty command stream degrades cleanly ----------
+
+  private def testEmptyStream(): Unit = {
+    val (s, e, r) =
+      IQScopeResolution.resolveScope(IndexedSeq.empty, 0, 0, 0, CheckContextScope.Block)
+    requireThat(r == CheckContextScope.Command,
+      "Empty command stream with Block must degrade to Command")
+    requireThat(s == 0 && e == 0, "degraded range must equal edit range")
+  }
+
+  // ---------- Scenario 8: scope=Proof on edit inside a NON-nested proof ----------
+  //
+  // Contract: 'proof' resolves to the OUTERMOST enclosing proof…qed. In a
+  // single-layer proof the innermost layer IS the outermost, so 'block' and
+  // 'proof' coincide here and both cover the one proof…qed. The nested case
+  // where they diverge (proof ⊋ block) is pinned by Scenarios 14-16.
+
+  private def testProofScopeFromInsideBody(): Unit = {
+    val pairs = List(
+      "lemma" -> "lemma A: \"P\"",
+      "proof" -> "proof -",
+      "have"  -> "have h: \"P\"",   // edit anchor
+      "by"    -> "by simp",
+      "thus"  -> "thus ?thesis",
+      "."     -> ".",
+      "qed"   -> "qed"
+    )
+    val (s, e, r) = resolveAt(pairs, "have h: \"P\"", CheckContextScope.Proof)
+    requireThat(r == CheckContextScope.Proof,
+      s"Proof scope from inside body should resolve to Proof, got $r")
+    val (cmds, _) = stream(pairs *)
+    val proofStart = cmds.find(_.name == "proof").get.offset
+    val qedEnd = { val q = cmds.find(_.name == "qed").get; q.offset + q.length }
+    requireThat(s == proofStart && e == qedEnd,
+      s"Proof inside a non-nested proof body covers that proof..qed, got [$s, $e)")
+  }
+
+  // ---------- Scenario 9: edits across multiple sibling lemmas walk-back gracefully ----------
+
+  private def testManySiblingBys(): Unit = {
+    // Several `lemma … by …` sequences, then an edit at the next lemma stmt.
+    val pairs = List(
+      "lemma" -> "lemma A: \"P\"", "by" -> "by simp",
+      "lemma" -> "lemma B: \"Q\"", "by" -> "by simp",
+      "lemma" -> "lemma C: \"R\"", "by" -> "by simp",
+      "lemma" -> "lemma D: \"S\""    // edit anchor
+    )
+    val (_, _, r) = resolveAt(pairs, "lemma D: \"S\"", CheckContextScope.Block)
+    requireThat(r == CheckContextScope.Proof,
+      s"edit at lemma D after many sibling bys should resolve to Proof, got $r")
+  }
+
+  // ---------- Scenario 10: anchor INSIDE a nested proof body, AFTER an inner `by` ----------
+  //
+  // Regression: previously findInnerProof treated a top-level 'by' as a
+  // closer. Walking back from `thus ?thesis` through the inner `by simp`
+  // would push the depth counter to 1, then the inner `proof` would
+  // decrement back to 0 and fail to return — silently latching onto the
+  // OUTER proof instead. scope_resolved still reported Block, so the
+  // caller had no way to detect the silent widening.
+  //
+  // Fix: 'by' (like 'sorry'/'oops'/'done') is a goal closer, not a
+  // 'proof' closer. Only 'qed' pairs with 'proof'.
+
+  private def testInnerByDoesNotShadowEnclosingProof(): Unit = {
+    val pairs = List(
+      "lemma" -> "lemma N05: \"P\"",
+      "proof" -> "proof -",            // OUTER proof   (idx 1)
+      "have"  -> "have outer: \"P\"",
+      "proof" -> "proof -",            // INNER proof   (idx 3)
+      "have"  -> "have inner: \"P\"",
+      "by"    -> "by simp",
+      "thus"  -> "thus ?thesis",       // <-- edit anchor (idx 6, after inner `by`)
+      "."     -> ".",
+      "qed"   -> "qed",                // closes inner  (idx 8)
+      "thus"  -> "thus ?thesis",       // (duplicate source — anchor by index, not source)
+      "."     -> ".",
+      "qed"   -> "qed"                 // closes outer
+    )
+    val anchorIdx = 6
+    val innerProofIdx = 3
+    val innerQedIdx = 8
+    val (s, e, r) = resolveAtIndex(pairs, anchorIdx, CheckContextScope.Block)
+    requireThat(r == CheckContextScope.Block,
+      s"edit after inner `by` in nested proof should resolve as Block (innermost), got $r")
+    val (cmds, _) = stream(pairs *)
+    val innerProofStart = cmds(innerProofIdx).offset
+    val innerQedEnd = cmds(innerQedIdx).offset + cmds(innerQedIdx).length
+    requireThat(s == innerProofStart && e == innerQedEnd,
+      s"resolver should latch onto the INNER proof…qed [$innerProofStart, $innerQedEnd), got [$s, $e)")
+  }
+
+  // ---------- Scenario 11: anchor inside a proof body, AFTER a sub-goal `sorry` ----------
+  //
+  // Regression: previously findInnerProof and the forward walk both
+  // treated 'sorry' as a 'proof'-paired closer (because it was in the
+  // StructuralEnders set, and the walks branched on that set). Walking
+  // back from `thus ?thesis` through a sub-goal `sorry` would push depth
+  // to 1; the enclosing 'proof' would decrement to 0 and not return —
+  // silently latching one level out. The forward walk had a mirror flaw:
+  // it would terminate at the inner 'sorry' rather than the matching
+  // 'qed', producing a too-narrow block that failed the coverage guard
+  // and degraded scope to Command.
+  //
+  // Fix: 'sorry' (like 'oops'/'done'/'by') is a goal closer, not a
+  // 'proof' closer. Only 'qed' pairs with 'proof'.
+
+  private def testInnerSorryDoesNotShadowEnclosingProof(): Unit = {
+    val pairs = List(
+      "lemma" -> "lemma S",
+      "proof" -> "proof -",            // (idx 1)
+      "have"  -> "have h: \"P\"",
+      "sorry" -> "sorry",               // sub-goal admitted
+      "thus"  -> "thus ?thesis",       // <-- edit anchor (idx 4)
+      "."     -> ".",
+      "qed"   -> "qed"                  // (idx 6)
+    )
+    val anchorIdx = 4
+    val proofIdx = 1
+    val qedIdx = 6
+    val (s, e, r) = resolveAtIndex(pairs, anchorIdx, CheckContextScope.Block)
+    requireThat(r == CheckContextScope.Block,
+      s"edit after sub-goal sorry should resolve as Block, got $r")
+    val (cmds, _) = stream(pairs *)
+    val proofStart = cmds(proofIdx).offset
+    val qedEnd = cmds(qedIdx).offset + cmds(qedIdx).length
+    requireThat(s == proofStart && e == qedEnd,
+      s"Block scope should cover proof…qed, got [$s, $e) expected [$proofStart, $qedEnd)")
+  }
+
+  // ---------- Scenario 12: anchor inside a proof body containing a sub-goal `done` ----------
+  //
+  // 'done' typically closes an apply-script's outer goal but can also
+  // appear inside an Isar proof body to close a sub-goal whose proof
+  // was given as an apply-script. Same conceptual issue as sorry.
+
+  private def testInnerDoneDoesNotShadowEnclosingProof(): Unit = {
+    val pairs = List(
+      "lemma" -> "lemma D",
+      "proof" -> "proof -",            // (idx 1)
+      "have"  -> "have h: \"P\"",
+      "apply" -> "apply x",
+      "done"  -> "done",                // sub-goal closed by apply-script
+      "thus"  -> "thus ?thesis",       // <-- edit anchor (idx 5)
+      "."     -> ".",
+      "qed"   -> "qed"                  // (idx 7)
+    )
+    val anchorIdx = 5
+    val proofIdx = 1
+    val qedIdx = 7
+    val (s, e, r) = resolveAtIndex(pairs, anchorIdx, CheckContextScope.Block)
+    requireThat(r == CheckContextScope.Block,
+      s"edit after sub-goal done should resolve as Block, got $r")
+    val (cmds, _) = stream(pairs *)
+    val proofStart = cmds(proofIdx).offset
+    val qedEnd = cmds(qedIdx).offset + cmds(qedIdx).length
+    requireThat(s == proofStart && e == qedEnd,
+      s"Block scope should cover proof…qed, got [$s, $e) expected [$proofStart, $qedEnd)")
+  }
+
+  // ---------- Scenario 13: lemma-style starter still terminates at 'sorry' ----------
+  //
+  // The conceptual fix says only 'qed' pairs with 'proof'. But for a
+  // lemma-style starter (no enclosing 'proof' block), 'sorry' at depth 0
+  // legitimately closes the lemma's outer goal and so terminates the
+  // forward walk. This pins that the special-casing is on the STARTER
+  // kind, not just on the keyword.
+
+  private def testLemmaSorryAtDepthZeroTerminates(): Unit = {
+    val pairs = List(
+      "lemma" -> "lemma A",
+      "sorry" -> "sorry"
+    )
+    val anchorIdx = 0
+    val (s, e, r) = resolveAtIndex(pairs, anchorIdx, CheckContextScope.Block)
+    requireThat(r == CheckContextScope.Proof,
+      s"lemma A: sorry with Block should degrade to Proof (lemma block), got $r")
+    val (cmds, _) = stream(pairs *)
+    val expectedStart = cmds(0).offset
+    val expectedEnd = cmds(1).offset + cmds(1).length
+    requireThat(s == expectedStart && e == expectedEnd,
+      s"Proof scope should cover lemma..sorry, got [$s, $e) expected [$expectedStart, $expectedEnd)")
+  }
+
+  // ===================================================================
+  // Block-vs-Proof scope contract (Scenarios 14-16).
+  //
+  // The contract:
+  //   - 'block' = the CURRENT (innermost) proof layer.
+  //   - 'proof' = the ENTIRE proof of the enclosing lemma, i.e. the
+  //               OUTERMOST enclosing proof…qed (the whole lemma proof).
+  //
+  // Inside a nested proof, 'proof' is strictly wider than 'block'; inside a
+  // non-nested proof the two coincide. These pin that contract against
+  // regression (it was previously collapsed: 'proof' resolved to the
+  // innermost proof, the same as 'block').
+  // ===================================================================
+
+  // ---------- Scenario 14: nested proof, edit in inner body ----------
+  //
+  // 'block' must cover the INNER proof…qed; 'proof' must cover the OUTER
+  // (entire) proof…qed. The two ranges must therefore DIFFER: proof ⊋ block.
+
+  private def testProofWidensToOutermostNested(): Unit = {
+    val pairs = List(
+      "lemma" -> "lemma A: \"P\"",
+      "proof" -> "proof -",            // OUTER  (idx 1)
+      "have"  -> "have outer: \"P\"",
+      "proof" -> "proof -",            // INNER  (idx 3)
+      "have"  -> "have inner: \"P\"",  // <-- edit anchor (idx 4)
+      "by"    -> "by simp",
+      "thus"  -> "thus ?thesis",
+      "."     -> ".",
+      "qed"   -> "qed",                // closes INNER (idx 8)
+      "thus"  -> "thus ?thesis",
+      "."     -> ".",
+      "qed"   -> "qed"                 // closes OUTER (idx 11)
+    )
+    val (cmds, _) = stream(pairs *)
+    val outerProofStart = cmds(1).offset
+    val outerQedEnd = cmds(11).offset + cmds(11).length
+    val innerProofStart = cmds(3).offset
+    val innerQedEnd = cmds(8).offset + cmds(8).length
+
+    // 'block' = inner layer (this already holds today).
+    val (bs, be, br) = resolveAtIndex(pairs, 4, CheckContextScope.Block)
+    requireThat(br == CheckContextScope.Block, s"block should resolve to Block, got $br")
+    requireThat(bs == innerProofStart && be == innerQedEnd,
+      s"block should cover INNER proof…qed [$innerProofStart,$innerQedEnd), got [$bs,$be)")
+
+    // 'proof' = entire (outer) proof.
+    val (ps, pe, pr) = resolveAtIndex(pairs, 4, CheckContextScope.Proof)
+    requireThat(pr == CheckContextScope.Proof,
+      s"Scenario 14: proof scope should report Proof, got $pr")
+    requireThat(ps == outerProofStart && pe == outerQedEnd,
+      s"Scenario 14: 'proof' should widen to the ENTIRE (outer) proof…qed " +
+      s"[$outerProofStart,$outerQedEnd) but got [$ps,$pe) " +
+      s"(must not collapse onto the inner proof…qed [$innerProofStart,$innerQedEnd))")
+    requireThat(ps < innerProofStart || pe > innerQedEnd,
+      s"Scenario 14: 'proof' range must be strictly WIDER than 'block' range; " +
+      s"got proof=[$ps,$pe) block=[$bs,$be)")
+  }
+
+  // ---------- Scenario 15: depth-3 nesting ----------
+  //
+  // 'block' = innermost layer; 'proof' = outermost layer, regardless of
+  // how deep the edit sits.
+
+  private def testProofWidensToOutermostDepth3(): Unit = {
+    val pairs = List(
+      "lemma" -> "lemma A: \"P\"",
+      "proof" -> "proof -",             // L1 outer   (idx 1)
+      "have"  -> "have h1: \"P\"",
+      "proof" -> "proof -",             // L2         (idx 3)
+      "have"  -> "have h2: \"P\"",
+      "proof" -> "proof -",             // L3 inner   (idx 5)
+      "have"  -> "have h3: \"P\"",      // <-- edit anchor (idx 6)
+      "by"    -> "by simp",
+      "thus"  -> "thus ?thesis",
+      "."     -> ".",
+      "qed"   -> "qed",                 // closes L3   (idx 10)
+      "thus"  -> "thus ?thesis",
+      "."     -> ".",
+      "qed"   -> "qed",                 // closes L2   (idx 13)
+      "thus"  -> "thus ?thesis",
+      "."     -> ".",
+      "qed"   -> "qed"                  // closes L1   (idx 16)
+    )
+    val (cmds, _) = stream(pairs *)
+    val outerStart = cmds(1).offset
+    val outerEnd = cmds(16).offset + cmds(16).length
+    val innerStart = cmds(5).offset
+    val innerEnd = cmds(10).offset + cmds(10).length
+
+    val (bs, be, _) = resolveAtIndex(pairs, 6, CheckContextScope.Block)
+    requireThat(bs == innerStart && be == innerEnd,
+      s"block at depth 3 should cover innermost proof…qed [$innerStart,$innerEnd), got [$bs,$be)")
+
+    val (ps, pe, _) = resolveAtIndex(pairs, 6, CheckContextScope.Proof)
+    requireThat(ps == outerStart && pe == outerEnd,
+      s"Scenario 15: 'proof' at depth 3 should widen to the OUTERMOST proof…qed " +
+      s"[$outerStart,$outerEnd), got [$ps,$pe)")
+  }
+
+  // ---------- Scenario 16: single-layer proof — block and proof coincide ----------
+  //
+  // With no nesting, the current and innermost layers ARE the outermost
+  // layer, so block and proof legitimately produce the same range. This
+  // pins that the intended fix does NOT over-widen in the common case.
+
+  private def testProofEqualsBlockSingleLayer(): Unit = {
+    val pairs = List(
+      "lemma" -> "lemma A: \"P\"",
+      "proof" -> "proof -",
+      "have"  -> "have h: \"P\"",   // edit anchor (idx 2)
+      "by"    -> "by simp",
+      "thus"  -> "thus ?thesis",
+      "."     -> ".",
+      "qed"   -> "qed"
+    )
+    val (bs, be, _) = resolveAtIndex(pairs, 2, CheckContextScope.Block)
+    val (ps, pe, pr) = resolveAtIndex(pairs, 2, CheckContextScope.Proof)
+    requireThat(pr == CheckContextScope.Proof,
+      s"Scenario 16: single-layer proof scope should report Proof, got $pr")
+    requireThat(bs == ps && be == pe,
+      s"Scenario 16: with no nesting, 'block' and 'proof' must coincide; " +
+      s"got block=[$bs,$be) proof=[$ps,$pe)")
+  }
+
+  def main(args: Array[String]): Unit = {
+    testInsideProofQed()
+    testInsideLemmaBy()
+    testAfterSiblingProofQed()
+    testTopLevelBetweenLemmas()
+    testDeepNested()
+    testPassThrough()
+    testEmptyStream()
+    testProofScopeFromInsideBody()
+    testManySiblingBys()
+    testInnerByDoesNotShadowEnclosingProof()
+    testInnerSorryDoesNotShadowEnclosingProof()
+    testInnerDoneDoesNotShadowEnclosingProof()
+    testLemmaSorryAtDepthZeroTerminates()
+
+    // Block-vs-Proof scope contract.
+    testProofWidensToOutermostNested()
+    testProofWidensToOutermostDepth3()
+    testProofEqualsBlockSingleLayer()
+
+    println("IQScopeResolutionTest: all tests passed")
+  }
+}


### PR DESCRIPTION
**Symptom:** write_file frequently reported success while the file still had errors. After an inline str_replace, the response array silently dropped the adjacent `by ...`, so a broken proof method right next to the edit looked like a clean run. And even when the local edit was clean, an upstream change that invalidated proofs further down produced no signal at all — the agent saw commands_failed: 0 and moved on while the file was full of errors.

Two distinct **causes:**

(a) Functional bug: the post-edit query range was off-by-many for str_replace, so the very command adjacent to the edit was missed.

(b) API/documentation issue: the response keys (commands_failed, total_commands, ...) read as theory-scoped but were only ever counted inside the inserted range. Cascading failures had nowhere to surface, and the wording gave callers no reason to suspect that. The shape of the return value was inviting misinterpretation.

**Fix:** correct the post-edit range, and split the response into a range-scoped edit_summary (with renamed keys: edits_failed, edits_finished, ...) plus a theory-scoped file_summary (commands_failed, errors, warnings, fully_processed, consolidated) so each number's scope is unambiguous from its parent key. A new check_context_scope parameter (command|block|proof|file) lets the caller widen what wait_until_processed waits on, so an edit inside a proof can have the rest of the proof rechecked before the response returns.
