### PR TITLE
Revert addition of `& raw mut` and `& raw const` syntax

### DIFF
--- a/Micro_Rust_Parsing_Frontend/Micro_Rust_Syntax.thy
+++ b/Micro_Rust_Parsing_Frontend/Micro_Rust_Syntax.thy
@@ -189,10 +189,10 @@ syntax
   "_urust_numeral_ascription_usize" :: "num_const \<Rightarrow> urust"
     ("_'_usize")
   \<comment> \<open>Breakpoints\<close>
-  "_urust_pause" :: "urust" 
+  "_urust_pause" :: "urust"
     ("\<y>\<i>\<e>\<l>\<d>")
   \<comment> \<open>Logging\<close>
-  "_urust_log" :: "'value \<Rightarrow> 'value \<Rightarrow> urust" 
+  "_urust_log" :: "'value \<Rightarrow> 'value \<Rightarrow> urust"
     ("\<l>\<o>\<g> \<llangle>_\<rrangle> \<llangle>_\<rrangle>")
   \<comment> \<open>The special unit value\<close>
   "_urust_unit" :: "urust"
@@ -550,10 +550,6 @@ syntax
     ("&_" [200]100)
   "_urust_borrow_mut" :: \<open>urust \<Rightarrow> urust\<close>
     ("& mut _" [200]100)
-  "_urust_raw_ptr_const" :: \<open>urust \<Rightarrow> urust\<close>
-    ("& raw const _" [200]100)
-  "_urust_raw_ptr_mut" :: \<open>urust \<Rightarrow> urust\<close>
-    ("& raw mut _" [200]100)
   "_urust_deref" :: \<open>urust \<Rightarrow> urust\<close>
     ("*_" [200]100)
   "_urust_double_deref" :: \<open>urust \<Rightarrow> urust\<close>
@@ -1003,9 +999,9 @@ parse_ast_translation\<open>
       end;
 
     \<comment> \<open>Split the \<^verbatim>\<open>_path_builder\<close> syntax representation of \<^verbatim>\<open>foo::bar.zoo.far\<close> into \<^verbatim>\<open>("foo::bar", ["zoo", "far"])\<close>\<close>
-    fun split_path_n_field 
+    fun split_path_n_field
       (Ast.Appl [Ast.Constant \<^syntax_const>\<open>_path_builder_two_longid\<close>, Ast.Variable secondlast, last]) =
-        let 
+        let
           val (tailhead, tailtail) = split_longid last
         in
           (secondlast ^ "::" ^ tailhead, tailtail)
@@ -1101,7 +1097,7 @@ parse_ast_translation\<open>
                AST in a meaningful way, and keep it as is.
                The problem is now that this will give a very poor error message, so add some logging\<close>
             let
-              val _ = writeln "Error: detected match with mixed numeral and constructors" 
+              val _ = writeln "Error: detected match with mixed numeral and constructors"
             in
               \<^syntax_const>\<open>_urust_temporary_match\<close>
             end

--- a/Shallow_Micro_Rust/Micro_Rust_Shallow_Embedding.thy
+++ b/Shallow_Micro_Rust/Micro_Rust_Shallow_Embedding.thy
@@ -100,7 +100,7 @@ fun replace_string (pattern: string) (replacement: string) (original: string)  =
     let
         val original_size = String.size original
         val pattern_size = String.size pattern
-        
+
         fun loop start acc =
             if start > original_size - pattern_size
             then String.concat (List.rev (String.extract(original, start, NONE) :: acc))
@@ -144,7 +144,7 @@ ML\<open>
      end)
 
      val remove_colons = String.translate (fn #":" => "" | c => String.str c)
-     val is_path_notation = remove_colons #> Symbol_Pos.is_identifier 
+     val is_path_notation = remove_colons #> Symbol_Pos.is_identifier
 
      (* Path notation *)
      fun custom_path_notation_nano_rust hol_identifier nano_rust_name thy: local_theory =
@@ -441,7 +441,7 @@ translations
   "_shallow (_urust_struct_expr id fields)"
     \<rightharpoonup> "_shallow (_urust_funcall_with_args (_urust_callable_id id) (_urust_struct_expr_to_args fields))"
   "_shallow (_urust_array_expr_empty)"
-    \<rightharpoonup> "CONST literal ([])" 
+    \<rightharpoonup> "CONST literal ([])"
   "_shallow (_urust_array_expr args)"
     \<rightharpoonup> "_urust_array_expr_to_shallow args"
   "_urust_array_expr_to_shallow (_urust_args_single a)"
@@ -566,10 +566,6 @@ translations
     \<rightharpoonup> "CONST bindlift1 (CONST ro_ref_from_ref) (_shallow exp)"
   "_shallow (_urust_borrow_mut exp)"
     \<rightharpoonup> "CONST bindlift1 (CONST mut_ref_from_ref) (_shallow exp)"
-  "_shallow (_urust_raw_ptr_const exp)"
-    \<rightharpoonup> "CONST bindlift1 (CONST ref_address) (_shallow exp)"
-  "_shallow (_urust_raw_ptr_mut exp)"
-    \<rightharpoonup> "CONST bindlift1 (CONST ref_address) (_shallow exp)"
   "_shallow (_urust_deref exp)"
     \<rightharpoonup> "_urust_shallow_store_dereference (_shallow exp)"
 

--- a/Shallow_Micro_Rust/Micro_Rust_Shallow_Embedding_Tests.thy
+++ b/Shallow_Micro_Rust/Micro_Rust_Shallow_Embedding_Tests.thy
@@ -1861,8 +1861,6 @@ term \<open>\<lbrakk> unimplemented!("not done: {} {}", idx, idx) \<rbrakk>\<clo
 term \<open>\<lbrakk> todo!("implement: {}", idx) \<rbrakk>\<close>
 term \<open>\<lbrakk> addr_of!(r) \<rbrakk>\<close>
 term \<open>\<lbrakk> addr_of_mut!(r) \<rbrakk>\<close>
-term \<open>\<lbrakk> & raw const r \<rbrakk>\<close>
-term \<open>\<lbrakk> & raw mut r \<rbrakk>\<close>
 end
 
 subsubsection\<open>Logging\<close>


### PR DESCRIPTION
This syntax addition leads to `raw` and `mut` being registered as tokens in the shared lexer for uRust and HOL. In consequence, it breaks consumers of AutoCorrode that happen to use any of `raw`, `mut` or `const` as identifiers.

Until a better solution is found, revert the change.