### PR TITLE
uRust: table-backed notation command and qualified-path support

### DIFF
--- a/Autogen/AutoLens.thy
+++ b/Autogen/AutoLens.thy
@@ -441,7 +441,6 @@ ML\<open>
     val code_eq_prop_str = "Rep_focus " ^ focus ^ " = make_focus_raw " ^
            "(\<lambda>s. Some (" ^ rec_name ^ "." ^ field ^ " s))" ^
            "(\<lambda>y. " ^ rec_name_full ^ ".update_" ^ field ^ "(\<lambda>_. y))"
-    val _ = code_eq_prop_str |> tracing
     val code_eq_prop = code_eq_prop_str |> Syntax.read_prop ctxt
     val prop_name = focus ^ "_code"
     fun after_qed name thms ctxt = ctxt

--- a/Micro_Rust_Parsing_Frontend/Micro_Rust_Syntax.thy
+++ b/Micro_Rust_Parsing_Frontend/Micro_Rust_Syntax.thy
@@ -38,7 +38,7 @@ identifiers. We intentionally avoid a wildcard identifier to keep pattern parsin
 
 text\<open>HOL identifiers can be used as Micro Rust identifiers:\<close>
 syntax
-  "_urust_identifier_id" :: \<open>id \<Rightarrow> urust_identifier\<close>
+  "_urust_identifier_id" :: \<open>id_position \<Rightarrow> urust_identifier\<close>
     ("_" [0]1000)
 
 text\<open>The following are intermediate syntax categories required for the definition of \<^text>\<open>urust\<close>.\<close>
@@ -363,10 +363,11 @@ syntax
     ("_._" [99,1000]100)
   "_urust_index" :: \<open>urust \<Rightarrow> urust \<Rightarrow> urust\<close>
     ("_/ '[_']" [100,0]100)
-  \<comment> \<open>Path identifiers (e.g. \<^verbatim>\<open>Foo::Bar\<close>), with the \<^verbatim>\<open>string_token\<close> containing the full path.
-      We will add parse AST transformations to construct these below.\<close>
-  "_urust_path_string_identifier" :: \<open>string_token \<Rightarrow> urust_identifier\<close>
-    ("URUST'_PATH'_STRING'_IDENTIFIER _")
+  \<comment> \<open>Path identifiers (e.g. \<^verbatim>\<open>Foo::Bar\<close>) used to have a dedicated
+      \<^verbatim>\<open>_urust_path_string_identifier\<close> syntax slot. After AST flattening
+      they are now indistinguishable from plain identifiers (the joined
+      name --- including the \<^verbatim>\<open>::\<close> separators --- lands in
+      \<^verbatim>\<open>_urust_identifier_id\<close>), so the dedicated slot has been retired.\<close>
 
   \<comment>\<open>Other control flow constructs\<close>
   "_urust_for_loop"
@@ -699,7 +700,7 @@ nonterminal urust_temporary_long_identifier
 syntax
   \<comment>\<open>Mark those as temporary to indicate that semantics definitions need not deal with it.
 It is immediately removed after parsing.\<close>
-  "_urust_temporary_long_id" :: \<open>longid \<Rightarrow> urust_temporary_long_identifier\<close>
+  "_urust_temporary_long_id" :: \<open>longid_position \<Rightarrow> urust_temporary_long_identifier\<close>
     ("_" [0]1000)
 
   \<comment>\<open>Allow long ids in a few grammar productions normally taking ordinary identifiers\<close>
@@ -759,10 +760,54 @@ ML\<open>
      fst (splitter (Symbol.explode str))
    end
 
+  (* Extract the bare identifier name from an AST that is either a bare
+     Ast.Variable or an id_position/longid_position-wrapped
+     Ast.Appl [Ast.Constant "_constrain", Ast.Variable _, Ast.Variable _]. *)
+  fun ast_var_name (Ast.Variable s) = s
+    | ast_var_name (Ast.Appl [Ast.Constant "_constrain", Ast.Variable s, _]) = s
+    | ast_var_name ast = raise Ast.AST ("ast_var_name", [ast])
+
+  (* Split a (possibly position-tagged) longid AST at "." into a list of
+     id_position-shaped AST components. Each component carries its own
+     sub-position so that IDE markup highlights each part of foo.bar.boo
+     separately. Inputs without position info yield bare Ast.Variable parts. *)
+  fun split_longid_ast (Ast.Variable s) =
+        map Ast.Variable (split_at_dots s)
+    | split_longid_ast (Ast.Appl [Ast.Constant "_constrain",
+                                  Ast.Variable s,
+                                  Ast.Variable enc]) =
+        let
+          val parts = split_at_dots s
+          val ps = Term_Position.decode enc
+          val (use_syntax, pos0) =
+            case ps of
+              {syntax, pos} :: _ => (syntax, pos)
+            | [] => (false, Position.none)
+          val mk_tag =
+            if use_syntax then Term_Position.syntax else Term_Position.no_syntax
+          fun step part pos =
+            let
+              val pos_end = Position.symbol_explode part pos
+              val sub_pos = Position.range_position (pos, pos_end)
+              val pos_after_dot = Position.symbol_explode "." pos_end
+              val sub_enc = Term_Position.encode [mk_tag sub_pos]
+            in
+              (Ast.Appl [Ast.Constant "_constrain",
+                         Ast.Variable part,
+                         Ast.Variable sub_enc],
+               pos_after_dot)
+            end
+          fun loop [] _ = []
+            | loop (p :: ps') pos =
+                let val (a, pos') = step p pos in a :: loop ps' pos' end
+        in loop parts pos0 end
+    | split_longid_ast ast = raise Ast.AST ("split_longid_ast", [ast])
+
+  (* Legacy string-only splitter for callers that already have a string in hand. *)
   val split_long_identifier = Ast.pretty_ast #> Pretty.string_of #> split_at_dots
 
-  fun ast_urust_identifier_id str =
-     Ast.mk_appl (Ast.Constant \<^syntax_const>\<open>_urust_identifier_id\<close>) [Ast.Variable str]
+  fun ast_urust_identifier_id ast =
+     Ast.mk_appl (Ast.Constant \<^syntax_const>\<open>_urust_identifier_id\<close>) [ast]
 \<close>
 
 text\<open>Lower slice patterns to nested list constructor patterns:
@@ -818,11 +863,12 @@ end
 
 parse_ast_translation\<open>
 let
-  \<comment>\<open>ML representations of the relevant Nano Rust grammar productions\<close>
-  \<comment>\<open>This does currently only work for long identifiers of the form \<^text>\<open>id.id\<close>.\<close>
+  \<comment>\<open>ML representations of the relevant Micro Rust grammar productions\<close>
+  \<comment>\<open>Splits a longid AST at \".\" while preserving sub-positions, so that each
+     component of \<^verbatim>\<open>foo.bar.boo\<close> carries its own markup.\<close>
   fun break_long_identifier [long_id] =
-     let val parts = long_id |> split_long_identifier
-         val parts_as_ids = map (ast_urust_identifier_id) parts
+     let val parts = split_longid_ast long_id
+         val parts_as_ids = map ast_urust_identifier_id parts
      in Ast.Appl parts_as_ids end
   | break_long_identifier args =
      Ast.mk_appl (Ast.Constant \<^syntax_const>\<open>_urust_temporary_long_id\<close>) args
@@ -935,20 +981,21 @@ nonterminal path_identifier \<comment> \<open>An identifier of the form \<^verba
 nonterminal path_identifier_long \<comment> \<open>An identifier of the form \<^verbatim>\<open>foo::bar.boo\<close>\<close>
 
 syntax
-  "_path_builder_two_id" :: \<open>id \<Rightarrow> id \<Rightarrow> path_identifier\<close>
+  "_path_builder_two_id" :: \<open>id_position \<Rightarrow> id_position \<Rightarrow> path_identifier\<close>
     ("_':': _"[0,0]1000)
-  "_path_builder_more" :: \<open>id \<Rightarrow> path_identifier \<Rightarrow> path_identifier\<close>
+  "_path_builder_more" :: \<open>id_position \<Rightarrow> path_identifier \<Rightarrow> path_identifier\<close>
     ("_':': _"[0,1000]1000)
-  \<comment> \<open>We will transform \<^verbatim>\<open>_urust_temporary_path_identifier\<close> into \<^verbatim>\<open>_urust_path_string_identifier\<close>,
-     where the string token contains the string representation of the \<^verbatim>\<open>path_identifier\<close> argument\<close>
+  \<comment> \<open>A parse AST translation flattens \<^verbatim>\<open>_urust_temporary_path_identifier\<close>
+     into an ordinary \<^verbatim>\<open>_urust_identifier_id\<close> whose name is the \<^verbatim>\<open>::\<close>-joined
+     path (see the translation below).\<close>
   "_urust_temporary_path_identifier" :: \<open>path_identifier \<Rightarrow> urust_identifier\<close>
     ("_")
 
   \<comment> \<open>Unfortunately, we need to do a bit more work to support \<^verbatim>\<open>foo::bar.boo\<close>. The \<^verbatim>\<open>bar.boo\<close> is
       a \<^verbatim>\<open>longid\<close> that is the last argument of the implicit list of type \<^verbatim>\<open>path_identifier_long\<close>.\<close>
-  "_path_builder_two_longid" :: \<open>id \<Rightarrow> longid \<Rightarrow> path_identifier_long\<close>
+  "_path_builder_two_longid" :: \<open>id_position \<Rightarrow> longid_position \<Rightarrow> path_identifier_long\<close>
     ("_':': _"[0,0]1000)
-  "_path_builder_more_longid" :: \<open>id \<Rightarrow> path_identifier_long \<Rightarrow> path_identifier_long\<close>
+  "_path_builder_more_longid" :: \<open>id_position \<Rightarrow> path_identifier_long \<Rightarrow> path_identifier_long\<close>
     ("_':': _"[0,1000]1000)
   \<comment> \<open>Such \<^emph>\<open>long\<close> paths are not \<^verbatim>\<open>urust_identifier\<close>s: they indicate method or field accesses
       of a path. In other words, \<^verbatim>\<open>foo::bar.boo\<close> must be parsed as \<^verbatim>\<open>(foo::bar).boo\<close>. We
@@ -960,28 +1007,105 @@ syntax
     ("_")
 
 text\<open>When the AST is initially built, we get a \<^verbatim>\<open>_urust_temporary_path_identifier\<close> with a
-\<^verbatim>\<open>path_identifier\<close> argument. We will convert that argument to a \<^verbatim>\<open>string_token\<close>, which makes it
-easier to parse that in a later stage to a term. That means we must turn the
-\<^verbatim>\<open>_urust_temporary_path_identifier\<close> into a \<^verbatim>\<open>_urust_path_string_identifier\<close>\<close>
+\<^verbatim>\<open>path_identifier\<close> argument. We join its segments with \<^verbatim>\<open>::\<close> and rewrite the whole node to an
+ordinary \<^verbatim>\<open>_urust_identifier_id\<close> carrying that joined name, so paths and plain identifiers
+flow through the same downstream pipeline.\<close>
 parse_ast_translation\<open>
   let
-    fun path_arg_to_rust_name
-        (Ast.Appl [Ast.Constant \<^syntax_const>\<open>_path_builder_two_id\<close>, Ast.Variable secondlast, Ast.Variable last]) =
-            secondlast ^ "::" ^ last
-      | path_arg_to_rust_name
-        (Ast.Appl [Ast.Constant \<^syntax_const>\<open>_path_builder_more\<close>, Ast.Variable head, tail]) =
-            head ^ "::" ^ path_arg_to_rust_name tail;
-    fun path_translator grammar_el ctx args =
+    \<comment>\<open>Extract \<open>(name, [position])\<close> from a single \<^verbatim>\<open>id_position\<close>-shaped AST
+       segment. Bare \<^verbatim>\<open>Ast.Variable\<close> entries (no source-position info) yield
+       \<open>[]\<close>. Position-tagged segments yield \<open>[{syntax, pos}]\<close> via
+       \<^ML>\<open>Term_Position.decode\<close>.\<close>
+    fun ast_var_name_pos (Ast.Variable s) = (s, [])
+      | ast_var_name_pos
+            (Ast.Appl [Ast.Constant "_constrain", Ast.Variable s, Ast.Variable enc]) =
+          (s, Term_Position.decode enc)
+      | ast_var_name_pos ast = raise Ast.AST ("ast_var_name_pos", [ast]);
+
+    \<comment>\<open>Walk the \<^verbatim>\<open>_path_builder_*\<close> tree, collecting per-segment
+       \<open>(name, [position])\<close> pairs in source order.\<close>
+    fun path_segments
+        (Ast.Appl [Ast.Constant \<^syntax_const>\<open>_path_builder_two_id\<close>, sl, l]) =
+          [ast_var_name_pos sl, ast_var_name_pos l]
+      | path_segments
+        (Ast.Appl [Ast.Constant \<^syntax_const>\<open>_path_builder_more\<close>, h, tail]) =
+          ast_var_name_pos h :: path_segments tail
+      | path_segments ast = raise Ast.AST ("path_segments", [ast]);
+
+    \<comment>\<open>Join the segments with \<^verbatim>\<open>::\<close> into the path's source string.\<close>
+    fun joined_name segs = String.concatWith "::" (map fst segs);
+
+    \<comment>\<open>Merged source position covering the whole path:
+       \<^verbatim>\<open>range_position (start_of_first, end_of_last)\<close>. Each segment carries
+       at most one \<^verbatim>\<open>Term_Position.T\<close>; compute the segment's end via
+       \<^verbatim>\<open>Position.symbol_explode\<close> over the segment's source name.
+
+       If neither end has a usable position, return \<^verbatim>\<open>NONE\<close>; markup is
+       silently skipped at the use site.\<close>
+    fun merged_position segs =
       let
-        val rust_name = path_arg_to_rust_name (hd args);
+        fun first_pos [] = NONE
+          | first_pos ((_, ps) :: rest) =
+              (case ps of {pos, ...} :: _ => SOME pos | [] => first_pos rest);
+        fun end_pos (name, ps) =
+          (case ps of
+             {pos, ...} :: _ => SOME (Position.symbol_explode name pos)
+           | [] => NONE);
+        fun last_end_pos [] = NONE
+          | last_end_pos [seg] = end_pos seg
+          | last_end_pos (seg :: rest) =
+              (case last_end_pos rest of
+                 SOME p => SOME p
+               | NONE => end_pos seg);
+        val syntax_flag =
+          (case List.find (not o null o snd) segs of
+             SOME (_, {syntax, ...} :: _) => syntax
+           | _ => false);
       in
-        Ast.mk_appl (Ast.Constant grammar_el) [Ast.Constant rust_name]
-      end
+        case (first_pos segs, last_end_pos segs) of
+          (SOME p0, SOME p1) =>
+            SOME (if syntax_flag then Term_Position.syntax (Position.range_position (p0, p1))
+                  else Term_Position.no_syntax (Position.range_position (p0, p1)))
+        | (SOME p0, NONE) =>
+            SOME (if syntax_flag then Term_Position.syntax p0 else Term_Position.no_syntax p0)
+        | _ => NONE
+      end;
+
+    \<comment>\<open>Wrap the joined-name \<^verbatim>\<open>Ast.Variable\<close> in a \<^verbatim>\<open>_constrain\<close> carrying
+       the merged source position, so downstream \<^verbatim>\<open>parse_translation\<close>s
+       (e.g. \<open>lookup_id_tr\<close>) can attach use-site markup at the path's
+       full source range.
+
+       Using \<^verbatim>\<open>Ast.Variable\<close> (not \<^verbatim>\<open>Ast.Constant\<close>) means the joined name
+       lowers to a plain \<^verbatim>\<open>Free\<close> term --- the same shape plain identifiers
+       use --- so downstream consumers can treat path and plain
+       identifiers uniformly without a shape-discrimination match.\<close>
+    fun wrap_with_position name segs =
+      (case merged_position segs of
+         SOME tp =>
+           Ast.Appl [Ast.Constant "_constrain",
+                     Ast.Variable name,
+                     Ast.Variable (Term_Position.encode [tp])]
+       | NONE => Ast.Variable name);
+
+    fun path_translator grammar_el ctx [arg] =
+          let
+            val segs = path_segments arg;
+            val rust_name = joined_name segs;
+            val payload = wrap_with_position rust_name segs;
+          in
+            Ast.mk_appl (Ast.Constant grammar_el) [payload]
+          end
       | path_translator grammar_el _ args =
           Ast.mk_appl (Ast.Constant grammar_el) args;
   in [
-    (\<^syntax_const>\<open>_urust_temporary_path_identifier\<close>, path_translator \<^syntax_const>\<open>_urust_path_string_identifier\<close>)
-  ]end
+    \<comment>\<open>Paths after AST flattening land in the same \<^verbatim>\<open>_urust_identifier_id\<close>
+       slot as plain identifiers; the joined-name carries a leading-marker
+       \<open>::\<close>-containing string. Downstream consumers (\<open>lookup_id_tr\<close>, the binder
+       resolver, etc.) only look at the name string, so the path/plain
+       distinction is invisible past this translation.\<close>
+    (\<^syntax_const>\<open>_urust_temporary_path_identifier\<close>, path_translator \<^syntax_const>\<open>_urust_identifier_id\<close>)
+  ] end
 \<close>
 
 text\<open>We take the same approach for \<^verbatim>\<open>_urust_temporary_path_identifier_long_{field,method}\<close>, but now
@@ -990,43 +1114,84 @@ translations possibly happening again and taking care of things, but need to man
 same steps done for splitting longid's.\<close>
 parse_ast_translation\<open>
   let
-    \<comment> \<open>Split \<^verbatim>\<open>foo.bar.zoo\<close> into \<^verbatim>\<open>("foo", ["bar", "zoo"])\<close>\<close>
+    \<comment> \<open>Split a (possibly position-tagged) longid AST \<^verbatim>\<open>foo.bar.zoo\<close> into a head
+        string \<^verbatim>\<open>"foo"\<close> and a list of position-preserving ASTs \<^verbatim>\<open>[bar, zoo]\<close>.\<close>
     fun split_longid longid_el =
       let
-        val parts = split_long_identifier longid_el
+        val parts = split_longid_ast longid_el
       in
-        (hd parts, tl parts)
+        case parts of
+          [] => raise Ast.AST ("split_longid: empty", [longid_el])
+        | (hd_ast :: tl_asts) => (ast_var_name hd_ast, tl_asts)
       end;
 
-    \<comment> \<open>Split the \<^verbatim>\<open>_path_builder\<close> syntax representation of \<^verbatim>\<open>foo::bar.zoo.far\<close> into \<^verbatim>\<open>("foo::bar", ["zoo", "far"])\<close>\<close>
+    \<comment> \<open>Decode the leading source position of a (possibly position-tagged)
+        path segment AST. A bare \<^verbatim>\<open>Ast.Variable\<close> carries none.\<close>
+    fun ast_var_position (Ast.Appl [Ast.Constant "_constrain", Ast.Variable _, Ast.Variable enc]) =
+          (case Term_Position.decode enc of
+             {syntax, pos} :: _ => SOME (syntax, pos)
+           | [] => NONE)
+      | ast_var_position _ = NONE;
+
+    \<comment> \<open>Split the \<^verbatim>\<open>_path_builder\<close> syntax representation of \<^verbatim>\<open>foo::bar.zoo.far\<close>
+        into \<^verbatim>\<open>("foo::bar", [zoo_ast, far_ast])\<close> where each field component is
+        a position-preserving AST. We also recover the \<^emph>\<open>head position\<close> ---
+        the leading position of the \<^verbatim>\<open>foo::bar\<close> path string --- so the joined
+        head can be re-tagged for use-site markup (see \<open>urust_path_string_to_identifier\<close>);
+        without it, dot-access heads (\<open>Foo::Bar.baz(0)\<close>) parse fine but
+        get no markup, unlike pure \<open>::\<close>-paths.\<close>
     fun split_path_n_field
-      (Ast.Appl [Ast.Constant \<^syntax_const>\<open>_path_builder_two_longid\<close>, Ast.Variable secondlast, last]) =
+      (Ast.Appl [Ast.Constant \<^syntax_const>\<open>_path_builder_two_longid\<close>, sl, last]) =
         let
           val (tailhead, tailtail) = split_longid last
         in
-          (secondlast ^ "::" ^ tailhead, tailtail)
+          (ast_var_name sl ^ "::" ^ tailhead, tailtail, ast_var_position sl)
         end
       | split_path_n_field
-        (Ast.Appl [Ast.Constant \<^syntax_const>\<open>_path_builder_more_longid\<close>, Ast.Variable head, tail]) =
+        (Ast.Appl [Ast.Constant \<^syntax_const>\<open>_path_builder_more_longid\<close>, h, tail]) =
         let
-          val (path, field) = split_path_n_field tail
+          val (path, field, _) = split_path_n_field tail
         in
-          (head ^ "::" ^ path, field)
-        end;
+          (ast_var_name h ^ "::" ^ path, field, ast_var_position h)
+        end
+      | split_path_n_field ast = raise Ast.AST ("split_path_n_field", [ast]);
 
-    \<comment> \<open>Convert a string \<^verbatim>\<open>"foo::bar"\<close> into a uRust grammar entry\<close>
-    fun urust_path_string_to_identifier arg =
-      Ast.mk_appl (Ast.Constant \<^syntax_const>\<open>_urust_path_string_identifier\<close>) [Ast.Constant arg];
+    \<comment> \<open>Convert a string \<^verbatim>\<open>"foo::bar"\<close> into a uRust grammar entry. Like the
+        short-path translator above, the joined name lands in
+        \<^verbatim>\<open>_urust_identifier_id\<close> as a plain \<^verbatim>\<open>Ast.Variable\<close>
+        (lowering to a \<^verbatim>\<open>Free\<close> term), so downstream consumers can treat
+        path and plain identifiers uniformly. When a head position is
+        available we wrap the joined name in a \<^verbatim>\<open>_constrain\<close> carrying it,
+        so \<open>lookup_id_tr\<close> can emit use-site markup at the path head ---
+        matching the plain-path translator's \<open>wrap_with_position\<close>. The
+        position spans the head's first segment (a best-effort anchor;
+        the joined name's later segments lose their individual ranges in
+        the string rejoin, but the head start is enough for the marker).\<close>
+    fun urust_path_string_to_identifier (arg, head_pos) =
+      let
+        val payload =
+          (case head_pos of
+             SOME (syntax, pos) =>
+               let val tp = if syntax then Term_Position.syntax pos
+                            else Term_Position.no_syntax pos
+               in Ast.Appl [Ast.Constant "_constrain",
+                            Ast.Variable arg,
+                            Ast.Variable (Term_Position.encode [tp])]
+               end
+           | NONE => Ast.Variable arg)
+      in
+        Ast.mk_appl (Ast.Constant \<^syntax_const>\<open>_urust_identifier_id\<close>) [payload]
+      end;
 
     \<comment> \<open>Convert the argument of syntax type \<^verbatim>\<open>_path_identifier_long\<close> into its path string and
         field/method accesses, then use the \<^verbatim>\<open>ast_joiner\<close> argument to turn it into a urust grammar
         entry. The 'syntax type' of \<^verbatim>\<open>ast_joiner\<close> is \<^verbatim>\<open>urust \<rightarrow> urust_identifier list \<rightarrow> urust\<close>.\<close>
     fun path_translator grammar_el (ast_joiner: Ast.ast -> Ast.ast list -> Ast.ast) ctx [arg] =
       let
-        val (path, field) = split_path_n_field arg
+        val (path, field, head_pos) = split_path_n_field arg
       in
         ast_joiner
-          (path |> urust_path_string_to_identifier |> ast_urust_identifier)
+          ((path, head_pos) |> urust_path_string_to_identifier |> ast_urust_identifier)
           (field |> map ast_urust_identifier_id)
       end
       | path_translator grammar_el _ _ args =

--- a/Micro_Rust_Std_Lib/StdLib_Arithmetic.thy
+++ b/Micro_Rust_Std_Lib/StdLib_Arithmetic.thy
@@ -126,7 +126,7 @@ lift_definition (code_dt) nonzerou64_new_core :: \<open>64 word \<Rightarrow> no
 
 definition nonzerou64_new :: \<open>64 word \<Rightarrow> ('machine, nonzero_u64 option, 'abort, 'i, 'o) function_body\<close> where
   \<open>nonzerou64_new n \<equiv> FunctionBody (if n = 0 then literal None else literal (Some (nonzero_u64_inject n)))\<close>
-notation_nano_rust_function nonzerou64_new ("NonZeroU64::new")
+micro_rust_notation (call) nonzerou64_new ("NonZeroU64::new")
 
 definition nonzerou64_new_contract :: \<open>64 word \<Rightarrow>
       ('machine::{sepalg}, nonzero_u64 option, 'b) function_contract\<close> where

--- a/Micro_Rust_Std_Lib/StdLib_Logging.thy
+++ b/Micro_Rust_Std_Lib/StdLib_Logging.thy
@@ -22,35 +22,35 @@ abbreviation fatal :: \<open>log_data \<Rightarrow> ('s, unit, 'abort, 'i prompt
   \<open>fatal m \<equiv> FunctionBody \<lbrakk>
      \<l>\<o>\<g> \<llangle>Fatal\<rrangle> \<llangle>m\<rrangle>
    \<rbrakk>\<close>
-notation_nano_rust_function fatal ("fatal!")
+micro_rust_notation (call) fatal ("fatal!")
 
 text\<open>The \<^verbatim>\<open>info\<close> logger:\<close>
 abbreviation info :: \<open>log_data \<Rightarrow> ('s, unit, 'abort, 'i prompt, 'o prompt_output) function_body\<close> where
   \<open>info m \<equiv> FunctionBody \<lbrakk>
      \<l>\<o>\<g> \<llangle>Info\<rrangle> \<llangle>m\<rrangle>
    \<rbrakk>\<close>
-notation_nano_rust_function info ("info!")
+micro_rust_notation (call) info ("info!")
 
 text\<open>The \<^verbatim>\<open>error\<close> logger:\<close>
 abbreviation error :: \<open>log_data \<Rightarrow> ('s, unit, 'abort, 'i prompt, 'o prompt_output) function_body\<close> where
   \<open>error m \<equiv> FunctionBody \<lbrakk>
      \<l>\<o>\<g> \<llangle>Error\<rrangle> \<llangle>m\<rrangle>
    \<rbrakk>\<close>
-notation_nano_rust_function error ("error!")
+micro_rust_notation (call) error ("error!")
 
 text\<open>The \<^verbatim>\<open>debug\<close> logger:\<close>
 abbreviation debug :: \<open>log_data \<Rightarrow> ('s, unit, 'abort, 'i prompt, 'o prompt_output) function_body\<close> where
   \<open>debug m \<equiv> FunctionBody \<lbrakk>
      \<l>\<o>\<g> \<llangle>Debug\<rrangle> \<llangle>m\<rrangle>
    \<rbrakk>\<close>
-notation_nano_rust_function debug ("debug!")
+micro_rust_notation (call) debug ("debug!")
 
 text\<open>The \<^verbatim>\<open>trace\<close> logger:\<close>
 abbreviation trace :: \<open>log_data \<Rightarrow> ('s, unit, 'abort, 'i prompt, 'o prompt_output) function_body\<close> where
   \<open>trace m \<equiv> FunctionBody \<lbrakk>
      \<l>\<o>\<g> \<llangle>Trace\<rrangle> \<llangle>m\<rrangle>
    \<rbrakk>\<close>
-notation_nano_rust_function trace ("trace!")
+micro_rust_notation (call) trace ("trace!")
 
 \<comment>\<open>A bit of syntax sugar to reduce the pain of writing logging expressions:
    Write \<^verbatim>\<open>trace! ([["string0", data0, "string1", data1, ...]])\<close>\<close>

--- a/Micro_Rust_Std_Lib/StdLib_Option.thy
+++ b/Micro_Rust_Std_Lib/StdLib_Option.thy
@@ -7,9 +7,6 @@ theory StdLib_Option
 begin
 (*>*)
 
-consts take_const :: \<open>'a\<close>
-notation_nano_rust_function take_const ("take")
-
 definition option_expect :: \<open>'v option \<Rightarrow> String.literal \<Rightarrow> ('s, 'v, 'abort, 'i, 'o) function_body\<close> where
   \<open>option_expect self msg \<equiv> FunctionBody \<lbrakk>
       match self {
@@ -57,7 +54,7 @@ definition urust_func_option_is_none :: \<open>'v option \<Rightarrow> ('s, bool
        None \<Rightarrow> True
      }
   \<rbrakk>\<close>
-notation_nano_rust_function urust_func_option_is_none ("is_none")
+micro_rust_notation (call) urust_func_option_is_none ("is_none")
 
 definition option_is_none_contract :: 
   \<open>'a option \<Rightarrow> ('s::{sepalg}, bool, 'abort) function_contract\<close>
@@ -78,7 +75,7 @@ definition urust_func_option_is_some :: \<open>'v option \<Rightarrow> ('s, bool
        None \<Rightarrow> False
      }
   \<rbrakk>\<close>
-notation_nano_rust_function urust_func_option_is_some ("is_some")
+micro_rust_notation (call) urust_func_option_is_some ("is_some")
 
 definition option_is_some_contract :: 
   \<open>'a option \<Rightarrow> ('s::{sepalg}, bool, 'abort) function_contract\<close>
@@ -158,8 +155,7 @@ definition take_mut_ref_option :: \<open>('a, 'b, 'v option) Global_Store.ref \<
     ptr = None;
     val
   \<rbrakk>\<close> 
-adhoc_overloading take_const \<rightleftharpoons>
-  take_mut_ref_option
+micro_rust_notation (call) take_mut_ref_option ("take")
 
 definition take_mut_ref_option_contract :: \<open>('a, 'b, 'v option) Global_Store.ref \<Rightarrow> 'b \<Rightarrow> 'v option \<Rightarrow>
     ('s::{sepalg}, 'v option, 'abort) function_contract\<close> where

--- a/Micro_Rust_Std_Lib/StdLib_Ordering.thy
+++ b/Micro_Rust_Std_Lib/StdLib_Ordering.thy
@@ -11,9 +11,9 @@ datatype ordering
   = Less
   | Equal
   | Greater
-notation_nano_rust ordering.Less ("Ordering::Less")
-notation_nano_rust ordering.Equal ("Ordering::Equal")
-notation_nano_rust ordering.Greater ("Ordering::Greater")
+micro_rust_notation (literal) ordering.Less ("Ordering::Less")
+micro_rust_notation (literal) ordering.Equal ("Ordering::Equal")
+micro_rust_notation (literal) ordering.Greater ("Ordering::Greater")
 
 definition cmp_pure :: \<open>'a::{order} \<Rightarrow> 'a \<Rightarrow> ordering\<close> where
   \<open>cmp_pure x y \<equiv>

--- a/Micro_Rust_Std_Lib/StdLib_References.thy
+++ b/Micro_Rust_Std_Lib/StdLib_References.thy
@@ -347,8 +347,8 @@ definition ref_cast_to_mut :: \<open>('a, 'b, 'v) ro_ref \<Rightarrow>
   ('s, ('a, 'b, 'v) Global_Store.ref, 'abort, 'i, 'o) function_body\<close> where
   \<open>ref_cast_to_mut r \<equiv> fun_literal (unsafe_ref_from_ro_ref r)\<close>
 
-notation_nano_rust_function ref_cast_to_ro ("as_ro_ref")
-notation_nano_rust_function ref_cast_to_mut ("as_mut_ref")
+micro_rust_notation (call) ref_cast_to_ro ("as_ro_ref")
+micro_rust_notation (call) ref_cast_to_mut ("as_mut_ref")
 
 (*<*)
 end

--- a/Micro_Rust_Std_Lib/StdLib_Result.thy
+++ b/Micro_Rust_Std_Lib/StdLib_Result.thy
@@ -59,8 +59,9 @@ definition urust_func_result_is_err :: \<open>('v,'e) result \<Rightarrow> ('s, 
        Err(_) \<Rightarrow> True
      }
   \<rbrakk>\<close>
+micro_rust_notation (call) urust_func_result_is_err ("is_err")
 
-definition result_is_err_contract :: 
+definition result_is_err_contract ::
   \<open>('a, 'e) result \<Rightarrow> ('s::{sepalg}, bool, 'abort) function_contract\<close>
   where [crush_contracts]: \<open>result_is_err_contract res \<equiv>
     let pre = UNIV; post = \<lambda>r. \<langle>r = result_is_err res\<rangle>
@@ -80,8 +81,9 @@ definition urust_func_result_is_ok :: \<open>('v,'e) result \<Rightarrow> ('s, b
        Err(_) \<Rightarrow> False
      }
   \<rbrakk>\<close>
+micro_rust_notation (call) urust_func_result_is_ok ("is_ok")
 
-definition result_is_ok_contract :: 
+definition result_is_ok_contract ::
   \<open>('a, 'e) result \<Rightarrow> ('s::{sepalg}, bool, 'abort) function_contract\<close>
   where [crush_contracts]: \<open>result_is_ok_contract res \<equiv>
     let pre = UNIV; post = \<lambda>r. \<langle>r = result_is_ok res\<rangle>
@@ -100,7 +102,7 @@ definition result_or :: \<open>('a, 'f) result \<Rightarrow> ('a, 'e) result \<R
         Err(_) \<Rightarrow> e
      } 
   \<rbrakk>\<close>
-notation_nano_rust_function result_or ("or")
+micro_rust_notation (call) result_or ("or")
 
 definition result_or_pure :: \<open>('a, 'f) result \<Rightarrow> ('a, 'e) result \<Rightarrow> ('a, 'e) result\<close> where
   \<open>result_or_pure v e \<equiv> case v of Ok(v) \<Rightarrow> Ok(v) | Err(_) \<Rightarrow> e\<close>

--- a/Shallow_Micro_Rust/Basic_Case_Expression.thy
+++ b/Shallow_Micro_Rust/Basic_Case_Expression.thy
@@ -121,8 +121,15 @@ ML\<open>
 fun case_error s = error ("Error in bcase expression:\n" ^ s);
 fun case_tr err ctxt [t, u] =
       let
+        \<comment> \<open>\<open>p\<close> is the binder \<^emph>\<open>term\<close>, e.g. \<open>Free (x, _)\<close> or
+            \<open>_constrain $ Free (x, _) $ Free (<pos>, _)\<close> when the pattern's
+            identifier carries source-position markup. Routing closure through
+            \<open>Syntax_Trans.abs_tr\<close> preserves that markup as a \<open>_constrainAbs\<close>
+            wrapper, which downstream phases turn into a binder report so that
+            jump-to-definition on a use of \<open>x\<close> in the branch RHS can find the
+            pattern occurrence.\<close>
         fun abs p t =
-          Syntax.const \<^const_syntax>\<open>case_abs\<close> $ Term.absfree (p, dummyT) t;
+          Syntax.const \<^const_syntax>\<open>case_abs\<close> $ Syntax_Trans.abs_tr [p, t];
 
         fun pattern_args_destruct (Const( \<^syntax_const>\<open>_case_basic_pattern_args_single\<close>,_) $ t) = [t]
           | pattern_args_destruct (Const( \<^syntax_const>\<open>_case_basic_pattern_args_app\<close>,_) $ t $ rem) = t :: (pattern_args_destruct rem)
@@ -135,8 +142,13 @@ fun case_tr err ctxt [t, u] =
         fun pattern_build_term constructor args  =  
                fold (fn a => fn b => (b $ a)) args constructor
 
+        \<comment> \<open>Identifier-shaped terms now arrive as \<open>_constrain $ Free name $ Free <pos>\<close>
+            because of the \<open>id_position\<close> grammar. The helpers below only \<^emph>\<open>read\<close> the
+            identifier name, so we strip positions up front.\<close>
+        val strip_id_pos = Term_Position.strip_positions
+
         fun dest_id_name id =
-              (fst (Term.dest_Free id))
+              (fst (Term.dest_Free (strip_id_pos id)))
                 handle TERM _ => case_error ("invalid pattern identifier: " ^ (print_term id))
 
         fun known_constructor_name ctxt name =
@@ -149,21 +161,34 @@ fun case_tr err ctxt [t, u] =
                 else NONE
               end
 
-        fun resolve_constructor_id _ (id as Const _) = id
-          | resolve_constructor_id ctxt (Free (name, _)) =
-              (case known_constructor_name ctxt name of
-                SOME full => Syntax.const full
-              | NONE => Free (name, dummyT))
-          | resolve_constructor_id ctxt t = t
+        \<comment> \<open>Re-wrap a resolved constructor \<^verbatim>\<open>Const\<close> in the original
+            \<open>_constrain $ _ $ <pos>\<close> envelope so the decoder's namespace
+            markup lands on the user's source token --- otherwise pattern
+            heads like \<open>Some\<close> in \<open>if let Some(x) = \<dots>\<close> /
+            \<open>match x { Some(y) => \<dots> }\<close> have no clickable entity ref.\<close>
+        fun preserve_position id new_inner =
+              (case id of
+                Const (\<^syntax_const>\<open>_constrain\<close>, T) $ _ $ pos_enc =>
+                  Const (\<^syntax_const>\<open>_constrain\<close>, T) $ new_inner $ pos_enc
+              | _ => new_inner)
+
+        fun resolve_constructor_id ctxt id =
+              (case strip_id_pos id of
+                t as Const _ => preserve_position id t
+              | Free (name, _) =>
+                  (case known_constructor_name ctxt name of
+                    SOME full => preserve_position id (Syntax.const full)
+                  | NONE => Free (name, dummyT))
+              | t => t)
 
         fun is_constructor_id ctxt id =
-              (case id of
+              (case strip_id_pos id of
                 Const _ => true
               | Free (name, _) => Option.isSome (known_constructor_name ctxt name)
               | _ => false)
 
         fun is_binding_id ctxt id =
-              (case id of
+              (case strip_id_pos id of
                 Free _ => not (is_constructor_id ctxt id)
               | _ => false)
 
@@ -222,22 +247,30 @@ fun case_tr err ctxt [t, u] =
                     handle ERROR _ =>
                       case_error ("collect_ids -- invalid pattern arg: " ^ (print_term t))))
 
+        \<comment> \<open>Binder bookkeeping returns binder \<^emph>\<open>terms\<close> (not just name strings) so
+            that source positions on user-supplied identifiers survive into the
+            \<open>case_abs\<close>/\<open>Syntax_Trans.abs_tr\<close> call site, where they become
+            \<open>_constrainAbs\<close> wrappers and thus binder reports.\<close>
+        fun fresh_binder used =
+              let val (x, used') = Name.variant "x" used
+              in (Free (x, dummyT), used') end
+
         fun pattern_arg_to_term arg used =
               (case strip_convert_arg arg of
                 Const ( \<^syntax_const>\<open>_case_basic_pattern_arg_dummy\<close>, _) =>
-                  let val (x, used') = Name.variant "x" used
-                  in (Free (x, dummyT), [x], used') end
+                  let val (b, used') = fresh_binder used
+                  in (b, [b], used') end
               | (Const (\<^syntax_const>\<open>_case_basic_pattern_arg_id\<close>,_)) $ id =>
-                  (id, [dest_id_name id], used)
+                  (id, [id], used)
               | (Const (\<^syntax_const>\<open>_case_basic_pattern_arg_pattern\<close>,_)) $ pat =>
                   pattern_term_of_pattern pat used
               | (Const ("_urust_shallow_match_pattern_arg_id",_)) $ id =>
-                  (id, [dest_id_name id], used)
+                  (id, [id], used)
               | (Const ("_urust_shallow_match_pattern_arg_pattern",_)) $ pat =>
                   pattern_term_of_pattern pat used
               | Const ("_urust_shallow_match_pattern_arg_dummy", _) =>
-                  let val (x, used') = Name.variant "x" used
-                  in (Free (x, dummyT), [x], used') end
+                  let val (b, used') = fresh_binder used
+                  in (b, [b], used') end
               | t =>
                   (pattern_term_of_pattern t used
                     handle ERROR _ =>
@@ -257,39 +290,39 @@ fun case_tr err ctxt [t, u] =
                   in (pattern_build_term (resolve_constructor_id ctxt c) arg_terms, binders, used') end
               | Const (\<^syntax_const>\<open>_case_basic_pattern_constr_no_args\<close>,_) $ c =>
                   if is_binding_id ctxt c
-                  then (c, [dest_id_name c], used)
+                  then (c, [c], used)
                   else (resolve_constructor_id ctxt c, [], used)
               | Const (\<^syntax_const>\<open>_case_basic_pattern_other\<close>, _) =>
-                  let val (x, used') = Name.variant "x" used
-                  in (Free (x, dummyT), [x], used') end
+                  let val (b, used') = fresh_binder used
+                  in (b, [b], used') end
               | Const ("_urust_shallow_match_pattern_constr_with_args", _) $ c $ args =>
                   let val args' = shallow_args_destruct args
                       val (arg_terms, binders, used') = pattern_args_to_terms args' used
                   in (pattern_build_term (resolve_constructor_id ctxt c) arg_terms, binders, used') end
               | Const ("_urust_shallow_match_pattern_constr_no_args", _) $ c =>
                   if is_binding_id ctxt c
-                  then (c, [dest_id_name c], used)
+                  then (c, [c], used)
                   else (resolve_constructor_id ctxt c, [], used)
               | Const ("_urust_shallow_match_pattern_other", _) =>
-                  let val (x, used') = Name.variant "x" used
-                  in (Free (x, dummyT), [x], used') end
+                  let val (b, used') = fresh_binder used
+                  in (b, [b], used') end
               | Const ("_urust_match_pattern_constr_with_args", _) $ c $ args =>
                   let val args' = urust_args_destruct args
                       val (arg_terms, binders, used') = pattern_args_to_terms args' used
                   in (pattern_build_term (resolve_constructor_id ctxt c) arg_terms, binders, used') end
               | Const ("_urust_match_pattern_constr_no_args", _) $ c =>
                   if is_binding_id ctxt c
-                  then (c, [dest_id_name c], used)
+                  then (c, [c], used)
                   else (resolve_constructor_id ctxt c, [], used)
               | Const ("_urust_match_pattern_other", _) =>
-                  let val (x, used') = Name.variant "x" used
-                  in (Free (x, dummyT), [x], used') end
+                  let val (b, used') = fresh_binder used
+                  in (b, [b], used') end
               | t => case_error ("invalid pattern: " ^ (print_term t)))
 
-        fun handle_pattern (Const (\<^syntax_const>\<open>_case_basic_pattern_other\<close>, _)) exp = 
+        fun handle_pattern (Const (\<^syntax_const>\<open>_case_basic_pattern_other\<close>, _)) exp =
             let val (constr_str, _) = Name.variant "C" (Term.declare_free_names t Name.context)
                 val constr = Free (constr_str, dummyT) in
-                abs constr_str (Syntax.const \<^const_syntax>\<open>case_elem\<close> $ constr $ exp) end
+                abs constr (Syntax.const \<^const_syntax>\<open>case_elem\<close> $ constr $ exp) end
           | handle_pattern pattern exp =
             let val used0 = Term.declare_free_names exp Name.context
                 val used = fold Name.declare (collect_ids_from_pattern pattern) used0

--- a/Shallow_Micro_Rust/Core_Syntax.thy
+++ b/Shallow_Micro_Rust/Core_Syntax.thy
@@ -762,18 +762,24 @@ let
     end;
 
   fun binding_name_of ctxt id =
-    (case id of
+    (case Term_Position.strip_positions id of
       Free (name, _) => name
     | Const (name, _) => Long_Name.base_name name
     | _ => case_error ("invalid alias pattern binder: " ^ Syntax.string_of_term ctxt id));
 
-  fun mk_alias_rhs ctxt id rhs =
+  fun mk_alias_rhs _ id rhs =
     let
-      val alias = binding_name_of ctxt id;
+      \<comment> \<open>Route closure through \<open>Syntax_Trans.abs_tr\<close> so that a position-tagged
+          binder \<open>_constrain $ Free name $ Free <pos>\<close> becomes a \<open>_constrainAbs\<close>
+          wrapper, preserving the binder report.\<close>
+      val binder =
+        (case Term_Position.strip_positions id of
+          Const (name, _) => Free (Long_Name.base_name name, dummyT)
+        | _ => id)
     in
       Syntax.const \<^const_syntax>\<open>bind\<close> $
         (Syntax.const \<^const_syntax>\<open>literal\<close> $ mk_anon_raw_value ()) $
-        Abs (alias, dummyT, rhs)
+        Syntax_Trans.abs_tr [binder, rhs]
     end;
 
   \<comment>\<open>Expand disjunctive patterns into a list of patterns.

--- a/Shallow_Micro_Rust/Micro_Rust_Notations.thy
+++ b/Shallow_Micro_Rust/Micro_Rust_Notations.thy
@@ -1,0 +1,1148 @@
+(* Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+   SPDX-License-Identifier: MIT *)
+
+(* Table-backed registry of uRust name notations + a typed dispatcher.
+
+   This is the sole mechanism for registering a uRust name with a HOL
+   backend, via the `micro_rust_notation` command. It replaces an older
+   approach based on per-name `translations` and per-operator
+   `adhoc_overloading` consts emitted by a family of per-kind commands. The
+   registry is a single string-indexed `Generic_Data` table; dispatch is a single
+   `String.literal`-parametrized const `urust_dispatch` whose markers are
+   resolved in a typed `term_check` phase, in adhoc-overloading style. *)
+
+theory Micro_Rust_Notations
+  imports
+    Main
+  keywords
+    "micro_rust_notation" :: thy_decl and
+    "print_micro_rust_notations" :: diag
+begin
+
+(* ===================================================================== *)
+(* uRust-name -> HOL-term registry, consulted by the dispatch term_check  *)
+(* phase on identifier resolution.  Three contexts (literal/field/        *)
+(* function); a name registered only as `field` must still fall back to   *)
+(* identity in value position, so we key by (context, name).              *)
+(* ===================================================================== *)
+
+ML\<open>
+structure Micro_Rust_Names = struct
+
+\<comment>\<open>The three registration contexts (\<open>"literal"\<close> / \<open>"field"\<close> /
+  \<open>"function"\<close>), selected by the optional \<open>micro_rust_notation\<close> kind
+  modifier (\<open>(literal)\<close> / \<open>(field)\<close> / \<open>(call)\<close>) or inferred from the
+  term's type when the modifier is omitted.\<close>
+datatype ctxt_kind = NLiteral | NFunction | NField;
+
+fun kind_to_string NLiteral = "literal"
+  | kind_to_string NFunction = "function"
+  | kind_to_string NField = "field";
+
+fun string_to_kind "literal" = NLiteral
+  | string_to_kind "function" = NFunction
+  | string_to_kind "field" = NField
+  | string_to_kind s = error ("unknown micro_rust_notation context: " ^ s);
+
+\<comment>\<open>Sniff the registration kind from a HOL term's type --- a function call
+  iff the type is \<open>_ \<Rightarrow> _ function_body\<close>, a field iff the type is \<open>_ lens\<close>,
+  otherwise a literal. Shared by the auto-inferred-kind path of
+  \<open>micro_rust_notation\<close> and by the shadow check (which only flags
+  call-/field-shaped HOL constants as ambiguous shadows).\<close>
+\<comment>\<open>Recognise the type by looking at its outermost shape:
+   - any \<open>_ \<Rightarrow> ... \<Rightarrow> _ function_body\<close> chain (uncurried calls have a
+     binary or higher \<open>function_body\<close> result) is a function backend;
+   - any \<open>_ lens\<close> is a field backend;
+   - everything else is a literal.
+
+  The \<open>fun\<close>-walk handles multi-argument functions like
+  \<open>nat \<Rightarrow> nat \<Rightarrow> ('s, nat, _, _, _) function_body\<close> --- without it the
+  binary signature would collapse to literal at auto-infer time and a
+  use site \<open>foo(x, y)\<close> would never reach the function-kind table.\<close>
+fun infer_kind_of_type (Type ("Core_Expression.function_body", _)) = NFunction
+  | infer_kind_of_type (Type ("fun", [_, T])) = infer_kind_of_type T
+  | infer_kind_of_type (Type ("Lens.lens", _)) = NField
+  | infer_kind_of_type _ = NLiteral;
+
+\<comment>\<open>A registered entry: the resolved HOL \<^emph>\<open>term\<close> the notation stands for,
+  the position of the registering command (so leaf markup can hyperlink to
+  the declaration site), and a unique \<open>serial\<close> that pairs the def-side
+  markup at the registration site with ref-side markup at every use site
+  (mirrors the \<open>def\<close>/\<open>ref\<close> protocol of \<^ML>\<open>Position.make_entity_markup\<close>;
+  see e.g. \<open>Pure/Isar/calculation.ML\<close> for a textbook use). Storing a TERM
+  (not just a constant name) is what lets a notation target an arbitrary
+  expression --- in particular a locale-fixed parameter (a \<open>Free\<close>) or a
+  local definition --- not only a global constant. The declaration
+  morphism is applied to this term at registration (see \<open>do_register\<close>),
+  so under locale interpretation / derivation the stored term tracks the
+  parameter substitution.\<close>
+type entry = { hol_term : term, reg_pos : Position.T, serial : serial };
+
+\<comment>\<open>MULTIPLE BACKENDS PER NAME (adhoc-overloading-style dispatch). A single
+  uRust name may have several HOL backends differing only by type, just as
+  the existing code base does manually via an uninterpreted const +
+  \<open>adhoc_overloading\<close>. We therefore store a LIST of entries per
+  \<open>(kind, name)\<close>, and merge tables by UNION (\<open>Symtab.merge_list\<close>) ---
+  exactly as \<open>adhoc_overloading.ML\<close>'s variant table does. This makes the
+  registry MERGE-STABLE: if two theories independently register a backend
+  for the same name, importing both yields the union of backends, no
+  collision and no "last-write-wins" loss. (Resolution to a single backend
+  happens later, in a typed \<open>term_check\<close> phase --- see \<open>urust_dispatch\<close>
+  below --- because the parse phase runs pre-type and cannot itself choose
+  by type.)
+
+  \<open>reg_eq\<close> dedupes entries by their term (position-erased), so
+  re-registering the same backend is idempotent (e.g. when a syntax
+  declaration is replayed on context-open).\<close>
+fun reg_eq (e1 : entry, e2 : entry) =
+  Term.aconv_untyped (#hol_term e1, #hol_term e2);
+
+\<comment>\<open>Table keyed by (context, rust_name) \<rightarrow> list of entries. The key is the
+  pair of strings (Position.T is not an ord type); entries (term + reg
+  position) ride in the value.\<close>
+structure Data = Generic_Data
+(
+  type T = entry list Symtab.table;
+  val empty = Symtab.empty;
+  val merge = Symtab.merge_list reg_eq;
+);
+
+fun mk_key kind name = kind_to_string kind ^ "\000" ^ name;
+
+\<comment>\<open>Markup kind for uRust notation entities (def/ref protocol).\<close>
+val notationN = "micro_rust_notation";
+
+\<comment>\<open>Shadow-check opt-out state. \<open>shadow_opts\<close> records two independent
+  bits; the table tracks a \<^emph>\<open>default\<close> (concrete, applies to every name)
+  plus per-(kind, name) overrides whose bits are \<open>bool option\<close>: a
+  \<open>SOME\<close>-bit replaces the default for that bit, a \<open>NONE\<close>-bit inherits.
+  The four user-facing modes each set exactly one override bit
+  (see \<open>set_shadow_bit\<close> below).\<close>
+type shadow_opts = { suppress_warning : bool, suppress_error : bool };
+type shadow_opts_override =
+  { suppress_warning : bool option, suppress_error : bool option };
+
+\<comment>\<open>Default: errors are suppressed; the check still fires as a warning
+  unless \<open>suppress_warning\<close> is also on.\<close>
+val default_shadow_opts : shadow_opts =
+  { suppress_warning = false, suppress_error = true };
+
+val no_override : shadow_opts_override =
+  { suppress_warning = NONE, suppress_error = NONE };
+
+\<comment>\<open>Combine two defaults (OR each bit) for merging tables across imports:
+  if either source said "suppress this bit", the merged default
+  preserves the suppression.\<close>
+fun merge_shadow_opts ({ suppress_warning = a1, suppress_error = b1 },
+                       { suppress_warning = a2, suppress_error = b2 })
+      : shadow_opts =
+  { suppress_warning = a1 orelse a2, suppress_error = b1 orelse b2 };
+
+\<comment>\<open>Combine two overrides per bit: \<open>NONE\<close> is identity; two \<open>SOME\<close>s OR
+  (the more-suppressing setting wins, mirroring \<open>merge_shadow_opts\<close>).\<close>
+fun merge_opt (NONE, x) = x
+  | merge_opt (x, NONE) = x
+  | merge_opt (SOME a, SOME b) = SOME (a orelse b);
+
+fun merge_shadow_overrides ({ suppress_warning = a1, suppress_error = b1 },
+                            { suppress_warning = a2, suppress_error = b2 })
+      : shadow_opts_override =
+  { suppress_warning = merge_opt (a1, a2),
+    suppress_error = merge_opt (b1, b2) };
+
+\<comment>\<open>The four single-bit setters: each updates one field of an existing
+  override and leaves the other untouched.\<close>
+datatype shadow_bit =
+    Set_Suppress_Warning of bool
+  | Set_Suppress_Error of bool;
+
+fun apply_shadow_bit (Set_Suppress_Warning b)
+                     ({ suppress_error, ... } : shadow_opts_override) =
+      { suppress_warning = SOME b, suppress_error = suppress_error }
+  | apply_shadow_bit (Set_Suppress_Error b)
+                     ({ suppress_warning, ... } : shadow_opts_override) =
+      { suppress_warning = suppress_warning, suppress_error = SOME b };
+
+\<comment>\<open>Same setter, but applied to a concrete (non-optional) default
+  \<open>shadow_opts\<close>: the bit value is forced (the override is collapsed
+  into the default).\<close>
+fun apply_shadow_bit_default (Set_Suppress_Warning b)
+                             ({ suppress_error, ... } : shadow_opts) =
+      { suppress_warning = b, suppress_error = suppress_error }
+  | apply_shadow_bit_default (Set_Suppress_Error b)
+                             ({ suppress_warning, ... } : shadow_opts) =
+      { suppress_warning = suppress_warning, suppress_error = b };
+
+\<comment>\<open>Storage: a concrete default plus a per-(kind, name) override table.
+  Default-merge ORs each bit; per-name override merge ORs each \<open>SOME\<close>
+  bit and treats \<open>NONE\<close> as identity.\<close>
+type shadow_opts_state =
+  { default : shadow_opts, per_name : shadow_opts_override Symtab.table };
+
+val empty_shadow_opts_state : shadow_opts_state =
+  { default = default_shadow_opts, per_name = Symtab.empty };
+
+fun merge_shadow_opts_state
+      ({ default = d1, per_name = p1 },
+       { default = d2, per_name = p2 }) : shadow_opts_state =
+  { default = merge_shadow_opts (d1, d2),
+    per_name = Symtab.join (K merge_shadow_overrides) (p1, p2) };
+
+structure ShadowOpts = Generic_Data
+(
+  type T = shadow_opts_state;
+  val empty = empty_shadow_opts_state;
+  val merge = merge_shadow_opts_state;
+);
+
+\<comment>\<open>Effective opts for a given \<open>(kind, name)\<close>: per-bit, the override's
+  \<open>SOME\<close> value replaces the default, \<open>NONE\<close> inherits. So a default of
+  \<open>suppress_error = true\<close> can be re-opened per name via
+  \<open>[shadow_err] "foo"\<close>, and vice versa.\<close>
+fun shadow_opts ctxt kind name =
+  let
+    val { default, per_name } = ShadowOpts.get (Context.Proof ctxt)
+    fun resolve (NONE, d) = d | resolve (SOME b, _) = b
+  in
+    case Symtab.lookup per_name (mk_key kind name) of
+      NONE => default
+    | SOME ov =>
+        { suppress_warning =
+            resolve (#suppress_warning ov, #suppress_warning default),
+          suppress_error =
+            resolve (#suppress_error ov, #suppress_error default) }
+  end;
+
+\<comment>\<open>Set one shadow bit on the default opts (when \<open>names = []\<close>) or on
+  each \<open>(kind, name)\<close> override (when \<open>names\<close> is non-empty).
+  Only the named bit is changed; the other bit is preserved.\<close>
+fun set_shadow_bit kind names bit =
+  if null names then
+    ShadowOpts.map (fn { default, per_name } =>
+      { default = apply_shadow_bit_default bit default, per_name = per_name })
+  else
+    let
+      fun update_entry (state as { default, per_name }) name =
+        let
+          val key = mk_key kind name
+          val old = the_default no_override (Symtab.lookup per_name key)
+          val new = apply_shadow_bit bit old
+        in
+          { default = default, per_name = Symtab.update (key, new) per_name }
+        end
+    in
+      ShadowOpts.map (fn state => fold (fn n => fn s => update_entry s n) names state)
+    end;
+
+\<comment>\<open>Register \<open>rust_name\<close> (in context \<open>kind\<close>) as a notation backend for
+  \<open>hol_term\<close>, recording \<open>reg_pos\<close>. CONSes onto the name's backend list
+  (deduped by \<open>reg_eq\<close>), so distinct backends accumulate while identical
+  re-registration is a no-op.
+
+  Allocates a fresh \<open>serial\<close> per \<^emph>\<open>declaration\<close> (not per merge-replay) and
+  emits a \<open>def\<close>-side entity markup at \<open>reg_pos\<close>. Use sites later emit
+  matching \<open>ref\<close>-side markup pointing back here, so jEdit's
+  jump-to-definition lands on the registering command.\<close>
+fun register kind name hol_term reg_pos context =
+  let
+    val s = serial ();
+    val entry = { hol_term = hol_term, reg_pos = reg_pos, serial = s };
+    val ctxt = Context.proof_of context;
+    val _ = Context_Position.report ctxt reg_pos
+      (Position.make_entity_markup {def = true} s notationN (name, reg_pos));
+  in
+    context |> Data.map (Symtab.insert_list reg_eq (mk_key kind name, entry))
+  end;
+
+\<comment>\<open>All backends registered for a \<open>(kind, name)\<close>, or \<open>[]\<close> if none.\<close>
+fun lookups ctxt kind name =
+  the_default [] (Symtab.lookup (Data.get (Context.Proof ctxt)) (mk_key kind name));
+
+\<comment>\<open>All registered entries, as (kind, rust_name, entry) triples (for the
+  query command). Splits the composite key back into kind + name; one row
+  per backend.\<close>
+fun dump ctxt =
+  Data.get (Context.Proof ctxt)
+  |> Symtab.dest
+  |> maps (fn (key, es) =>
+       (case String.fields (fn ch => ch = #"\000") key of
+          [k, n] => map (fn e => (string_to_kind k, n, e)) es
+        | _ => error "malformed micro_rust_notation key"));
+
+end
+\<close>
+
+(* ===================================================================== *)
+(* Type-directed dispatch for multi-backend notations.                    *)
+(*                                                                        *)
+(* When a uRust name has >1 backend, the parse phase cannot choose       *)
+(* (types are not yet known).  Instead it emits a marker                  *)
+(* `urust_dispatch (STR ''<kind>:<name>'')`; a `term_check` phase runs   *)
+(* AFTER type inference and resolves the marker to the unique backend    *)
+(* whose type unifies with the occurrence.                                *)
+(*                                                                        *)
+(*   0 candidates  \<rightarrow>  "no backend at type"                              *)
+(*   1 candidate   \<rightarrow>  splice it                                         *)
+(*   \<ge>2 candidates \<rightarrow>  ambiguous (loud, listing all candidates)          *)
+(*                                                                        *)
+(* Same loud-on-ambiguity discipline as `adhoc_overloading` (never        *)
+(* "last wins").  `urust_dispatch` is one global anchor (merge-stable);   *)
+(* per-name identities are STRING tags reconciled by the union-merged     *)
+(* `Micro_Rust_Names` table.                                              *)
+(* ===================================================================== *)
+
+\<comment>\<open>Plain-identifier dispatch carries a \<^emph>\<open>witness\<close> --- the bare \<^verbatim>\<open>Free name\<close>
+  that the source identifier would have been if no notation registration
+  existed. The witness travels through HOL's normal binding pipeline, so
+  by term_check time it has been resolved by Isabelle the same way an
+  unmarked occurrence would be (\<^verbatim>\<open>Bound\<close> for \<open>\<lambda>\<close>-bound, \<^verbatim>\<open>Const\<close> for an
+  in-scope HOL constant of the same name, \<^verbatim>\<open>Free\<close> for a truly-free
+  occurrence). The dispatcher's resolver then prefers the witness over
+  the table whenever the witness has bound or constant shape --- this is
+  what stops a registered \<^verbatim>\<open>("mask")\<close> from hijacking a
+  \<^verbatim>\<open>\<lambda>mask. \<dots> mask \<dots>\<close> use site.
+
+  Path identifiers (\<^verbatim>\<open>Foo::Bar\<close>) cannot be HOL binders, so they have
+  no useful witness and use a separate marker.\<close>
+\<comment>\<open>Bespoke witness wrapper: a private datatype with two constructors,
+  used solely to carry the optional witness inside the dispatch marker.
+  Going through a dedicated wrapper rather than HOL's \<^typ>\<open>'a option\<close>
+  prevents accidental collision with notation registrations of \<open>Some\<close>,
+  \<open>None\<close>, etc. (\<open>Some(x)\<close> at function position has the witness
+  \<open>Some\<close> --- which would itself be elaborated by HOL to
+  \<^const>\<open>Option.Some\<close> if we used \<^typ>\<open>'a option\<close> as the wrapper, and
+  HOL's type inference would then conflate the wrapper-\<open>Some\<close> with the
+  witness-\<open>Some\<close>.)\<close>
+datatype 'a urust_witness = Witness 'a | NoWitness
+
+\<comment>\<open>The dispatch marker carries a payload term \<open>'x\<close> (an opaque
+  carrier for kind/name/source-pos metadata, built in ML by
+  \<open>Micro_Rust_Dispatch.mk_payload\<close>) and an optional witness
+  \<open>'y urust_witness\<close>. The result type \<open>'z\<close> is independent so
+  the marker's elaboration doesn't get pinned by the witness or
+  payload types.\<close>
+consts urust_dispatch :: \<open>'x \<Rightarrow> 'y urust_witness \<Rightarrow> 'z\<close>
+
+ML\<open>
+structure Micro_Rust_Dispatch = struct
+
+\<comment>\<open>The marker's payload encodes \<open>(kind, name, source_pos)\<close> as a
+  bare \<^verbatim>\<open>Const\<close> with the data packed into the constant's name.
+  Using a \<^verbatim>\<open>Const\<close> rather than a HOL \<^typ>\<open>String.literal\<close> avoids the
+  ~7n nested-constructor blowup of bit-list literal strings; the
+  payload is two heap cells regardless of name length. The sentinel
+  prefix keeps the encoded name out of any real namespace.\<close>
+val payload_prefix = "_urust_dispatch_payload___";
+val payload_sep = String.str (Char.chr 0);
+
+\<comment>\<open>Drop the \<^verbatim>\<open>file\<close> property of a position. CRITICAL: the encoded
+  position is spliced into the payload \<^verbatim>\<open>Free\<close>'s \<^emph>\<open>name\<close> (see
+  \<open>mk_payload\<close>), and a file path contains \<open>.\<close> characters. A \<open>.\<close> in a
+  name makes \<^ML>\<open>Long_Name.is_qualified\<close> true, which makes
+  \<^ML>\<open>Proof_Context.lookup_free\<close> return \<^verbatim>\<open>NONE\<close>, which makes
+  \<^ML>\<open>Syntax_Phases.decode_term\<close> promote the \<^verbatim>\<open>Free\<close> to a constant
+  lookup --- raising "Undefined constant" at parse time. This bites
+  \<^emph>\<open>only\<close> in batch builds: interactive PIDE term evaluation yields
+  positions without a \<open>file\<close> property, so the bug stays latent in jEdit
+  and surfaces under \<^verbatim>\<open>isabelle build\<close>. Markup keys on \<open>offset\<close>+\<open>id\<close>
+  (see \<^ML>\<open>Position.is_reported\<close>), which survive, so dropping the file
+  is invisible to the use-site report.\<close>
+fun strip_file pos =
+  let val {line, offset, end_offset, props = {label, id, ...}} = Position.dest pos
+  in Position.make {line = line, offset = offset, end_offset = end_offset,
+       props = {label = label, file = "", id = id}} end;
+
+fun encode_payload kind name pos =
+  let
+    val tag = Micro_Rust_Names.kind_to_string kind ^ payload_sep ^ name
+  in
+    if Position.is_reported pos
+    then tag ^ payload_sep ^ Term_Position.encode_no_syntax [strip_file pos]
+    else tag
+  end;
+
+fun decode_payload s =
+  let
+    val parts = String.fields (fn ch => ch = Char.chr 0) s
+    val (kind_str, name, pos) =
+      (case parts of
+         [k, n] => (k, n, Position.none)
+       | [k, n, enc] =>
+           (k, n,
+            case Term_Position.decode enc of
+              {pos, ...} :: _ => pos
+            | [] => Position.none)
+       | _ => error "malformed urust_dispatch payload")
+  in (Micro_Rust_Names.string_to_kind kind_str, name, pos) end;
+
+\<comment>\<open>Build the payload \<^verbatim>\<open>Free\<close> with the encoded data in its name.
+
+  Using \<^verbatim>\<open>Free\<close> rather than \<^verbatim>\<open>Const\<close> matters: the preterm decoder runs
+  a namespace lookup on \<^verbatim>\<open>Const\<close> names and raises "Undefined constant"
+  when the name doesn't resolve. \<^verbatim>\<open>Free\<close> variables aren't subject to
+  that lookup; the decoder accepts the free variable verbatim. The
+  sentinel prefix is reserved enough that no user identifier could
+  collide with it.\<close>
+fun mk_payload kind name pos =
+  Free (payload_prefix ^ encode_payload kind name pos, dummyT);
+
+\<comment>\<open>Recognise the payload \<^verbatim>\<open>Free\<close> and recover \<open>(kind, name, pos)\<close>.\<close>
+fun dest_payload (Free (s, _)) =
+      if String.isPrefix payload_prefix s
+      then SOME (decode_payload (String.extract (s, size payload_prefix, NONE)))
+      else NONE
+  | dest_payload _ = NONE;
+
+\<comment>\<open>Construct a marker \<open>urust_dispatch (STR ''<tag>'') opt\<close>:
+
+   - Plain id: \<open>opt = SOME witness\<close>, where \<open>witness\<close> is the bare
+     \<open>Free name\<close> the source identifier would have parsed to. HOL
+     elaboration resolves the witness through normal binding (so a
+     \<lambda>-bound \<open>name\<close> becomes \<open>Bound n\<close>, an in-scope HOL constant becomes
+     \<open>Const\<close>, etc.); the term_check resolver inspects the elaborated
+     witness and prefers it over a table lookup whenever the witness
+     resolved to a binder or a HOL constant.
+
+   - Path id: \<open>opt = NONE\<close>. Path names cannot be HOL binders, so there
+     is no useful witness to carry.
+
+  The two type variables \<open>'a\<close> (witness) and \<open>'b\<close> (result) are
+  independent --- this is essential. If they were collapsed, the
+  witness's elaborated type would force the marker's result type, and a
+  registered name like \<open>Some\<close> (which HOL elaborates to
+  \<^const>\<open>Option.Some\<close>) at function position would fail type unification
+  before the term_check resolver had a chance to pick the registered
+  function-kind backend.\<close>
+fun mk_marker_term opt_witness =
+  let
+    val opt_term =
+      (case opt_witness of
+         SOME w => Const (\<^const_name>\<open>Witness\<close>, dummyT) $ w
+       | NONE => Const (\<^const_name>\<open>NoWitness\<close>, dummyT))
+  in fn payload =>
+       Const (\<^const_name>\<open>urust_dispatch\<close>, dummyT) $ payload $ opt_term
+  end;
+
+\<comment>\<open>Build the marker with the witness term unmodified --- positions
+  on the witness are preserved. After \<^ML>\<open>Syntax_Trans.abs_tr\<close>
+  binds an enclosing same-named binder, the witness becomes
+  \<^verbatim>\<open>_constrain $ Bound n $ <pos>\<close>, and \<^verbatim>\<open>decode_term\<close> emits paired
+  binder def/use markup automatically.
+
+  The trade-off: when the witness elaborates to a HOL constant
+  (e.g. \<^verbatim>\<open>Free "Some"\<close> \<rightsquigarrow> \<^const>\<open>Option.Some\<close>), the decoder ALSO
+  emits \<^verbatim>\<open>Markup.const\<close> at the user's source token, which can stack
+  visibly with the \<open>micro_rust_notation\<close> entity ref \<open>resolve\<close> emits.\<close>
+fun mk_marker kind name pos witness =
+  mk_marker_term (SOME witness) (mk_payload kind name pos);
+
+\<comment>\<open>Recognise a marker. Returns \<open>SOME ((kind, name, src_pos),
+  opt_witness, T)\<close> where \<open>opt_witness\<close> is \<open>SOME witness\<close> for plain ids
+  (the elaborated witness term) and \<open>NONE\<close> for paths, and \<open>T\<close> is the
+  marker's inferred result type at this occurrence.\<close>
+\<comment>\<open>Type-aware destructure: requires the marker's outer type to be a
+  proper function chain so we can extract the result type. Returns
+  \<open>NONE\<close> on a malformed payload, on a non-witness opt-payload, or
+  when the marker's type is still \<open>dummyT\<close>-shaped (i.e. before type
+  inference); callers in early phases should use
+  \<^verbatim>\<open>dest_marker_untyped\<close> instead.\<close>
+fun dest_marker (Const (\<^const_name>\<open>urust_dispatch\<close>, T) $ payload $ opt) =
+      ((case dest_payload payload of
+          NONE => NONE
+        | SOME tag =>
+            let
+              val result_T = Term.range_type (Term.range_type T)
+              val witness =
+                (case opt of
+                   Const (\<^const_name>\<open>Witness\<close>, _) $ w => SOME w
+                 | Const (\<^const_name>\<open>NoWitness\<close>, _) => NONE
+                 | _ => raise Match)
+            in SOME (tag, witness, result_T) end)
+       handle Match => NONE | TYPE _ => NONE)
+  | dest_marker _ = NONE;
+
+\<comment>\<open>Type-blind destructure: only inspects the term skeleton (payload
+  and witness shape). Used in the early \<^verbatim>\<open>~1\<close> phase, before type
+  inference, where the marker's type is still \<open>dummyT\<close> and
+  \<^verbatim>\<open>dest_marker\<close> would bail out.\<close>
+fun dest_marker_untyped (Const (\<^const_name>\<open>urust_dispatch\<close>, _) $ payload $ opt) =
+      ((case dest_payload payload of
+          NONE => NONE
+        | SOME tag =>
+            let
+              val witness =
+                (case opt of
+                   Const (\<^const_name>\<open>Witness\<close>, _) $ w => SOME w
+                 | Const (\<^const_name>\<open>NoWitness\<close>, _) => NONE
+                 | _ => raise Match)
+            in SOME (tag, witness) end)
+       handle Match => NONE)
+  | dest_marker_untyped _ = NONE;
+
+\<comment>\<open>Can backend type \<open>T'\<close> serve an occurrence of type \<open>T\<close>?
+  (Mirrors \<open>adhoc_overloading.ML\<close>: rename the backend's tvars away
+  from the occurrence and try \<open>typ_unify\<close>.)\<close>
+fun unifiable_types ctxt (T, T') =
+  let
+    val thy = Proof_Context.theory_of ctxt;
+    val maxidx1 = Term.maxidx_of_typ T;
+    val T'' = Logic.incr_tvar (maxidx1 + 1) T';
+    val maxidx2 = Term.maxidx_typ T'' maxidx1;
+  in can (Sign.typ_unify thy (T, T'')) (Vartab.empty, maxidx2) end;
+
+\<comment>\<open>Try to unify a backend term against an occurrence type \<open>T\<close>; on
+  success, return the backend term with its schematic TVars
+  instantiated by the unifier. Mirrors the shift-and-unify dance of
+  \<open>unifiable_types\<close> but also \<^emph>\<open>applies the substitution\<close> so the
+  resulting term has no orphan schematics --- otherwise \<open>check_term\<close>'s
+  later "Illegal schematic type variable" guard fires.\<close>
+fun unify_and_instantiate ctxt T t =
+  let
+    val thy = Proof_Context.theory_of ctxt;
+    val T' = fastype_of t;
+    val maxidx1 = Term.maxidx_of_typ T;
+    val shift = maxidx1 + 1;
+    val T'' = Logic.incr_tvar shift T';
+    val t' = Term.map_types (Logic.incr_tvar shift) t;
+    val maxidx2 = Term.maxidx_typ T'' maxidx1;
+  in
+    case try (Sign.typ_unify thy (T, T'')) (Vartab.empty, maxidx2) of
+      NONE => NONE
+    | SOME (tyenv, _) =>
+        let
+          val subst = Term.map_types (Envir.subst_type tyenv)
+        in SOME (subst t') end
+  end;
+
+\<comment>\<open>Candidate backends for \<open>(kind, name)\<close> whose type unifies with \<open>T\<close>.
+  Each backend term is freshly \<^emph>\<open>polymorphised\<close> (its \<open>TFree\<close>s are generalised
+  to schematic \<open>TVar\<close>s) and then imported with fresh schematic indices ---
+  this is the same dance \<open>adhoc_overloading\<close>'s variant table does, and is
+  what lets a registered term whose declared type is \<open>'a \<Rightarrow> 'a option\<close>
+  match an occurrence whose inferred type is \<open>nat \<Rightarrow> nat option\<close>.
+  Skipping the polymorphisation leaves \<open>TFree\<close>s in the backend, which
+  do not unify with the occurrence's schematic Vars and cause spurious
+  "no backend matches type" errors.\<close>
+\<comment>\<open>Generalise a backend's free type variables to schematics, leaving
+  any pre-existing schematics untouched. Distinct from
+  \<open>Logic.varify_types_global\<close>, which raises on pre-existing schematics
+  --- the registered backend may legitimately contain both
+  (e.g. \<open>lift_fun1 Some\<close>: \<open>lift_fun1\<close>'s tvars are TFree but the inlined
+  \<open>Some\<close> has TVar from its declared signature).\<close>
+fun varify_tfrees_in_term t =
+  Term.map_types (Term.map_atyps
+    (fn TFree (a, S) => TVar ((a, 0), S) | T => T)) t;
+
+fun candidates ctxt kind name T =
+  Micro_Rust_Names.lookups ctxt kind name
+  |> map_filter (fn { hol_term, ... } =>
+       \<comment>\<open>Mirror \<open>adhoc_overloading.ML\<close>: keep the backend's type for
+         the unifiability check, but splice the term with all internal
+         types erased to \<open>dummyT\<close> --- subsequent type inference re-checks
+         the spliced term against \<open>T\<close> and fills in dummies, which lets
+         residual polymorphism flow naturally and avoids "Illegal
+         schematic type variable" reports for tvars that the surrounding
+         context can still pin.\<close>
+       let val varified = varify_tfrees_in_term hol_term
+       in
+         if unifiable_types ctxt (T, fastype_of varified)
+         then SOME (Type.constraint T (Term.map_types (K dummyT) varified))
+         else NONE
+       end);
+
+\<comment>\<open>Look up a HOL constant by user-visible name. Returns
+  \<open>SOME (full_name, declared_type)\<close> if the name resolves to a proper
+  constant in \<open>ctxt\<close>, \<open>NONE\<close> otherwise (free variable, abbreviation,
+  unknown name, etc.). Used by \<open>shadow_check\<close> below.\<close>
+fun lookup_hol_const ctxt name =
+  (case try (Proof_Context.read_const {proper = true, strict = false} ctxt) name of
+     SOME (Const (full_name, T)) => SOME (full_name, T)
+   | _ => NONE);
+
+\<comment>\<open>If a \<^emph>\<open>registered\<close> uRust notation \<open>name\<close> shares its name with an
+  \<^emph>\<open>unregistered\<close> HOL constant in scope whose type has matching kind
+  (call-position vs \<open>_ \<Rightarrow> _ function_body\<close>, or field-position vs
+  \<open>_ lens\<close>), surface it as a shadow:
+
+   - by default, errors are suppressed (\<open>suppress_error\<close>) and the
+     shadow is reported at warning level only;
+   - per-name \<open>[shadow_err]\<close> re-enables the error;
+   - per-name \<open>[shadow_no_warn]\<close> silences the warning too.
+
+  Literal-position uses are never shadow-checked --- shadowing on bare
+  values produces too much noise (e.g. \<^const>\<open>Some\<close> at \<open>'a \<Rightarrow> 'a option\<close>
+  would shadow every uRust \<^verbatim>\<open>Some\<close> use without any real ambiguity).
+  Cross-kind clashes are likewise ignored (a call-shaped HOL constant
+  is unrelated to a field-position uRust use of the same name, and
+  vice versa).
+
+  Only fires when there is at least one registered backend that unifies;
+  if dispatch has nothing to say, shadowing is irrelevant.\<close>
+fun shadow_check ctxt kind name T pos have_backend =
+  if not have_backend then () else
+  if kind = Micro_Rust_Names.NLiteral then () else
+  let val { suppress_warning, suppress_error } =
+        Micro_Rust_Names.shadow_opts ctxt kind name
+  in
+  (case lookup_hol_const ctxt name of
+    NONE => ()
+  | SOME (full_name, const_T) =>
+      if Micro_Rust_Names.infer_kind_of_type const_T <> kind then ()
+      else
+        let
+          \<comment>\<open>Render the constant via \<^ML>\<open>Syntax.pretty_term\<close> so name-space markup
+            (\<^verbatim>\<open>Name_Space.markup\<close> + \<^verbatim>\<open>Markup.const\<close>) is attached and ctrl-click
+            jumps to the defining \<^verbatim>\<open>definition\<close>/\<^verbatim>\<open>fun\<close>/\<^verbatim>\<open>primrec\<close> command.\<close>
+          val pretty_const = Syntax.pretty_term ctxt (Const (full_name, const_T))
+          val msg = Pretty.string_of (Pretty.chunks
+            [Pretty.str ("Ambiguous uRust notation \<open>" ^ name ^
+               "\<close>: a registered backend matches type"),
+             Pretty.block [Pretty.str "  ", Syntax.pretty_typ ctxt T],
+             Pretty.block
+               [Pretty.str "but the HOL constant ", pretty_const,
+                Pretty.str " of type"],
+             Pretty.block [Pretty.str "  ", Syntax.pretty_typ ctxt const_T],
+             Pretty.str "also matches.",
+             Pretty.str ("Either rename the registered backend or pick a different rust_name,"),
+             Pretty.str ((if suppress_error then
+                            "or run \<open>micro_rust_notation (config) [shadow_no_warn] \""
+                              ^ name ^ "\"\<close> to silence."
+                          else
+                            "or run \<open>micro_rust_notation (config) [shadow_no_err] \""
+                              ^ name ^ "\"\<close>.")
+                         ^ Position.here pos)])
+        in
+          if not suppress_error then error msg
+          else if not suppress_warning then warning msg
+          else ()
+        end)
+  end;
+
+\<comment>\<open>Should the elaborated witness shadow the table registration? Only in
+  one case: a \<^bold>\<open>literal\<close>-position occurrence (bare \<open>x\<close>) whose witness is a
+  \<^verbatim>\<open>Bound\<close> --- i.e. a \<open>let\<close>/\<lambda>-bound local, which correctly wins, mirroring
+  Rust's lexical scoping (\<open>let x = \<dots>; x\<close>).
+
+  In \<^bold>\<open>field\<close> (\<open>x.f\<close>) and \<^bold>\<open>function\<close> (\<open>f(\<dots>)\<close> / \<open>x.f(\<dots>)\<close>) positions the name
+  is a selector/callee that can never be a local binder, so a registered
+  notation \<^emph>\<open>always\<close> wins: e.g. the field selector \<open>.f\<close> in \<open>x.f\<close> must not be
+  shadowed by a same-named closure parameter \<open>|f| \<dots>\<close>, and a method call
+  \<open>x.f(f)\<close> must invoke the \<open>.f\<close> method even when the argument \<open>f\<close> is a
+  same-named local binder. (Trade-off: a locally-bound callable
+  \<open>let f = \<dots>; f(\<dots>)\<close> can no longer shadow a registered function notation;
+  uRust does not rely on that.)
+
+  \<^verbatim>\<open>Const\<close> witnesses never win either, since a backend is often registered
+  precisely to override a same-named HOL constant (e.g. \<^verbatim>\<open>("Some")\<close> for
+  \<^verbatim>\<open>lift_fun1 Some\<close>, where the witness \<^verbatim>\<open>Free "Some"\<close> elaborates to
+  \<^const>\<open>Option.Some\<close>).\<close>
+fun witness_takes_precedence Micro_Rust_Names.NLiteral (Bound _) = true
+  | witness_takes_precedence _ _ = false;
+
+\<comment>\<open>Resolve all dispatch markers in a term, in the typed check phase.
+  The marker has shape \<open>urust_dispatch (STR ''<tag>'') opt\<close> where \<open>opt\<close>
+  is either \<open>Some witness\<close> (plain id; HOL elaboration has resolved the
+  witness to \<open>Bound\<close>/\<open>Const\<close>/\<open>Free\<close> through normal binding) or \<open>None\<close>
+  (path id; no witness available).
+
+  Resolution rules (\<lambda>-binders already consumed at stage \<^verbatim>\<open>~1\<close> by
+  \<open>resolve_bound\<close>, so any surviving witness here is \<open>Free\<close>/\<open>Const\<close>):
+   - exactly 1 type-compatible candidate \<Rightarrow> splice it in (+ use-site markup);
+   - \<ge>2 candidates \<Rightarrow> ambiguous: leave the marker for \<open>reject_unresolved\<close>;
+   - 0 candidates \<Rightarrow> the name IS registered (a marker would not exist
+     otherwise) but no backend type-unifies with the occurrence \<Rightarrow>
+     \<open>no_match_error\<close> (a hard error; see there). We do NOT silently demote
+     to the witness free variable --- that would mask genuine arity/type
+     mismatches like \<open>Foo::mk()\<close> against a binary backend.\<close>
+\<comment>\<open>Early phase, runs at stage \<^verbatim>\<open>~1\<close> before type inference. Replaces a
+  marker with its witness ONLY if the witness is a \<^verbatim>\<open>Bound\<close> --- meaning
+  the surrounding \<open>_abs\<close> machinery has already resolved a \<lambda>-binder of
+  the same name. This must happen before \<open>adhoc_overloading\<close> runs (at
+  stage 0), so that \<lambda>-bound uses don't leave a polymorphic marker
+  behind that breaks operator resolution.
+
+  Uses \<^verbatim>\<open>dest_marker_untyped\<close> --- at this stage the marker's outer
+  type is still \<open>dummyT\<close>, so \<^verbatim>\<open>dest_marker\<close> would silently fail.\<close>
+\<comment>\<open>When the witness wins (the marker resolves to a \<^verbatim>\<open>Bound\<close>), we
+  also need to emit \<^verbatim>\<open>Markup.bound\<close> at the user's source position.
+  Without this the use site has no markup at all --- the position
+  carried by the user's source token went into the marker's payload
+  string (not into a \<open>_constrain\<close> wrapper around the witness, because
+  we strip those to suppress the const-promotion leak), so the
+  decoder never sees a position-tagged \<open>Bound\<close> to attach binder-use
+  markup to. We emit it ourselves from the recovered tag position.\<close>
+fun resolve_bound ctxt =
+  let
+    fun go t =
+      (case dest_marker_untyped t of
+         SOME ((kind, _, pos), SOME w) =>
+           if witness_takes_precedence kind w then
+             let val _ = Context_Position.report ctxt pos Markup.bound
+             in w end
+           else t
+       | _ =>
+           (case t of
+              u $ v => go u $ go v
+            | Abs (x, S, b) => Abs (x, S, go b)
+            | _ => t));
+  in map go end;
+
+\<comment>\<open>Late phase, runs at stage \<^verbatim>\<open>1\<close> after type inference. Markers that
+  survived \<^verbatim>\<open>resolve_bound\<close> here have a witness that's NOT a \<lambda>-binder
+  (so \<^verbatim>\<open>Free\<close> or \<^verbatim>\<open>Const\<close>), or are path markers (no witness). Now we
+  have full types and can do the typed table lookup.\<close>
+\<comment>\<open>Emit use-site markup at \<open>pos\<close> for every registered backend under
+  \<open>(kind, name)\<close>: an entity ref to the registration site (so ctrl-click
+  jumps back to \<open>micro_rust_notation\<close>), plus a \<^verbatim>\<open>Name_Space.markup\<close> +
+  \<^verbatim>\<open>Markup.keyword3\<close> chain when the backend itself is a bare constant
+  (ctrl-click to its definition, coloured as a keyword). Called by \<open>resolve\<close>
+  ONLY when a marker is actually replaced by a registered backend ---
+  never when the witness wins. This is what stops the markup from
+  leaking onto an identifier whose witness ends up being a \<lambda>-binder
+  (e.g. \<open>let x = \<dots>; x\<close> where \<open>x\<close> is also a registered notation: the
+  trailing \<open>x\<close> resolves to the let-binder, so no notation markup
+  should be attached).\<close>
+fun emit_use_markup_at_pos ctxt kind name pos =
+  if not (Position.is_reported pos) then ()
+  else
+    let
+      val entries = Micro_Rust_Names.lookups ctxt kind name
+      fun report_one ({serial, reg_pos, hol_term} : Micro_Rust_Names.entry) =
+        let
+          val notation_markup =
+            [Position.make_entity_markup {def = false} serial
+               Micro_Rust_Names.notationN (name, reg_pos)]
+          \<comment>\<open>Walk to the head \<^verbatim>\<open>Const\<close> of the backend so wrapper
+            forms like \<^verbatim>\<open>lift_fun1 Some\<close> still get const-styling
+            (color + ctrl-click) attached at the use site, not just the
+            \<open>micro_rust_notation\<close> entity ref. We use the standard
+            \<^verbatim>\<open>Name_Space.markup\<close> (an entity-style markup keyed by the
+            constant's def-site serial) for the click target, plus the
+            \<^verbatim>\<open>Markup.keyword3\<close> kind tag for the colour face (so
+            notation-resolved constants are coloured as keywords rather than
+            as ordinary constants).\<close>
+          fun head_const t =
+            (case Term_Position.strip_positions t of
+               Const (c, _) => SOME c
+             | u $ _ => head_const u
+             | _ => NONE)
+          val const_markup =
+            (case head_const hol_term of
+               SOME c =>
+                 [Name_Space.markup (Consts.space_of (Proof_Context.consts_of ctxt)) c,
+                  Markup.keyword3]
+             | NONE => [])
+        in
+          app (Context_Position.report ctxt pos) (notation_markup @ const_markup)
+        end
+    in
+      app report_one entries
+    end;
+
+\<comment>\<open>A marker only exists because \<open>lookup_id_tr\<close> found a registration for
+  \<open>(kind, name)\<close> (it emits nothing otherwise). So by the time \<open>resolve\<close>
+  runs --- with \<lambda>-binders already consumed by \<open>resolve_bound\<close> at stage
+  \<^verbatim>\<open>~1\<close> --- an empty candidate set means the name \<^emph>\<open>is\<close> registered but
+  \<^bold>\<open>no backend's type unifies\<close> with the occurrence type \<open>T\<close>. That is a
+  genuine error (e.g. \<open>Foo::mk()\<close> --- a no-arg call ---
+  against a backend of type \<open>'a \<Rightarrow> 'b \<Rightarrow> _ function_body\<close>),
+  not a reason to silently demote the name to a free variable. We report
+  it loudly, showing the occurrence type and every registered backend
+  with its type, so the arity/type mismatch is obvious.\<close>
+fun no_match_error ctxt kind name pos T =
+  error (Pretty.string_of (Pretty.chunks
+    [Pretty.block [Pretty.str ("uRust notation \<open>" ^ name ^
+       "\<close> is registered, but no backend matches the use-site type "),
+       Syntax.pretty_typ ctxt T, Pretty.str (Position.here pos)],
+     Pretty.big_list "registered backends (none type-compatible here):"
+       (map (fn { hol_term, ... } : Micro_Rust_Names.entry =>
+               Pretty.block [Syntax.pretty_term ctxt hol_term, Pretty.str " :: ",
+                             Syntax.pretty_typ ctxt (fastype_of hol_term)])
+          (Micro_Rust_Names.lookups ctxt kind name))]));
+
+fun resolve ctxt =
+  let
+    fun go t =
+      (case dest_marker t of
+         SOME ((kind, name, pos), opt_witness, T) =>
+           let
+             val cands = candidates ctxt kind name T
+             val _ = shadow_check ctxt kind name T pos (not (null cands))
+             fun emit () = emit_use_markup_at_pos ctxt kind name pos
+           in
+             (case (opt_witness, cands) of
+                (SOME w, _) =>
+                  if witness_takes_precedence kind w then w \<comment>\<open>binder wins, no markup\<close>
+                  else
+                    (case cands of
+                       [single] => (emit (); single)
+                     | [] => no_match_error ctxt kind name pos T
+                     | _ => t \<comment>\<open>ambiguous: leave for reject_unresolved\<close>)
+              | (NONE, [single]) => (emit (); single)
+              | (NONE, []) => no_match_error ctxt kind name pos T
+              | (NONE, _) => t)
+           end
+       | NONE =>
+           (case t of
+              u $ v => go u $ go v
+            | Abs (x, S, b) => Abs (x, S, go b)
+            | _ => t));
+  in map go end;
+
+\<comment>\<open>After resolution, any surviving marker is genuinely ambiguous (\<ge>2
+  unifying backends); report it loudly, listing the candidates.\<close>
+fun reject_unresolved ctxt =
+  let
+    fun check t =
+      (case dest_marker t of
+         SOME ((kind, name, pos), _, T) =>
+           error (Pretty.string_of (Pretty.chunks
+             [Pretty.block [Pretty.str ("Ambiguous uRust notation \<open>" ^ name ^
+                "\<close> at type "), Syntax.pretty_typ ctxt T,
+                Pretty.str (Position.here pos)],
+              Pretty.big_list "candidate backends:"
+                (map (Syntax.pretty_term ctxt o #hol_term)
+                   (Micro_Rust_Names.lookups ctxt kind name))]))
+       | NONE =>
+           (case t of u $ v => (check u; check v) | Abs (_, _, b) => check b | _ => ()));
+  in app check end;
+
+\<comment>\<open>Install the two check phases (only fire when at least one marker is
+  present, so this is free for marker-less terms). Phase 0 resolves; phase
+  1 rejects leftover/ambiguous.\<close>
+\<comment>\<open>Run at negative priority so we resolve markers \<^emph>\<open>before\<close>
+  \<^verbatim>\<open>adhoc_overloading\<close>'s check (which lives at priority 0). Otherwise
+  a use site like \<open>shdw + mask\<close> --- where \<open>+\<close> is adhoc-overloaded
+  \<^verbatim>\<open>urust_add\<close> --- would fail adhoc resolution before our marker had a
+  chance to splice in the registered backend (or fall back to the
+  \<lambda>-bound witness), because the marker carries a polymorphic result
+  type that adhoc-overloading cannot disambiguate.\<close>
+val _ = Context.>>
+  (Syntax_Phases.term_check ~1 "urust_dispatch_bind"
+     (fn ctxt => resolve_bound ctxt)
+   #> Syntax_Phases.term_check 0 "urust_dispatch"
+        (fn ctxt => resolve ctxt)
+   #> Syntax_Phases.term_check 1 "urust_dispatch_unresolved"
+        (fn ctxt => fn ts => (reject_unresolved ctxt ts; ts)));
+
+end
+\<close>
+
+(* ===================================================================== *)
+(* Outer-syntax command for registering and configuring uRust notations.  *)
+(*                                                                        *)
+(* Single command, three modifier flavours:                               *)
+(*                                                                        *)
+(*   micro_rust_notation                <hol_term> ("<rust_name>")        *)
+(*     -- kind auto-inferred from the HOL term's type                     *)
+(*                                                                        *)
+(*   micro_rust_notation (literal)      <hol_term> ("<rust_name>")        *)
+(*   micro_rust_notation (call)         <hol_term> ("<rust_name>")        *)
+(*   micro_rust_notation (field)        <hol_term> ("<rust_name>")        *)
+(*     -- forces the kind; validates the HOL term's type and errors      *)
+(*        out if it doesn't fit (call: needs `_ \<Rightarrow> _ function_body`,     *)
+(*        field: needs `_ \<Rightarrow> _ \<Rightarrow> _ \<Rightarrow> _ focus`).                            *)
+(*                                                                        *)
+(*   micro_rust_notation (config) [<mode>] "name1" "name2" ...            *)
+(*     -- shadow-check configuration. Modes:                              *)
+(*          shadow_warn / shadow_no_warn / shadow_err / shadow_no_err     *)
+(*        (each toggles one bit; the orthogonal bit is preserved.)       *)
+(*        Empty name list applies to the global default.                  *)
+(*                                                                        *)
+(* `print_micro_rust_notations` (separate diag command) lists every       *)
+(* registered notation.                                                   *)
+(* ===================================================================== *)
+
+ML\<open>
+structure Micro_Rust_Notation_Cmd = struct
+
+\<comment>\<open>Validate that a forced kind is consistent with the term's type. Fail
+  loudly if not. (Auto-inferred kind never fails this check by
+  construction.)\<close>
+fun check_forced_kind kind ctxt t =
+  let
+    val T = fastype_of t
+    val inferred = Micro_Rust_Names.infer_kind_of_type T
+  in
+    if kind = Micro_Rust_Names.NLiteral
+      orelse kind = inferred
+    then ()
+    else
+      error (Pretty.string_of (Pretty.chunks
+        [Pretty.block [Pretty.str ("micro_rust_notation (" ^
+           Micro_Rust_Names.kind_to_string kind ^ "): forced kind does not match\
+           \ the registered term's type."),
+         Pretty.brk 1, Pretty.str "Term: ", Syntax.pretty_term ctxt t],
+         Pretty.block [Pretty.str "Type: ", Syntax.pretty_typ ctxt T]]))
+  end;
+
+\<comment>\<open>A rust name is \<^emph>\<open>grammatical\<close> if the µRust frontend's grammar can
+  already parse it as a \<^verbatim>\<open>urust_identifier\<close>: either a plain identifier
+  (\<open>foo_bar\<close>) or a \<^verbatim>\<open>::\<close>-style path (\<open>Foo::bar::baz\<close>, which the path-AST
+  translation flattens). Anything else --- turbofish forms like
+  \<open>Address::<IPA>::new\<close>, or macro names like \<open>fatal!\<close> --- contains
+  characters (\<open><\<close>, \<open>>\<close>, \<open>!\<close>, \<dots>) that no grammar production covers, so
+  the token cannot be parsed at all. For those we must additionally emit
+  a bespoke grammar production + AST translation (see
+  \<open>emit_bespoke_syntax\<close>): the dispatch-table entry alone is useless if the
+  use site never parses.\<close>
+fun is_grammatical_name name =
+  let val remove_colons = String.translate (fn #":" => "" | c => String.str c)
+  in Symbol_Pos.is_identifier name
+       orelse Symbol_Pos.is_identifier (remove_colons name)
+  end;
+
+\<comment>\<open>For a non-grammatical rust name (turbofish/macro), emit a bespoke
+  grammar production so the surface token parses, then funnel it back into
+  the \<^emph>\<open>ordinary\<close> identifier pipeline --- exactly as the path frontend does
+  for \<open>Foo::bar\<close>. We declare a fresh nullary \<^verbatim>\<open>urust_identifier\<close> constant
+  whose mixfix template IS the rust name (so the exact token sequence
+  becomes one grammar atom), plus a \<^verbatim>\<open>parse_ast_translation\<close> hook
+  rewriting it to \<open>_urust_identifier_id (Ast.Variable <rust_name>)\<close> --- the
+  SAME AST node a plain/path identifier yields. From there it flows through
+  \<open>lookup_id_tr\<close> and the dispatch table uniformly; the turbofish-ness is
+  confined to the AST frontend. The syntax-constant name is a sanitised
+  (alphanumeric-only) form of the rust name.
+
+  \<^bold>\<open>Clickability + no overloading.\<close> A \<^verbatim>\<open>syntax_consts\<close> dependency binds
+  the bespoke constant to its backend constant, which (a) makes the use
+  site ctrl-clickable --- \<^verbatim>\<open>parsetree_to_ast\<close> reports the binding before
+  the parse translation fires --- and (b) forces \<^emph>\<open>at most one\<close> backend per
+  name (the single production has one \<^verbatim>\<open>syntax_consts\<close> target), so we reject
+  a second registration in any kind.
+
+  We therefore need a single backend constant \<open>c\<close>. \<open>Term.head_of t0\<close> gives
+  it for a definition/raw constant; for an \<^theory_text>\<open>abbreviation\<close>
+  \<^verbatim>\<open>read_term\<close> returns the \<^emph>\<open>expansion\<close> (head \<^verbatim>\<open>Abs\<close>), so we recover \<open>c\<close>
+  from the source string via \<^ML>\<open>Proof_Context.read_const\<close> (no unfolding).
+  Error only if neither yields a constant.\<close>
+fun emit_bespoke_syntax hol_src rust_name t0 lthy =
+  if is_grammatical_name rust_name then lthy
+  else
+    let
+      val c =
+        (case Term.head_of t0 of
+           Const (c, _) => c
+         | _ =>
+           (case try (Proof_Context.read_const {proper = true, strict = false} lthy) hol_src of
+              SOME (Const (c, _)) => c
+            | _ =>
+             error (Pretty.string_of (Pretty.chunks
+               [Pretty.str ("micro_rust_notation: the rust name " ^ quote rust_name ^
+                  " is not a plain identifier or ::-path, so it needs a bespoke"),
+                Pretty.str "grammar production whose markup binds to a single backend\
+                  \ constant --- but the registered term is not a constant or abbreviation:",
+                Pretty.block [Pretty.str "  ", Syntax.pretty_term lthy t0]]))))
+      \<comment>\<open>Reject overloading: at most one backend per non-grammatical name,
+        across all kinds (the single grammar production has a single
+        \<^verbatim>\<open>syntax_consts\<close> target).\<close>
+      val existing =
+        maps (fn k => Micro_Rust_Names.lookups lthy k rust_name)
+          [Micro_Rust_Names.NLiteral, Micro_Rust_Names.NFunction,
+           Micro_Rust_Names.NField]
+      val _ =
+        if null existing then ()
+        else error (Pretty.string_of (Pretty.chunks
+          [Pretty.str ("micro_rust_notation: the non-grammatical name " ^
+             quote rust_name ^ " is already registered and cannot be"),
+           Pretty.str "overloaded --- its bespoke grammar production binds to a single\
+             \ backend. Pick a distinct name, or use a plain/::-path name",
+           Pretty.str "(those support type-directed multi-backend dispatch)."]))
+      val sanitise =
+        String.translate (fn ch =>
+          if Char.isAlphaNum ch then String.str ch else "")
+      val syntax_constant = "_urust_identifier_bespoke_" ^ sanitise rust_name
+      \<comment>\<open>The nullary template parses to \<open>Ast.Constant syntax_constant\<close> with
+        no arguments, so the hook recovers the name from its closure (not
+        from the AST args). We name \<open>_urust_identifier_id\<close> by string rather
+        than \<^verbatim>\<open>\<^syntax_const>\<close>: this theory imports only \<open>Main\<close>, so that
+        frontend syntax constant is not in scope at ML-compile time --- but
+        it always is at the downstream use sites where the command runs.
+        (The existing \<open>urust_const_ast_tr\<close> in \<open>Micro_Rust_Shallow_Embedding\<close>
+        names it the same way, for the same reason.)\<close>
+      fun hook _ _ =
+        Ast.Appl [Ast.Constant "_urust_identifier_id",
+                  Ast.Variable rust_name]
+    in
+      lthy
+      |> Local_Theory.syntax_cmd true Syntax.mode_default
+           [(syntax_constant, "urust_identifier", Mixfix.mixfix rust_name)]
+      |> Local_Theory.background_theory
+           (Sign.parse_ast_translation [(syntax_constant, hook)])
+      \<comment>\<open>Bind the bespoke syntax constant to its backend so use sites are
+        ctrl-clickable to the backend's definition (see above). The RHS
+        must be the \<^emph>\<open>marked\<close> constant name (\<^ML>\<open>Lexicon.mark_const\<close>):
+        \<^ML>\<open>Syntax.get_consts\<close> feeds it to \<^ML>\<open>Lexicon.unmark_entity\<close>,
+        which only recognises marked names --- an unmarked name falls
+        through to the default case, yielding no markup. (The
+        \<^theory_text>\<open>syntax_consts\<close> command applies the same marking.)\<close>
+      |> Local_Theory.syntax_deps [(syntax_constant, [Lexicon.mark_const c])]
+    end;
+
+fun do_register kind_opt (hol_src, (rust_name, rust_pos)) lthy =
+  let
+    val t0 = Syntax.read_term lthy hol_src
+    val kind =
+      case kind_opt of
+        SOME k => (check_forced_kind k lthy t0; k)
+      | NONE => Micro_Rust_Names.infer_kind_of_type (fastype_of t0)
+  in
+    lthy
+    |> emit_bespoke_syntax hol_src rust_name t0
+    |> Local_Theory.declaration {pervasive=false, syntax=true, pos=Position.none}
+      (fn phi =>
+        Micro_Rust_Names.register kind rust_name (Morphism.term phi t0) rust_pos)
+  end;
+
+\<comment>\<open>Config sub-command: parse \<open>[mode] "name"+\<close> and update the
+  shadow-opt-out table. Empty name list \<Rightarrow> touch the default.\<close>
+val parse_shadow_mode : Micro_Rust_Names.shadow_bit parser =
+  Parse.$$$ "[" |--
+    (   Args.$$$ "shadow_warn"    >> K (Micro_Rust_Names.Set_Suppress_Warning false)
+     || Args.$$$ "shadow_no_warn" >> K (Micro_Rust_Names.Set_Suppress_Warning true)
+     || Args.$$$ "shadow_err"     >> K (Micro_Rust_Names.Set_Suppress_Error false)
+     || Args.$$$ "shadow_no_err"  >> K (Micro_Rust_Names.Set_Suppress_Error true))
+    --| Parse.$$$ "]";
+
+val parse_names : string list parser =
+  Scan.repeat (Parse.position Parse.string >> #1);
+
+val all_kinds =
+  [Micro_Rust_Names.NLiteral, Micro_Rust_Names.NFunction, Micro_Rust_Names.NField];
+
+fun do_config (bit, names) lthy =
+  lthy |> Local_Theory.declaration {pervasive=false, syntax=false, pos=Position.none}
+    (fn _ => fold (fn k => Micro_Rust_Names.set_shadow_bit k names bit) all_kinds);
+
+\<comment>\<open>Payload for the registration sub-commands: a HOL term followed by
+  the rust-side name (positional, for markup).\<close>
+val parse_payload =
+  Parse.term -- Parse.position (Parse.$$$ "(" |-- Parse.string --| Parse.$$$ ")");
+
+\<comment>\<open>Top-level dispatch on the optional \<open>(\<dots>)\<close> modifier:
+     absent     \<longrightarrow> auto-inferred registration
+     \<open>(literal)\<close> \<longrightarrow> forced literal
+     \<open>(call)\<close>    \<longrightarrow> forced function (the keyword \<open>function\<close> is taken
+                    by HOL globally, so we use \<open>call\<close>)
+     \<open>(field)\<close>   \<longrightarrow> forced field
+     \<open>(config)\<close>  \<longrightarrow> shadow-check configuration sub-command
+  Each branch parses its own remainder of the line.\<close>
+val parse_cmd : (local_theory -> local_theory) parser =
+  let
+    val parse_register_with_kind =
+      parse_payload >> (fn p => fn k => do_register (SOME k) p)
+  in
+       (Parse.$$$ "(" |-- Args.$$$ "literal" --| Parse.$$$ ")"
+          |-- parse_register_with_kind
+          >> (fn f => f Micro_Rust_Names.NLiteral))
+    || (Parse.$$$ "(" |-- Args.$$$ "call" --| Parse.$$$ ")"
+          |-- parse_register_with_kind
+          >> (fn f => f Micro_Rust_Names.NFunction))
+    || (Parse.$$$ "(" |-- Args.$$$ "field" --| Parse.$$$ ")"
+          |-- parse_register_with_kind
+          >> (fn f => f Micro_Rust_Names.NField))
+    || (Parse.$$$ "(" |-- Args.$$$ "config" --| Parse.$$$ ")"
+          |-- parse_shadow_mode -- parse_names
+          >> do_config)
+    || (parse_payload >> do_register NONE)
+  end;
+
+val _ =
+  Outer_Syntax.local_theory \<^command_keyword>\<open>micro_rust_notation\<close>
+    "register a uRust notation (auto / forced kind) or configure shadow checks"
+    parse_cmd;
+
+end
+\<close>
+
+
+ML\<open>
+\<comment>\<open>Query command: prints every registered notation as
+  \<open><rust> \<longmapsto> <hol> (context)\<close>, with the HOL term printed via
+  \<open>Syntax.pretty_term\<close>.\<close>
+val _ =
+  Outer_Syntax.command \<^command_keyword>\<open>print_micro_rust_notations\<close>
+    "list all registered uRust name notations"
+    (Scan.succeed (Toplevel.keep (fn st =>
+      let
+        val ctxt = Toplevel.context_of st;
+        val entries = Micro_Rust_Names.dump ctxt;
+        fun pretty (kind, rust, { hol_term, ... } : Micro_Rust_Names.entry) =
+          Pretty.block
+            [Pretty.str rust, Pretty.str " \<longmapsto> ",
+             Syntax.pretty_term ctxt hol_term,
+             Pretty.str ("  (" ^ Micro_Rust_Names.kind_to_string kind ^ ")")];
+      in
+        if null entries then writeln "no uRust name notations registered"
+        else Pretty.writeln
+          (Pretty.big_list "uRust name notations:" (map pretty entries))
+      end)));
+\<close>
+
+
+(* ===================================================================== *)
+(* Smoke tests                                                            *)
+(* ===================================================================== *)
+
+experiment
+begin
+
+definition test_my_some_a :: \<open>nat \<Rightarrow> nat option\<close> where
+  \<open>test_my_some_a x = Some x\<close>
+
+definition test_my_some_b :: \<open>bool \<Rightarrow> bool option\<close> where
+  \<open>test_my_some_b b = Some b\<close>
+
+\<comment>\<open>Single backend, kind forced via \<open>(literal)\<close>. The HOL constant's
+  type is \<open>nat \<Rightarrow> nat option\<close> (no \<open>function_body\<close>, no \<open>lens\<close>) so the
+  auto-inferred kind would also be \<open>literal\<close>; the modifier here is
+  purely to exercise the parser branch.\<close>
+micro_rust_notation (literal) test_my_some_a ("MySome")
+
+\<comment>\<open>Multi-backend, no modifier: kind auto-inferred from the term's
+  type. Same name as above; the typed term_check phase picks exactly
+  one per occurrence (or reports ambiguity if both unify).\<close>
+micro_rust_notation test_my_some_b ("MySome")
+
+\<comment>\<open>Field-position registration: as a smoke test we don't have a real
+  lens fixture in this experiment, so we register the same
+  \<open>literal\<close>-shaped \<open>test_my_some_a\<close> under a field name with no kind
+  modifier (auto-infer falls back to \<open>literal\<close>). For a real
+  field-typed backend, see \<^verbatim>\<open>register_lens_with_micro_rust\<close> in
+  Micro_Rust_Shallow_Embedding.thy.\<close>
+micro_rust_notation test_my_some_a ("a_field")
+
+print_micro_rust_notations
+
+\<comment>\<open>Direct exercise of the dispatch term_check phase: a marker constrained
+  at type \<open>nat \<Rightarrow> nat option\<close> resolves to \<open>test_my_some_a\<close>; constrained
+  at \<open>bool \<Rightarrow> bool option\<close> resolves to \<open>test_my_some_b\<close>. The check fires
+  only when the marker survives type inference, so we use \<open>typ\<close>
+  ascriptions.\<close>
+term \<open>(urust_dispatch (STR ''literal:MySome'') NoWitness :: nat \<Rightarrow> nat option)\<close>
+term \<open>(urust_dispatch (STR ''literal:MySome'') NoWitness :: bool \<Rightarrow> bool option)\<close>
+
+\<comment>\<open>Ambiguity: register two same-typed backends under the same name and
+  show the loud error.  We use a comment-only assertion --- attempting
+  the lookup at \<open>id\<close>'s shared schematic type would unify with both.\<close>
+definition test_id_a :: \<open>nat \<Rightarrow> nat\<close> where \<open>test_id_a x = x\<close>
+definition test_id_b :: \<open>nat \<Rightarrow> nat\<close> where \<open>test_id_b x = x\<close>
+
+micro_rust_notation test_id_a ("Ambig")
+micro_rust_notation test_id_b ("Ambig")
+
+\<comment>\<open>Both backends have type \<open>nat \<Rightarrow> nat\<close>; an occurrence at \<open>nat \<Rightarrow> nat\<close>
+  unifies with both, so resolution errors loudly listing candidates:
+
+    Ambiguous uRust notation \<open>Ambig\<close> at type nat \<Rightarrow> nat
+    candidate backends:
+      test_id_b
+      test_id_a
+
+  Uncomment the line below to reproduce; left commented so the file
+  builds clean.\<close>
+\<comment>\<open>term \<open>(urust_dispatch (STR ''function:Ambig'') :: nat \<Rightarrow> nat)\<close>\<close>
+
+end
+
+end

--- a/Shallow_Micro_Rust/Micro_Rust_Notations_Test.thy
+++ b/Shallow_Micro_Rust/Micro_Rust_Notations_Test.thy
@@ -1,0 +1,929 @@
+(* Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+   SPDX-License-Identifier: MIT *)
+
+(* Tests for the `micro_rust_notation` command: a uRust identifier
+   registered with it must resolve to its HOL backend when used inside
+   `\<lbrakk> \<dots> \<rbrakk>`. The parse-translation for `_shallow_identifier_as_*` consults
+   `Micro_Rust_Names`, emits a `urust_dispatch` marker, and the typed
+   term_check phase resolves it (e.g. to `my_test_some`). *)
+
+theory Micro_Rust_Notations_Test
+  imports Micro_Rust_Shallow_Embedding
+begin
+
+definition my_test_some :: \<open>nat \<Rightarrow> nat option\<close> where
+  \<open>my_test_some x = Some x\<close>
+
+\<comment>\<open>Register in literal context: bare \<open>MyTestSome\<close> in value position
+  takes the \<open>_shallow_identifier_as_literal\<close> path.\<close>
+micro_rust_notation my_test_some ("MyTestSome")
+print_micro_rust_notations
+
+text\<open>\<^verbatim>\<open>\<lbrakk> MyTestSome \<rbrakk>\<close> resolves to a literal whose value is
+\<^const>\<open>my_test_some\<close>, NOT a free variable named \<open>MyTestSome\<close>.\<close>
+
+term \<open>\<lbrakk> MyTestSome \<rbrakk>\<close>
+
+\<comment>\<open>Acceptance test: the identifier resolves to the registered HOL
+  constant, so the embedding is syntactically equal to \<open>literal
+  my_test_some\<close>.\<close>
+lemma test_my_test_some_dispatched:
+  shows \<open>\<lbrakk> MyTestSome \<rbrakk> = literal my_test_some\<close>
+  by (rule refl)
+
+text\<open>Non-\<open>Const\<close> backend: register an arbitrary HOL expression. The
+dispatch should still resolve, but the use-site markup should fall back
+to the registration site (since there is no underlying constant for
+ctrl-click to jump to).\<close>
+
+micro_rust_notation \<open>1 + (1 :: nat)\<close> ("OnePlusOne")
+
+term \<open>\<lbrakk> OnePlusOne \<rbrakk>\<close>
+              
+\<comment>\<open>Acceptance: the marker resolves to the registered expression.\<close>
+lemma test_one_plus_one_dispatched:
+  shows \<open>\<lbrakk> OnePlusOne \<rbrakk> = literal (1 + (1 :: nat))\<close>
+  by (rule refl)
+
+text\<open>\<^verbatim>\<open>print_micro_rust_notations\<close> enumerates every entry in
+\<^ML_structure>\<open>Micro_Rust_Names\<close> --- e.g. the \<open>Some\<close>/\<open>Ok\<close>/\<open>Err\<close> and
+std-lib registrations in scope.\<close>
+
+print_micro_rust_notations
+
+
+subsection\<open>Shadow detection\<close>
+
+text\<open>The dispatcher rejects --- and warns about --- registrations whose
+\<^emph>\<open>rust\<close>-name accidentally collides with an existing HOL constant. The
+fixture below sets up two HOL constants and uses them via dispatch
+markers to trigger both branches of the check.\<close>
+
+context begin
+
+\<comment>\<open>HOL constant whose type matches what we then register: \<open>nat \<Rightarrow> nat\<close>.\<close>
+private definition shadow_target_const :: \<open>nat \<Rightarrow> nat\<close>
+  where \<open>shadow_target_const x = x + 1\<close>
+
+\<comment>\<open>HOL constant of a different type, used to test the warning branch.\<close>
+private definition shadow_warn_const :: \<open>nat \<Rightarrow> bool\<close>
+  where \<open>shadow_warn_const x = (x = 0)\<close>
+
+\<comment>\<open>An unrelated backend we will register under each shadow name.\<close>
+private definition shadow_backend :: \<open>nat \<Rightarrow> nat\<close>
+  where \<open>shadow_backend x = x\<close>
+
+\<comment>\<open>Register the backend under names that collide with the HOL constants.
+  Registration itself is silent; the check fires at use time.\<close>
+micro_rust_notation shadow_backend ("shadow_target_const")
+micro_rust_notation shadow_backend ("shadow_warn_const")
+
+text\<open>\<^bold>\<open>Error path\<close> --- a HOL constant of \<^emph>\<open>matching\<close> type already exists.
+The marker below triggers \<open>shadow_check\<close>'s \<open>error\<close>:
+
+\<^verbatim>\<open>Ambiguous uRust notation \<open>shadow_target_const\<close>:
+   a registered backend matches type nat \<Rightarrow> nat
+   but the HOL constant "shadow_target_const" of type nat \<Rightarrow> nat also matches.\<close>
+
+The line is left commented so the test theory still compiles; uncomment
+to reproduce the error interactively.\<close>
+
+\<comment>\<open>term \<open>(urust_dispatch (STR ''literal:shadow_target_const'') :: nat \<Rightarrow> nat)\<close>\<close>
+
+text\<open>\<^bold>\<open>Warning path\<close> --- a HOL constant exists but its type does
+\<^emph>\<open>not\<close> match this occurrence. Dispatch picks the registered backend and
+emits a \<open>warning\<close> mentioning the shadowed constant. Compiles cleanly.
+
+The warning attaches to the \<^emph>\<open>use site\<close> of \<open>shadow_warn_const\<close>
+(plumbed via \<open>mk_marker\<close>), not to the surrounding \<open>term\<close> command, so
+jEdit highlights the identifier itself.
+
+We use a ``urust_dispatch`` marker directly here (rather than wrapping
+in \<open>\<lbrakk> \<dots> \<rbrakk>\<close>) so the registered backend's bare \<open>nat \<Rightarrow> nat\<close>
+type matches without needing a \<open>function_body\<close> lift.\<close>
+term \<open>(urust_dispatch (STR ''literal:shadow_warn_const'') NoWitness :: nat \<Rightarrow> nat)\<close>
+
+end
+
+
+subsection\<open>Shadow-opt-out flags\<close>
+
+text\<open>The \<open>[no_shadow_warning]\<close> and \<open>[no_shadow_error]\<close> brackets on
+\<open>micro_rust_notation\<close> silence the corresponding diagnostic for the
+named registration. Each flag is per-(kind, name); the underlying
+warning / error logic is unchanged.\<close>
+
+context begin
+
+private definition silenced_warn_const :: \<open>nat \<Rightarrow> bool\<close>
+  where \<open>silenced_warn_const _ = True\<close>
+
+private definition silenced_target_const :: \<open>nat \<Rightarrow> nat\<close>
+  where \<open>silenced_target_const x = x\<close>
+
+private definition silenced_backend :: \<open>nat \<Rightarrow> nat\<close>
+  where \<open>silenced_backend x = x + 1\<close>
+
+\<comment>\<open>Register the backends without flags; configure shadow checks
+  separately afterwards via \<open>micro_rust_notation_config\<close>. This
+  decouples the registration site from the silencing decision, and
+  lets the user adjust either independently.\<close>
+micro_rust_notation silenced_backend ("silenced_warn_const")
+micro_rust_notation silenced_backend ("silenced_target_const")
+
+\<comment>\<open>\<^bold>\<open>Warning silenced.\<close> The HOL constant
+  \<^const>\<open>silenced_warn_const\<close> exists at type \<open>nat \<Rightarrow> bool\<close>; without
+  the config below, dispatch at \<open>nat \<Rightarrow> nat\<close> would print the
+  "uRust notation \<dots> shadows the HOL constant \<dots>" warning.\<close>
+micro_rust_notation (config) [shadow_no_warn] "silenced_warn_const"
+
+term \<open>(urust_dispatch (STR ''literal:silenced_warn_const'') NoWitness :: nat \<Rightarrow> nat)\<close>
+
+\<comment>\<open>\<^bold>\<open>Error silenced.\<close> The HOL constant
+  \<^const>\<open>silenced_target_const\<close> exists at \<open>nat \<Rightarrow> nat\<close>; without the
+  config below, dispatch at \<open>nat \<Rightarrow> nat\<close> would error out as ambiguously
+  shadowing. \<open>shadow_no_err\<close> on this name routes us silently to the
+  registered backend.\<close>
+micro_rust_notation (config) [shadow_no_err] "silenced_target_const"
+
+term \<open>(urust_dispatch (STR ''literal:silenced_target_const'') NoWitness :: nat \<Rightarrow> nat)\<close>
+
+end
+
+
+subsection\<open>Variant coverage\<close>
+
+text\<open>Exercise every form of the consolidated \<open>micro_rust_notation\<close>
+command --- the auto-infer paths for all three kinds, the forced-kind
+paths in their happy and error cases, and the four \<open>shadow_*\<close> config
+modes (set, clear, per-name, default).\<close>
+
+context begin
+
+\<comment>\<open>Auto-infer literal: a non-function, non-lens HOL term routes to
+  literal kind (the default fallthrough in \<open>infer_kind_of_type\<close>).\<close>
+private definition variant_lit :: \<open>nat\<close> where \<open>variant_lit = 0\<close>
+micro_rust_notation variant_lit ("VariantLit")
+term \<open>(urust_dispatch (STR ''literal:VariantLit'') NoWitness :: nat)\<close>
+
+\<comment>\<open>Auto-infer function: a HOL term whose type ends in \<open>function_body\<close>
+  routes to function kind. We use \<open>lift_fun1\<close>, the standard wrapper.\<close>
+private definition variant_fn :: \<open>nat \<Rightarrow> ('s, nat, 'abort, 'i, 'o) function_body\<close>
+  where \<open>variant_fn = lift_fun1 Suc\<close>
+micro_rust_notation variant_fn ("VariantFn")
+term \<open>(urust_dispatch (STR ''function:VariantFn'') NoWitness :: nat \<Rightarrow> ('s, nat, 'a, 'i, 'o) function_body)\<close>
+
+\<comment>\<open>Forced-kind happy paths.\<close>
+private definition variant_lit_forced :: \<open>nat\<close> where \<open>variant_lit_forced = 1\<close>
+micro_rust_notation (literal) variant_lit_forced ("VariantLitForced")
+term \<open>(urust_dispatch (STR ''literal:VariantLitForced'') NoWitness :: nat)\<close>
+
+private definition variant_fn_forced :: \<open>nat \<Rightarrow> ('s, nat, 'abort, 'i, 'o) function_body\<close>
+  where \<open>variant_fn_forced = lift_fun1 Suc\<close>
+micro_rust_notation (call) variant_fn_forced ("VariantFnForced")
+term \<open>(urust_dispatch (STR ''function:VariantFnForced'') NoWitness :: nat \<Rightarrow> ('s, nat, 'a, 'i, 'o) function_body)\<close>
+
+text\<open>Forced-kind error paths. Each line below would error with
+``forced kind does not match the registered term's type'' if
+uncommented; we keep them as commented-out smoke tests so the file
+builds clean while documenting the expected behaviour.
+
+\<^verbatim>\<open>micro_rust_notation (call)  variant_lit ("X")\<close>  -- term has type \<open>nat\<close>, not \<open>_ \<Rightarrow> _ function_body\<close>
+\<^verbatim>\<open>micro_rust_notation (field) variant_lit ("Y")\<close>  -- term has type \<open>nat\<close>, not \<open>_ lens\<close>
+\<^verbatim>\<open>micro_rust_notation (field) variant_fn  ("Z")\<close>  -- term has type \<open>_ \<Rightarrow> _ function_body\<close>, not \<open>_ lens\<close>\<close>
+
+\<comment>\<open>Toggle off and back on: \<open>shadow_no_warn\<close> sets the bit;
+  \<open>shadow_warn\<close> clears it.\<close>
+private definition variant_warn_const :: \<open>nat \<Rightarrow> bool\<close>
+  where \<open>variant_warn_const _ = False\<close>
+private definition variant_warn_backend :: \<open>nat \<Rightarrow> nat\<close>
+  where \<open>variant_warn_backend x = x\<close>
+micro_rust_notation variant_warn_backend ("variant_warn_const")
+
+\<comment>\<open>Set the suppression: this dispatch should NOT warn even though the
+  HOL constant of differently-typed name exists.\<close>
+micro_rust_notation (config) [shadow_no_warn] "variant_warn_const"
+term \<open>(urust_dispatch (STR ''literal:variant_warn_const'') NoWitness :: nat \<Rightarrow> nat)\<close>
+
+\<comment>\<open>Clear the suppression: this dispatch SHOULD warn again.\<close>
+micro_rust_notation (config) [shadow_warn] "variant_warn_const"
+term \<open>(urust_dispatch (STR ''literal:variant_warn_const'') NoWitness :: nat \<Rightarrow> nat)\<close>
+
+\<comment>\<open>Default-scope (no names): \<open>shadow_no_warn\<close> with no name argument
+  silences the warning globally for the next dispatch.\<close>
+private definition variant_default_const :: \<open>nat \<Rightarrow> bool\<close>
+  where \<open>variant_default_const _ = False\<close>
+private definition variant_default_backend :: \<open>nat \<Rightarrow> nat\<close>
+  where \<open>variant_default_backend x = x\<close>
+micro_rust_notation variant_default_backend ("variant_default_const")
+
+\<comment>\<open>Globally suppress warnings; the dispatch below proceeds silently.\<close>
+micro_rust_notation (config) [shadow_no_warn]
+term \<open>(urust_dispatch (STR ''literal:variant_default_const'') NoWitness :: nat \<Rightarrow> nat)\<close>
+
+\<comment>\<open>Restore warnings globally so we don't pollute later tests.\<close>
+micro_rust_notation (config) [shadow_warn]
+
+\<comment>\<open>Toggle off and back on for the error bit, mirroring the warning
+  test above. We register a backend whose type matches an existing
+  HOL constant (so without suppression the dispatch errors).\<close>
+private definition variant_err_const :: \<open>nat \<Rightarrow> nat\<close>
+  where \<open>variant_err_const x = x\<close>
+private definition variant_err_backend :: \<open>nat \<Rightarrow> nat\<close>
+  where \<open>variant_err_backend x = x + 1\<close>
+micro_rust_notation variant_err_backend ("variant_err_const")
+
+\<comment>\<open>Suppress the matching-shadow error and dispatch.\<close>
+micro_rust_notation (config) [shadow_no_err] "variant_err_const"
+term \<open>(urust_dispatch (STR ''literal:variant_err_const'') NoWitness :: nat \<Rightarrow> nat)\<close>
+
+\<comment>\<open>The \<open>shadow_err\<close> mode (re-enable errors) flips the bit back.
+  We don't actually re-dispatch here --- it would error --- but the
+  command itself succeeds and toggles the bit.\<close>
+micro_rust_notation (config) [shadow_err] "variant_err_const"
+
+end
+
+
+subsection\<open>Path-style names (\<^verbatim>\<open>Foo::Bar\<close>) via the new dispatcher\<close>
+
+text\<open>\<^verbatim>\<open>lookup_id_tr\<close> consults \<^ML_structure>\<open>Micro_Rust_Names\<close> for
+path-flattened identifiers (\<^verbatim>\<open>foo::bar\<close>) through the same single
+identifier-resolution case it uses for plain names --- paths are flattened
+into \<^verbatim>\<open>_urust_identifier_id\<close> earlier, so there is no separate path branch.
+These tests exercise:
+
+- short paths (\<open>foo::bar\<close>) registered via \<open>micro_rust_notation\<close>
+  in literal and function positions;
+- long paths (\<open>foo::bar.method()\<close>) where the head is resolved via
+  the new dispatcher and the trailing method splits remain ordinary
+  identifiers;
+- multi-backend dispatch on a single path name (registering the same
+  rust path for two distinct HOL terms differing only by type, then
+  resolving by occurrence type).\<close>
+
+context begin
+
+text\<open>\<^bold>\<open>Short path, literal kind.\<close>\<close>
+
+private definition path_lit_target :: \<open>nat\<close> where \<open>path_lit_target = 7\<close>
+micro_rust_notation path_lit_target ("Foo::lit_value")
+
+term \<open>\<lbrakk> Foo::lit_value \<rbrakk>\<close>
+
+lemma test_path_lit_dispatched:
+  shows \<open>\<lbrakk> Foo::lit_value \<rbrakk> = literal path_lit_target\<close>
+  by (rule refl)
+
+
+text\<open>\<^bold>\<open>Short path, function kind.\<close> A path-style \<^verbatim>\<open>Foo::bar\<close> in
+function position must reach the dispatcher in the function kind
+(\<^verbatim>\<open>NFunction\<close>) and resolve to the registered \<open>function_body\<close>-typed
+backend. Shape-only smoke test: we just want the term to parse and
+type-check via the new dispatch path.\<close>
+
+private definition path_fn_target ::
+  \<open>nat \<Rightarrow> ('s, nat, 'abort, 'i, 'o) function_body\<close>
+  where \<open>path_fn_target = lift_fun1 Suc\<close>
+micro_rust_notation path_fn_target ("Foo::add_one")
+
+term \<open>\<lbrakk> Foo::add_one(0) \<rbrakk>\<close>
+
+
+text\<open>\<^bold>\<open>Long path with method call.\<close> \<open>Foo::wrap(0)\<close> --- the head
+\<open>Foo::wrap\<close> is a path identifier registered as a function backend via
+the new command; the parenthesised argument is a function call.\<close>
+
+private definition longpath_head ::
+  \<open>nat \<Rightarrow> ('s, nat, 'abort, 'i, 'o) function_body\<close>
+  where \<open>longpath_head x \<equiv> FunctionBody \<lbrakk> \<llangle>x\<rrangle> \<rbrakk>\<close>
+micro_rust_notation longpath_head ("Foo::wrap")
+
+term \<open>\<lbrakk> Foo::wrap(0) \<rbrakk>\<close>
+
+
+text\<open>\<^bold>\<open>Long path with method call.\<close> \<open>Bar::value.cont(0)\<close> --- this
+exercises the long-path AST translator's \<^verbatim>\<open>_temporary_..._long_method\<close>
+branch (\<^file>\<open>../Micro_Rust_Parsing_Frontend/Micro_Rust_Syntax.thy\<close>),
+which splits \<open>Bar::value.cont\<close> into:
+- a path head \<open>"Bar::value"\<close> (literal kind): after AST flattening it is
+  an ordinary \<^verbatim>\<open>_urust_identifier_id\<close> carrying the joined \<open>::\<close>-name,
+  resolved by the same single table-lookup case in \<open>lookup_id_tr\<close> as a
+  plain identifier;
+- a method name \<open>cont\<close> (function kind, plain \<^verbatim>\<open>_urust_identifier_id\<close>).
+
+Long-path field syntax (\<open>foo::bar.fld\<close>) goes through the same
+translator with a different \<^verbatim>\<open>ast_joiner\<close>; we don't add an explicit
+test for that since constructing a lens-typed field backend requires
+more setup than these tests warrant, and the translator is already
+exercised by the method-call shape.\<close>
+
+private definition longpath_value :: \<open>nat\<close>
+  where \<open>longpath_value = 13\<close>
+private definition longpath_method ::
+  \<open>nat \<Rightarrow> ('s, nat, 'abort, 'i, 'o) function_body\<close>
+  where \<open>longpath_method self \<equiv> FunctionBody \<lbrakk> \<llangle>self\<rrangle> \<rbrakk>\<close>
+micro_rust_notation longpath_value  ("Bar::value")
+micro_rust_notation longpath_method ("cont")
+
+term \<open>\<lbrakk> Bar::value.cont() \<rbrakk>\<close>
+
+
+text\<open>\<^bold>\<open>Multi-backend dispatch on a path name.\<close> Register two distinct
+HOL targets under the same path; the typed term_check phase picks the
+unique match by occurrence type. Both backends are literals (so no
+shadow check fires); the test asserts each route resolves to its own
+backend.\<close>
+
+private definition path_multi_nat :: \<open>nat \<Rightarrow> nat option\<close>
+  where \<open>path_multi_nat n = Some n\<close>
+private definition path_multi_bool :: \<open>bool \<Rightarrow> bool option\<close>
+  where \<open>path_multi_bool b = Some b\<close>
+
+micro_rust_notation path_multi_nat  ("Foo::ctor")
+micro_rust_notation path_multi_bool ("Foo::ctor")
+
+\<comment>\<open>Type-driven dispatch through the user-facing surface: the same path
+  identifier \<^verbatim>\<open>Foo::ctor\<close> resolves to the \<open>nat\<close>-typed backend or the
+  \<open>bool\<close>-typed backend depending on the use-site type ascription.
+
+  (We previously also had explicit \<^verbatim>\<open>urust_dispatch (STR ''...'') NoWitness\<close>
+  probes here, but the marker's payload representation is now an
+  ML-internal \<^verbatim>\<open>Free\<close> with an encoded name and can't be written
+  literally in source.)\<close>
+lemma test_path_multi_dispatch_nat:
+  shows \<open>(\<lbrakk> Foo::ctor \<rbrakk> :: ('s, nat \<Rightarrow> nat option, 'r, 'abort, 'i, 'o) expression)
+       = literal path_multi_nat\<close>
+  by (rule refl)
+
+lemma test_path_multi_dispatch_bool:
+  shows \<open>(\<lbrakk> Foo::ctor \<rbrakk> :: ('s, bool \<Rightarrow> bool option, 'r, 'abort, 'i, 'o) expression)
+       = literal path_multi_bool\<close>
+  by (rule refl)
+
+
+text\<open>\<^bold>\<open>Shadowing on a path name (warning level).\<close> Mirrors the
+plain-id warning test: the path's flattened source happens to look like
+the qualified name of a HOL constant of mismatched type. Compiles
+cleanly and prints a warning at the use site.\<close>
+
+private definition shadow_path_target :: \<open>nat \<Rightarrow> bool\<close>
+  where \<open>shadow_path_target _ = True\<close>
+private definition shadow_path_backend :: \<open>nat \<Rightarrow> nat\<close>
+  where \<open>shadow_path_backend x = x\<close>
+
+micro_rust_notation shadow_path_backend ("Shadow::path_target")
+\<comment>\<open>No HOL constant called \<^verbatim>\<open>Shadow::path_target\<close> exists; this is
+  not a shadow case at all --- this block is here as a smoke-test of
+  the path-shape dispatch, not the shadow check (which fires only on
+  bona-fide HOL constant collisions, indexed by Isabelle's name
+  resolution).\<close>
+term \<open>(urust_dispatch (STR ''literal:Shadow::path_target'') NoWitness :: nat \<Rightarrow> nat)\<close>
+
+end
+
+subsection\<open>Print-table sanity check (path entries enumerated)\<close>
+
+text\<open>\<^verbatim>\<open>print_micro_rust_notations\<close> after the path registrations
+above lists every entry, including the path-style ones. This is a
+visual sanity check rather than a programmatic one --- the count is
+non-zero by construction since the section above registers several.\<close>
+
+print_micro_rust_notations
+
+
+subsection\<open>Lambda / let / locale shadowing of registered names\<close>
+
+text\<open>The dispatch pipeline must NOT emit a \<^const>\<open>urust_dispatch\<close>
+marker for a uRust name that, at the use site, refers to a binder
+(\<lambda>-bound, let-bound, fixed-by-locale, or quantifier-bound) rather than
+to a registered backend.
+
+Concretely: registering \<^verbatim>\<open>("mask")\<close> as a field-kind notation must NOT
+hijack a \<^emph>\<open>function parameter\<close> called \<^verbatim>\<open>mask\<close> when that parameter is
+used at literal position inside the function body. The earlier
+implementation of the legacy shim registered plain identifiers under
+all three kinds for "compatibility" and so a literal-position \<open>mask\<close>
+inside a \<open>\<lambda>mask. \<dots>\<close> would dispatch to the field's lens, breaking the
+function definition with a "no backend matches type \<open>'l word\<close>" error.
+
+These tests pin down the contract: same-named binders must win.\<close>
+
+definition \<open>foo \<equiv> 42\<close>
+micro_rust_notation foo ("bar")
+
+term \<open>\<lbrakk> let foo = 12; bar \<rbrakk>\<close>
+
+
+context begin
+
+\<comment>\<open>Registered backends. The HOL targets are deliberately distinct from
+  any of the binder names used below.\<close>
+
+private definition shadow_test_lens :: \<open>('outer, 'inner) lens\<close>
+  where \<open>shadow_test_lens \<equiv> undefined\<close>
+private definition shadow_test_fn ::
+  \<open>nat \<Rightarrow> ('s, nat, 'abort, 'i, 'o) function_body\<close>
+  where \<open>shadow_test_fn \<equiv> lift_fun1 Suc\<close>
+definition shadow_test_lit :: \<open>nat\<close>
+  where \<open>shadow_test_lit = 99\<close>
+  \<comment>\<open>Public so the \<open>shadow_no_shadow_test_dispatches\<close> sanity lemma
+    below can unfold this via \<open>shadow_test_lit_def\<close>.\<close>
+
+\<comment>\<open>Register the same name \<^verbatim>\<open>shdw\<close> in each of the three kinds, with
+  three different HOL backends.\<close>
+micro_rust_notation (field) shadow_test_lens ("shdw")
+micro_rust_notation (call)  shadow_test_fn   ("shdw")
+micro_rust_notation         shadow_test_lit  ("shdw")  \<comment>\<open>auto-infer: literal\<close>
+
+text\<open>\<^bold>\<open>Lambda-bound binder.\<close> A function parameter named \<open>shdw\<close> must
+shadow the registered backends inside the function body.\<close>
+
+definition shadow_lambda_test ::
+  \<open>64 word \<Rightarrow> 64 word \<Rightarrow> ('s, 64 word, 'abort, 'i, 'o) function_body\<close>
+  where \<open>shadow_lambda_test \<equiv> \<lambda>shdw mask. FunctionBody \<lbrakk>
+     \<comment> \<open>Both \<open>shdw\<close> and \<open>mask\<close> are \<lambda>-bound function parameters; their
+        in-body uses must NOT reach the dispatch table even though
+        \<open>shdw\<close> has registrations under all three kinds.\<close>
+     shdw + mask
+   \<rbrakk>\<close>
+
+lemma shadow_lambda_test_unaffected:
+  shows \<open>shadow_lambda_test = (\<lambda>shdw mask. FunctionBody \<lbrakk> shdw + mask \<rbrakk>)\<close>
+  unfolding shadow_lambda_test_def by (rule refl)
+\<comment>\<open>If the dispatch had hijacked \<open>shdw\<close> or \<open>mask\<close>, the term on the
+  right would type-check differently (or not at all).\<close>
+
+text\<open>\<^bold>\<open>Let-bound binder.\<close> Same scenario via a \<^verbatim>\<open>let\<close> binding inside
+the body.\<close>
+
+definition shadow_let_test ::
+  \<open>('s, 64 word, 'abort, 'i, 'o) function_body\<close>
+  where \<open>shadow_let_test \<equiv> FunctionBody \<lbrakk>
+     \<comment> \<open>\<open>shdw\<close> is bound by \<open>let\<close>; its later uses must come from the let,
+        not from the table. \<open>64 word\<close> chosen so the body's \<open>+\<close>
+        resolves via the registered word-arithmetic \<open>urust_add\<close>.\<close>
+     let shdw = 7;
+     shdw + shdw
+   \<rbrakk>\<close>
+
+
+text\<open>\<^bold>\<open>Mutable let-bound binder.\<close>\<close>
+
+definition shadow_mut_let_test ::
+  \<open>('s, unit, 'abort, 'i, 'o) function_body\<close>
+  where \<open>shadow_mut_let_test \<equiv> FunctionBody \<lbrakk>
+     let mut shdw = 7_u64;
+     shdw = (8_u64);
+   \<rbrakk>\<close>
+
+
+subsection\<open>Position determines whether a binder can shadow a notation\<close>
+
+text\<open>The three tests above all use \<open>shdw\<close> in \<^emph>\<open>value/operator\<close> position
+(bare \<open>shdw\<close>, \<open>shdw + \<dots>\<close>, \<open>shdw = \<dots>\<close>), which dispatches in the \<^bold>\<open>literal\<close>
+kind --- there a same-named \<open>let\<close>/\<open>\<lambda>\<close> binder legitimately shadows the
+registration (Rust lexical scoping). The contract for the other two
+positions is the opposite, and these tests pin it down:
+
+  \<^item> \<^bold>\<open>call\<close> position \<open>x.shdw(\<dots>)\<close> / \<open>shdw(\<dots>)\<close>: a method/call head is a
+    selector that can never be the local; the registered \<^bold>\<open>function\<close>
+    notation \<^emph>\<open>wins\<close> over a same-named binder.
+  \<^item> \<^bold>\<open>field\<close> position \<open>x.shdw\<close>: likewise a selector; the registered
+    \<^bold>\<open>field\<close> notation wins.
+
+\<open>shdw\<close> is registered in all three kinds (\<open>shadow_test_lens\<close> field,
+\<open>shadow_test_fn\<close> call, \<open>shadow_test_lit\<close> literal); see
+\<^ML>\<open>Micro_Rust_Notation_Cmd.is_grammatical_name\<close> and
+\<open>witness_takes_precedence\<close> in \<^file>\<open>Micro_Rust_Notations.thy\<close>.\<close>
+
+text\<open>\<^bold>\<open>Literal position: binder wins.\<close> With a \<open>let shdw\<close> in scope, the
+trailing bare \<open>shdw\<close> resolves to the \<open>let\<close>-bound \<open>7\<close>, NOT to the
+registered literal \<open>shadow_test_lit = 99\<close>.\<close>
+
+definition shadow_literal_binder_wins ::
+  \<open>('s, 64 word, 'abort, 'i, 'o) function_body\<close>
+  where \<open>shadow_literal_binder_wins \<equiv> FunctionBody \<lbrakk>
+     let shdw = 7;
+     shdw
+   \<rbrakk>\<close>
+
+lemma shadow_literal_binder_wins_uses_binder:
+  shows \<open>shadow_literal_binder_wins = FunctionBody \<lbrakk> let shdw = 7; shdw \<rbrakk>\<close>
+  unfolding shadow_literal_binder_wins_def by (rule refl)
+\<comment>\<open>The RHS \<open>shdw\<close> is the let-binder; had the literal notation hijacked
+  it, this would mention \<open>shadow_test_lit\<close> and fail to be \<open>refl\<close>.\<close>
+
+text\<open>\<^bold>\<open>Call position: function notation wins.\<close> Even with a same-named
+\<open>let shdw\<close> in scope, the method head \<open>.shdw()\<close> resolves to the
+registered \<open>shadow_test_fn\<close>, not the local. This is the \<open>x.f(f)\<close>
+scenario in miniature: the \<open>shdw\<close> \<^emph>\<open>value\<close>
+passed as the receiver is the binder, while the \<open>.shdw\<close> \<^emph>\<open>method\<close> head
+is the notation. (\<open>shadow_test_fn :: nat \<Rightarrow> \<dots> function_body\<close> is unary,
+so the no-arg method call \<open>r.shdw()\<close> supplies the receiver \<open>r\<close> as its
+sole argument.)
+
+The proof that the notation won is structural: the \<^emph>\<open>definition itself
+type-checks\<close>. Had the \<open>let shdw\<close> binder hijacked the \<open>.shdw\<close> method
+head, the head would be a \<open>nat\<close> local --- not callable --- and the body
+would fail to parse/type-check.\<close>
+
+definition shadow_call_notation_wins ::
+  \<open>('s, nat, 'abort, 'i, 'o) function_body\<close>
+  where \<open>shadow_call_notation_wins \<equiv> FunctionBody \<lbrakk>
+     let shdw = 0;
+     shdw.shdw()
+   \<rbrakk>\<close>
+\<comment>\<open>The definition type-checking IS the test: the \<open>.shdw\<close> method head
+  resolved to the registered \<open>shadow_test_fn\<close> (a \<open>function_body\<close>-typed
+  call whose sole argument is the \<open>shdw\<close> receiver, the let-binder \<open>0\<close>).
+  Had the \<open>let shdw\<close> binder captured the method head, it would be a
+  \<open>nat\<close> local --- not callable --- and this definition would fail to
+  type-check. (We assert via type-checking rather than an equality
+  lemma, matching the call-position tests earlier in this file.)\<close>
+
+text\<open>\<^bold>\<open>Field position: field notation wins.\<close> With a same-named \<open>let shdw\<close>
+in scope, the field access \<open>r.shdw\<close> resolves to the registered
+\<open>shadow_test_lens\<close>, not the local. This is the \<open>x.f\<close> selector
+scenario: the \<open>.shdw\<close>
+selector is the field, while the \<open>r\<close> receiver (here itself named
+\<open>shdw\<close>) is the binder.
+
+As with the call case, the proof is structural --- the definition only
+type-checks because \<open>.shdw\<close> resolved to the \<open>shadow_test_lens\<close> lens; a
+\<open>let\<close>-bound non-lens local could not be field-accessed.\<close>
+
+definition shadow_field_notation_wins ::
+  \<open>('s, 'inner, 'abort, 'i, 'o) function_body\<close>
+  where \<open>shadow_field_notation_wins \<equiv> FunctionBody \<lbrakk>
+     let shdw = \<llangle>undefined :: 'outer\<rrangle>;
+     shdw.shdw
+   \<rbrakk>\<close>
+
+
+text\<open>\<^bold>\<open>Free identifier with no binder and no registration.\<close> An
+unregistered, unbound identifier should remain a free variable rather
+than getting routed through dispatch.\<close>
+
+term \<open>\<lbrakk> some_unregistered_name \<rbrakk>\<close>
+  \<comment>\<open>Should print as \<open>literal some_unregistered_name\<close>, with
+    \<open>some_unregistered_name\<close> a fresh free variable.\<close>
+
+
+subsubsection\<open>Extended binder-shadow tests\<close>
+
+text\<open>The tests in this subsection extend the basic
+\<open>shadow_{lambda,let,mut_let}_test\<close> coverage above to every µRust
+binder shape. Each test re-uses the \<^verbatim>\<open>shdw\<close>/\<^verbatim>\<open>mask\<close> registrations
+declared earlier (literal/function/field). The contract under test is
+the same in every case: a binder named like a registered notation must
+shadow the registration in its body.
+
+The proof method everywhere is \<open>by (rule refl)\<close> because the resolved
+term is expected to have the bound variable as an in-scope binder use
+(the \<open>\<up>\<close> arrow in the printer reflects the \<open>literal\<close> wrapper, but
+the underlying \<open>Bound n\<close>/\<open>Free name\<close> is the same on both sides of the
+equation).\<close>
+
+
+text\<open>\<^bold>\<open>let with arithmetic body using the binder twice.\<close> Already
+tested via \<open>shadow_let_test\<close> above; here we add a sequence-of-lets
+form to exercise multiple successive binders where the inner one
+shadows again.\<close>
+
+definition shadow_nested_let_test ::
+  \<open>('s, 64 word, 'abort, 'i, 'o) function_body\<close>
+  where \<open>shadow_nested_let_test \<equiv> FunctionBody \<lbrakk>
+     let shdw = 1_u64;
+     let shdw = shdw + 2;
+     shdw + 3
+   \<rbrakk>\<close>
+
+lemma shadow_nested_let_test_unaffected:
+  shows \<open>shadow_nested_let_test = FunctionBody \<lbrakk>
+     let shdw = 1_u64;
+     let shdw = shdw + 2;
+     shdw + 3
+   \<rbrakk>\<close>
+  unfolding shadow_nested_let_test_def by (rule refl)
+
+
+text\<open>\<^bold>\<open>let \<dots> else \<dots> binder.\<close> The binder introduced by a
+\<^verbatim>\<open>let \<dots> else \<dots>\<close> form must shadow the registration in the success-path
+body, just like a plain \<^verbatim>\<open>let\<close>.\<close>
+
+definition shadow_let_else_test ::
+  \<open>('s, 64 word, 'abort, 'i, 'o) function_body\<close>
+  where \<open>shadow_let_else_test \<equiv> FunctionBody \<lbrakk>
+     let Some(shdw) = Some(7_u64) else { return 0_u64; };
+     shdw + shdw
+   \<rbrakk>\<close>
+
+lemma shadow_let_else_test_unaffected:
+  shows \<open>shadow_let_else_test = FunctionBody \<lbrakk>
+     let Some(shdw) = Some(7_u64) else { return 0_u64; };
+     shdw + shdw
+   \<rbrakk>\<close>
+  unfolding shadow_let_else_test_def by (rule refl)
+
+
+text\<open>\<^bold>\<open>if-let binder.\<close> Same shadowing in the success branch of an
+\<^verbatim>\<open>if let\<close> form.\<close>
+
+definition shadow_if_let_test ::
+  \<open>('s, unit, 'abort, 'i, 'o) function_body\<close>
+  where \<open>shadow_if_let_test \<equiv> FunctionBody \<lbrakk>
+     if let Some(shdw) = Some(7_u64) {
+       \<llangle>shdw + shdw\<rrangle>;
+     }
+   \<rbrakk>\<close>
+
+lemma shadow_if_let_test_unaffected:
+  shows \<open>shadow_if_let_test = FunctionBody \<lbrakk>
+     if let Some(shdw) = Some(7_u64) {
+       \<llangle>shdw + shdw\<rrangle>;
+     }
+   \<rbrakk>\<close>
+  unfolding shadow_if_let_test_def by (rule refl)
+
+
+text\<open>\<^bold>\<open>if-let-else binder.\<close> Both branches; the binder is in scope in
+the success branch but not in the else branch.\<close>
+
+definition shadow_if_let_else_test ::
+  \<open>('s, 64 word, 'abort, 'i, 'o) function_body\<close>
+  where \<open>shadow_if_let_else_test \<equiv> FunctionBody \<lbrakk>
+     if let Some(shdw) = Some(7_u64) {
+       shdw + shdw
+     } else {
+       0_u64
+     }
+   \<rbrakk>\<close>
+
+lemma shadow_if_let_else_test_unaffected:
+  shows \<open>shadow_if_let_else_test = FunctionBody \<lbrakk>
+     if let Some(shdw) = Some(7_u64) {
+       shdw + shdw
+     } else {
+       0_u64
+     }
+   \<rbrakk>\<close>
+  unfolding shadow_if_let_else_test_def by (rule refl)
+
+
+text\<open>\<^bold>\<open>match-arm constructor-with-args binder.\<close> A name introduced as a
+constructor argument in a match arm shadows the registration in that
+arm's RHS.\<close>
+
+definition shadow_match_arm_test ::
+  \<open>('s, 64 word, 'abort, 'i, 'o) function_body\<close>
+  where \<open>shadow_match_arm_test \<equiv> FunctionBody \<lbrakk>
+     match Some(7_u64) {
+       Some(shdw) \<Rightarrow> shdw + shdw,
+       None \<Rightarrow> 0_u64
+     }
+   \<rbrakk>\<close>
+
+lemma shadow_match_arm_test_unaffected:
+  shows \<open>shadow_match_arm_test = FunctionBody \<lbrakk>
+     match Some(7_u64) {
+       Some(shdw) \<Rightarrow> shdw + shdw,
+       None \<Rightarrow> 0_u64
+     }
+   \<rbrakk>\<close>
+  unfolding shadow_match_arm_test_def by (rule refl)
+
+
+text\<open>\<^bold>\<open>Tuple destructuring let.\<close> Multiple binders introduced in one
+\<^verbatim>\<open>let\<close> via tuple destructuring; each must shadow the registration in
+the body.\<close>
+
+definition shadow_tuple_let_test ::
+  \<open>('s, 64 word, 'abort, 'i, 'o) function_body\<close>
+  where \<open>shadow_tuple_let_test \<equiv> FunctionBody \<lbrakk>
+     let (shdw, mask) = (3_u64, 4_u64);
+     shdw + mask
+   \<rbrakk>\<close>
+
+lemma shadow_tuple_let_test_unaffected:
+  shows \<open>shadow_tuple_let_test = FunctionBody \<lbrakk>
+     let (shdw, mask) = (3_u64, 4_u64);
+     shdw + mask
+   \<rbrakk>\<close>
+  unfolding shadow_tuple_let_test_def by (rule refl)
+
+
+text\<open>\<^bold>\<open>Closure parameter shadows the registration.\<close> A closure
+parameter named \<^verbatim>\<open>shdw\<close> must shadow the same-named registration in
+its body, exactly like a function parameter. The body of the closure
+type-checks at \<open>64 word \<Rightarrow> 64 word\<close>, but lifted into the embedding,
+so the test pins the closure's resolved shape via cartouche
+equivalence.\<close>
+term \<open>\<lbrakk> |shdw| { shdw + shdw } \<rbrakk>\<close>
+  \<comment>\<open>The closure's body uses of \<open>shdw\<close> must be the closure binder, not
+    a dispatch to \<open>shadow_test_lit\<close>. Inspection sanity check.\<close>
+
+
+text\<open>\<^bold>\<open>Mixed: let-binder shadows registration; outside it, a
+sibling closure with the same parameter name is independent.\<close> The
+two binder slots are at different positions in the AST; both must
+shadow the registration in their respective bodies.\<close>
+                  
+term \<open>\<lbrakk>         
+  let shdw = 5_u64;
+  shdw
+\<rbrakk>\<close>
+
+term \<open>\<lbrakk> let asdf = 42; asdf \<rbrakk>\<close>
+
+  \<comment>\<open>Pre-condition: the let-binder shadows the registration.\<close>
+
+term \<open>\<lbrakk> |shdw| { shdw + 1_u64 } \<rbrakk>\<close>
+  \<comment>\<open>Pre-condition: the closure parameter shadows the registration.\<close>
+
+\<comment>\<open>The combination form
+   \<^verbatim>\<open>let shdw = ...; let inner = |shdw| { shdw + ... }; inner(shdw)\<close>
+   is not currently accepted by the grammar (closures are not valid
+   RHSes of \<open>let\<close>). The two single-binder tests above cover the
+   shadowing semantics in each scope independently.\<close>
+
+
+text\<open>\<^bold>\<open>Body that does NOT shadow uses the registration.\<close> Sanity
+check: when a registered name is used WITHOUT a same-named binder, the
+dispatch fires and we see the registered backend in the resolved term.
+This is the contrast to the shadow tests --- it confirms the
+registrations are still active.\<close>
+
+definition shadow_no_shadow_test ::
+  \<open>('s, nat, 'abort, 'i, 'o) function_body\<close>
+  where \<open>shadow_no_shadow_test \<equiv> FunctionBody \<lbrakk>
+     \<comment>\<open>No \<open>shdw\<close> binder anywhere; the literal use must dispatch to
+       the registered \<open>shadow_test_lit :: nat = 99\<close>.\<close>
+     shdw
+   \<rbrakk>\<close>
+
+lemma shadow_no_shadow_test_dispatches:
+  shows \<open>shadow_no_shadow_test = FunctionBody (literal 99)\<close>
+  unfolding shadow_no_shadow_test_def shadow_test_lit_def by (rule refl)
+
+
+text\<open>\<^bold>\<open>Path-style name shadowed by a binder is impossible by
+construction\<close> --- you cannot bind a variable whose name contains \<^verbatim>\<open>::\<close>
+in HOL. So the only shadow risk is the plain-identifier kind, which the
+above tests cover.
+
+We DO have to make sure path-style dispatch still fires when the same
+name is registered as a path. The \<open>multi-backend dispatch on a path
+name\<close> tests in the previous subsection cover this.\<close>
+
+
+subsection\<open>Path identifier source-position markup\<close>
+
+text\<open>The path AST translator merges per-segment source positions into
+a single range covering the whole \<open>foo::bar(::\<dots>)\<close> form. \<open>lookup_id_tr\<close>
+reads it back via \<open>source_positions_of\<close> so use-site markup highlights
+the entire path. This is a visual sanity check --- the test below
+processes cleanly and at jEdit time exposes the merged position by
+ctrl-click on the path identifier landing back at the registration.\<close>
+
+private definition shadow_path_lit :: \<open>nat\<close>
+  where \<open>shadow_path_lit = 100\<close>
+micro_rust_notation shadow_path_lit ("Markup::path::name")
+
+term \<open>\<lbrakk> Markup::path::name \<rbrakk>\<close>
+
+
+subsection\<open>Non-grammatical names (turbofish / macro forms)\<close>
+
+text\<open>Names that are neither plain identifiers nor \<^verbatim>\<open>::\<close>-style paths ---
+turbofish forms like \<open>Foo::<T>::new\<close> --- contain characters (\<open><\<close>, \<open>>\<close>)
+that no µRust grammar production covers, so the surface token cannot be
+parsed at all. \<^verbatim>\<open>micro_rust_notation\<close> detects this (via
+\<^ML>\<open>Micro_Rust_Notation_Cmd.is_grammatical_name\<close>) and additionally emits
+a bespoke \<^verbatim>\<open>syntax\<close> production (a new lexer token whose template IS the
+rust name) plus a \<^verbatim>\<open>parse_ast_translation\<close> that rewrites the token to
+the ordinary \<^verbatim>\<open>_urust_identifier_id\<close> AST node --- so it flows through the
+exact same table-dispatch pipeline as a plain or path identifier (no
+backend special-casing; type-directed dispatch, markup, and binder/field
+precedence all apply). Without the production the dispatch-table entry
+alone is useless: there is nothing to parse. These tests pin that the
+bespoke path makes the turbofish use sites both \<^emph>\<open>parse\<close> and \<^emph>\<open>resolve\<close>.\<close>
+
+context begin
+
+text\<open>\<^bold>\<open>Turbofish, function kind.\<close> \<open>Turbo::<T>::new(x)\<close> must parse
+(needs the bespoke production) and resolve in function position to the
+registered backend. As with the path-name function tests above, this is
+a shape-only smoke test: \<open>\<lbrakk>f(x)\<rbrakk>\<close> is a \<^emph>\<open>call expression\<close>, not a bare
+\<open>function_body\<close>, so we do not equate it to the backend --- we just confirm
+the turbofish use site parses and type-checks via the new dispatch path
+(it would fail to parse at all without the bespoke production).\<close>
+
+
+private definition turbo_new ::
+  \<open>nat \<Rightarrow> ('s, nat, 'abort, 'i, 'o) function_body\<close>
+  where \<open>turbo_new x \<equiv> FunctionBody \<lbrakk> \<llangle>x\<rrangle> \<rbrakk>\<close>
+micro_rust_notation (call) turbo_new ("Turbo::<T>::new")
+
+term \<open>\<lbrakk> Turbo::<T>::new(0) \<rbrakk>\<close>
+
+text\<open>\<^bold>\<open>Turbofish with a numeric generic argument.\<close> Exercises a
+turbofish whose generic argument is a numeral, e.g. \<open>Foo::<2>::new\<close>.\<close>
+
+private definition turbo_numeric_new ::
+  \<open>nat \<Rightarrow> ('s, nat, 'abort, 'i, 'o) function_body\<close>
+  where \<open>turbo_numeric_new x \<equiv> FunctionBody \<lbrakk> \<llangle>x\<rrangle> \<rbrakk>\<close>
+micro_rust_notation (call) turbo_numeric_new ("Turbo::<2>::new")
+
+term \<open>\<lbrakk> Turbo::<2>::new(0) \<rbrakk>\<close>
+
+text\<open>\<^bold>\<open>Turbofish, literal kind.\<close> A non-grammatical name registered as
+a literal value also gets the bespoke production and resolves at a bare
+use site. Here the use is a literal (not a call), so we \<^emph>\<open>can\<close> assert the
+resolved value: it must dispatch to \<open>turbo_lit\<close>.\<close>
+
+private definition turbo_lit :: \<open>nat\<close> where \<open>turbo_lit = 13\<close>
+micro_rust_notation (literal) turbo_lit ("Turbo::<T>::VALUE")
+
+term \<open>\<lbrakk> Turbo::<T>::VALUE \<rbrakk>\<close>
+
+lemma test_turbofish_lit_dispatched:
+  shows \<open>\<lbrakk> Turbo::<T>::VALUE \<rbrakk> = literal turbo_lit\<close>
+  by (rule refl)
+
+text\<open>\<^bold>\<open>Macro name backed by an \<^theory_text>\<open>abbreviation\<close>\<close> (the std-lib
+logger shape: \<^verbatim>\<open>StdLib_Logging.fatal\<close> registered as \<^verbatim>\<open>fatal!\<close>). The
+\<^verbatim>\<open>!\<close> makes the name non-grammatical, and \<^ML>\<open>Syntax.read_term\<close> expands
+the abbreviation to an \<^verbatim>\<open>Abs\<close> --- so \<^verbatim>\<open>emit_bespoke_syntax\<close> recovers the
+backend constant via \<^ML>\<open>Proof_Context.read_const\<close> for its markup binding.
+This pins that such a name both registers (would throw without the
+\<^verbatim>\<open>read_const\<close> recovery) and resolves at a use site (would not parse
+without the bespoke grammar production).\<close>
+
+context begin
+
+private abbreviation shout :: \<open>nat \<Rightarrow> ('s, nat, 'abort, 'i, 'o) function_body\<close> where
+  \<open>shout x \<equiv> FunctionBody \<lbrakk> \<llangle>x\<rrangle> \<rbrakk>\<close>
+micro_rust_notation (call) shout ("shout!")
+
+private definition shout_use :: \<open>('s, nat, 'abort, 'i, 'o) function_body\<close>
+  where \<open>shout_use \<equiv> FunctionBody \<lbrakk> shout!(0) \<rbrakk>\<close>
+
+end
+
+
+subsection\<open>Registered-but-no-type-match is a hard error\<close>
+
+text\<open>If a uRust notation is registered for a name but \<^emph>\<open>no\<close> backend's
+type unifies with the use-site type, the dispatcher must \<^bold>\<open>error\<close> ---
+not silently demote the name to a free variable. This is the
+\<open>Foo::mk()\<close> bug: a no-arg call against a backend that
+takes arguments. The marker only exists because the name is registered,
+so an empty candidate set is a genuine arity/type mismatch.
+
+\<open>resolve\<close>'s \<open>no_match_error\<close> fires during the typed \<open>term_check\<close> phase,
+so we verify it the robust way: build the offending use with
+\<^ML>\<open>Syntax.read_term\<close> inside an \<^ML>\<open>Exn.capture\<close> and assert it raises.\<close>
+
+context begin
+
+private definition err_backend ::
+  \<open>nat \<Rightarrow> nat \<Rightarrow> ('s, nat, 'abort, 'i, 'o) function_body\<close>
+  where \<open>err_backend \<equiv> \<lambda>a b. FunctionBody \<lbrakk> \<llangle>a\<rrangle> \<rbrakk>\<close>
+micro_rust_notation (call) err_backend ("ErrName::mk")
+
+text\<open>\<^bold>\<open>Correct arity resolves.\<close> Sanity check: a 2-arg use type-checks
+(the definition succeeding is the proof the notation resolved).\<close>
+
+private definition err_ok_use ::
+  \<open>('s, nat, 'abort, 'i, 'o) function_body\<close>
+  where \<open>err_ok_use \<equiv> FunctionBody \<lbrakk> ErrName::mk(0, 0) \<rbrakk>\<close>
+
+text\<open>\<^bold>\<open>Wrong arity errors.\<close> A no-arg use \<open>ErrName::mk()\<close> has no
+type-compatible backend (the only backend is binary), so reading it must
+raise. We capture the exception rather than let it abort the theory.\<close>
+
+ML\<open>
+  val _ =
+    let
+      val bad = "\<lbrakk> ErrName::mk() \<rbrakk>"
+      val res = Exn.capture (fn () => Syntax.read_term \<^context> bad) ()
+    in
+      (case res of
+        Exn.Exn (ERROR msg) =>
+          if String.isSubstring "no backend matches" msg
+          then writeln ("OK: registered-but-no-match errored as expected:\n" ^ msg)
+          else error ("Wrong error message for ErrName::mk():\n" ^ msg)
+      | Exn.Exn e => Exn.reraise e
+      | Exn.Res _ =>
+          error "ErrName::mk() should have failed (no type-compatible backend) but resolved")
+    end;
+\<close>
+
+end
+
+
+end
+
+
+end

--- a/Shallow_Micro_Rust/Micro_Rust_Shallow_Embedding.thy
+++ b/Shallow_Micro_Rust/Micro_Rust_Shallow_Embedding.thy
@@ -6,15 +6,13 @@ theory Micro_Rust_Shallow_Embedding
   imports
     Micro_Rust_Parsing_Frontend.Micro_Rust_Syntax
     Core_Syntax
+    Micro_Rust_Notations
     Prompts_And_Responses
     "HOL-Library.Datatype_Records"
     Autogen.Autogen
     Lenses_And_Other_Optics.Lenses_And_Other_Optics
     Tuple
   keywords
-    "notation_nano_rust"
-    "notation_nano_rust_field"
-    "notation_nano_rust_function"
     "micro_rust_record" :: thy_decl
 begin
 (*>*)
@@ -27,9 +25,12 @@ to the category of HOL terms.\<close>
 subsection\<open>Custom identifiers and identifier remapping\<close>
 
 text\<open>The in-built syntax category \<^verbatim>\<open>id\<close> of HOL identifiers does not encompass qualified
-Rust names such as \<^verbatim>\<open>Foo::Bar\<close>. To still be able to use those in Micro Rust, the abstract syntax
-parser for uRust outputs these as \<^verbatim>\<open>urust_path_string_identifier\<close> entries. We just have
-to add a way to parse these as HOL terms.
+Rust names such as \<^verbatim>\<open>Foo::Bar\<close>. The path-flattening AST translation in
+\<^file>\<open>../Micro_Rust_Parsing_Frontend/Micro_Rust_Syntax.thy\<close> turns such paths into
+\<^verbatim>\<open>_urust_identifier_id\<close> nodes whose payload is a plain \<^verbatim>\<open>Ast.Variable\<close> carrying
+the joined name (e.g. \<^verbatim>\<open>"Foo::Bar"\<close>); downstream consumers therefore see no
+structural difference between path and plain identifiers --- only the name
+string contains \<^verbatim>\<open>::\<close>.
 
 For general \<^verbatim>\<open>id\<close>s, we introduce an intermediate \<^verbatim>\<open>_urust_identifier_id_const\<close>. This allows us
 to register Micro-Rust-to-HOL name changes for those identifiers which \<^emph>\<open>do\<close> fall
@@ -47,151 +48,12 @@ in
 end
 \<close>
 
-text\<open>Entries marked \<^verbatim>\<open>_shallow_unparsed_path_string\<close> are waiting to be resolved by a parse
-translation to a proper HOL term, by looking up the string token in a map.\<close>
-syntax
-  "_shallow_unparsed_path_string" :: \<open>string_token \<Rightarrow> logic\<close>
-    ("URUST'_SHALLOW'_UNPARSED'_PATH'_STRING _")
-
-text\<open>Define the map in which Rust path literals (\<^verbatim>\<open>Foo::Bar\<close>) will be looked up in.\<close>
-ML\<open>
-  structure RustPathResolution = Generic_Data
-  (
-    type T = string Symtab.table;
-    val empty = Symtab.empty;
-    val merge = Symtab.merge (op =);
-  );
-
-  fun add_rust_path_resolution key value =
-    Symtab.insert (op =) (key, value) |>
-    RustPathResolution.map;
-
-  fun get_rust_path_resolution key =
-    RustPathResolution.get #> (fn tab => Symtab.lookup tab key)
-\<close>
-
-text\<open>Add the parse translation which will perform the lookup.\<close>
-parse_translation\<open>
-  let
-    fun internal_path_translator ctx [Term.Const (rust_name, the_typ)] =
-      let
-        val rust_resolution = ctx |> Context.Proof |> get_rust_path_resolution rust_name
-      in
-        case rust_resolution of
-            SOME term_name =>
-            \<comment> \<open>Note that we cannot have a term map, at least not a naive one, since at this point
-                generics still need to be unified.\<close>
-            Term.Const (term_name, the_typ)
-          | NONE =>
-            \<comment> \<open>In the \<^verbatim>\<open>NONE\<close> case, this will output a somewhat nice error message of the form
-              \<^verbatim>\<open>Foo::Bar constant not found\<close>\<close>
-              Term.Const (rust_name, the_typ)
-      end
-      | internal_path_translator _ args =
-          Term.list_comb (Syntax.const \<^syntax_const>\<open>_shallow_unparsed_path_string\<close>, args);
-  in [
-    (\<^syntax_const>\<open>_shallow_unparsed_path_string\<close>, internal_path_translator)
-  ] end
-\<close>
-
-ML\<open>
-\<comment> \<open>Replace \<^verbatim>\<open>pattern\<close> by \<^verbatim>\<open>replacement\<close> in \<^verbatim>\<open>original\<close>.\<close>
-fun replace_string (pattern: string) (replacement: string) (original: string)  =
-    let
-        val original_size = String.size original
-        val pattern_size = String.size pattern
-
-        fun loop start acc =
-            if start > original_size - pattern_size
-            then String.concat (List.rev (String.extract(original, start, NONE) :: acc))
-            else if String.substring(original, start, pattern_size) = pattern
-            then loop (start + pattern_size) (replacement :: acc)
-            else loop (start + 1)
-                 (String.str(String.sub(original, start)) :: acc)
-    in
-        if pattern_size = 0 orelse original_size = 0
-        then original
-        else loop 0 []
-    end;
-
-replace_string "Hello" "Hi" "Hello, world! Hello, universe!" ;
-
-replace_string "::" "_" "a::b::c";
-
-replace_string  "one" "1" "one two one two";
-\<close>
-
-text\<open>Core helper that registers \<^verbatim>\<open>nano_rust_name\<close> as notation for \<^verbatim>\<open>hol_name\<close> in uRust. There are
-three cases:
-1. \<^verbatim>\<open>nano_rust_name\<close> falls in the \<^verbatim>\<open>id\<close> syntax category. We only add a simple \<^verbatim>\<open>translations\<close> macro.
-2. \<^verbatim>\<open>nano_rust_name\<close> is a path identifier (\<^verbatim>\<open>Foo::Bar\<close>). We just have to register them as a  \<^verbatim>\<open>RustPathResolution\<close>
-3. \<^verbatim>\<open>nano_rust_name\<close> contains other special characters (e.g. \<^verbatim>\<open>fatal!\<close>). We need to add a syntax entry and a \<^verbatim>\<open>translations\<close> step.
-\<close>
-ML\<open>
-   fun notation_nano_rust ty (hol_name, nano_rust_name) = let
-     (* If the Nano Rust name is an identifier, we only need to register a translation
-        rule which converts it into the respective HOL identifier.
-
-        If the Nano Rust name is not an identifier, for example `Foo::Bar`, then we
-        insert it into the `RustPathResolution` map. *)
-
-     (* Ordinary identifier *)
-     fun simple_hol_notation_nano_rust ty hol_name nano_rust_name thy: local_theory = (
-        let val translation_in = "_shallow_identifier_as_" ^ ty ^ "(URUST_CONST " ^ " " ^ nano_rust_name ^ ")"
-            val translation_out = "CONST " ^ hol_name
-            val translation = Syntax.Parse_Rule (("logic",translation_in), ("logic",translation_out)) in
-        thy |> Local_Theory.translations_cmd true [translation]
-     end)
-
-     val remove_colons = String.translate (fn #":" => "" | c => String.str c)
-     val is_path_notation = remove_colons #> Symbol_Pos.is_identifier
-
-     (* Path notation *)
-     fun custom_path_notation_nano_rust hol_identifier nano_rust_name thy: local_theory =
-        let
-          \<comment> \<open>TODO: the calls to \<^verbatim>\<open>replace_string\<close> are for backwards compatibility. Remove them?\<close>
-          val actual_name = nano_rust_name |> replace_string "'_" "_" |> replace_string "':" ":"
-        in
-          thy |> Local_Theory.declaration {pervasive=false, syntax=false, pos=Position.none}
-          (K (add_rust_path_resolution actual_name hol_identifier))
-        end
-
-     fun remove_dots long_identifier =
-           (long_identifier |> String.explode |> filter (fn c : char => (c <> #".")) |> String.implode)
-
-     (* Complex identifier which needs to be treated as a custom keyword *)
-     fun custom_hol_notation_nano_rust ty hol_identifier nano_rust_name thy: local_theory = (
-        let val mode = Syntax.mode_default
-            val syntax_constant = "_urust_identifier_" ^ (remove_dots hol_identifier)
-            val translation_in = "_shallow_identifier_as_" ^ ty ^ " " ^ syntax_constant
-            val translation_out = "CONST " ^ hol_identifier
-            val translation = Syntax.Parse_Rule (("logic",translation_in), ("logic",translation_out)) in
-        thy |> Local_Theory.syntax_cmd true mode [(syntax_constant, "urust_identifier", Mixfix.mixfix nano_rust_name)]
-            |> Local_Theory.translations_cmd true [translation]
-     end)
-  in
-    if Symbol_Pos.is_identifier nano_rust_name then
-      simple_hol_notation_nano_rust ty hol_name nano_rust_name
-    else if is_path_notation nano_rust_name then
-      custom_path_notation_nano_rust hol_name nano_rust_name
-    else
-      custom_hol_notation_nano_rust ty hol_name nano_rust_name
-  end
-\<close>
-
-ML\<open>
-   \<comment>\<open>TODO: We should actually be able to do the right thing automatically here, by looking at the type
-of the HOL constant that's being registered: Fields are lenses, and functions are \<^text>\<open>function_body\<close>'s.\<close>
-   Outer_Syntax.local_theory @{command_keyword "notation_nano_rust"}
-      "Add a named HOL literal to Micro Rust"
-      (((Parse.long_ident || Parse.short_ident) -- (Parse.$$$ "(" |-- Parse.string --| Parse.$$$ ")")) >> (notation_nano_rust "literal"));
-   Outer_Syntax.local_theory @{command_keyword "notation_nano_rust_field"}
-      "Add a named Micro Rust field to Micro Rust"
-      (((Parse.long_ident || Parse.short_ident) -- (Parse.$$$ "(" |-- Parse.string --| Parse.$$$ ")")) >> notation_nano_rust "field");
-   Outer_Syntax.local_theory @{command_keyword "notation_nano_rust_function"}
-      "Add a named Micro Rust function to Micro Rust"
-      (((Parse.long_ident || Parse.short_ident) -- (Parse.$$$ "(" |-- Parse.string --| Parse.$$$ ")")) >> notation_nano_rust "function")
-\<close>
+\<comment>\<open>Path-style uRust names (\<^verbatim>\<open>Foo::Bar\<close>) and plain identifiers both reach
+  \<open>lookup_id_tr\<close> (the \<open>parse_translation\<close> on \<open>_shallow_identifier_as_*\<close>)
+  as the same \<^verbatim>\<open>Free name\<close> shape; resolution proceeds via the
+  \<^ML_structure>\<open>Micro_Rust_Names\<close> table, populated by the
+  \<^theory_text>\<open>micro_rust_notation\<close> command in
+  \<^theory>\<open>Shallow_Micro_Rust.Micro_Rust_Notations\<close>.\<close>
 
 named_theorems micro_rust_record_simps
 named_theorems micro_rust_record_intros
@@ -226,30 +88,112 @@ ML\<open>
 \<close>
 
 ML\<open>
-   fun register_lens_with_micro_rust rec_name field lthy =
+   \<comment>\<open>Register an auto-generated field lens as \<^verbatim>\<open>micro_rust_notation (field)\<close>
+     under its uRust name, via the command's \<open>do_register\<close>. By default the
+     uRust name is the bare (record-prefixed) HOL field name; the optional
+     \<^verbatim>\<open>(hol_field = "urust_name", \<dots>)\<close> mapping passed to \<^verbatim>\<open>micro_rust_record\<close>
+     overrides this per field — useful because HOL field names are usually
+     disambiguated with a record-name prefix that one does not want to repeat
+     at every uRust use site. The uRust name is a plain identifier
+     (grammatical, so no bespoke grammar production is emitted) and the lens
+     has type \<open>_ lens\<close> (so the forced \<open>field\<close> kind validates against the
+     term's type).\<close>
+   fun register_lens_with_micro_rust rec_name overrides field lthy =
       let val name = lens_name rec_name field
           val full_name = Local_Theory.full_name lthy (Binding.name name)
-      in notation_nano_rust "field" (full_name, field) lthy end
-   fun register_lenses_with_micro_rust rec_name thy =
-      let val fields = get_fields rec_name thy in fold (register_lens_with_micro_rust rec_name) fields thy end
+          val (rust_name, rust_pos) =
+            case AList.lookup (op =) overrides field of
+              SOME name_and_pos => name_and_pos
+            | NONE              => (field, Position.thread_data ())
+      in
+        Micro_Rust_Notation_Cmd.do_register (SOME Micro_Rust_Names.NField)
+          (full_name, (rust_name, rust_pos)) lthy
+      end
 
-   fun make_lenses (with_fields, rec_name) _ =
-       lens_autogen_defs                                                                          rec_name
-    #> lens_autogen_defining_equations     @{attributes [micro_rust_record_simps, focus_simps]}   rec_name
-    #> lens_autogen_prove_lens_validity    @{attributes [micro_rust_record_intros, focus_intros,
-                                                         micro_rust_record_simps, focus_simps]}   rec_name
-    #> lens_autogen_prove_update_equations @{attributes [micro_rust_record_simps, focus_simps]}
-                                           @{attributes [micro_rust_record_intros, focus_intros]} rec_name
-    #> focus_autogen_make_field_foci @{attributes [focus_components]} rec_name
-    #> (if with_fields then
-          register_lenses_with_micro_rust rec_name
-        else
-          I)
-    #> instantiate_localizable_class rec_name
+   \<comment>\<open>Reject a uRust-name mapping whose left-hand sides are not all fields of
+     the record: an unmatched entry is silently dropped otherwise, masking a
+     typo in the field name.\<close>
+   fun check_override_fields rec_name fields overrides =
+      let val unknown = filter_out (member (op =) fields) (map fst overrides) in
+        if null unknown then ()
+        else error ("micro_rust_record: unknown field(s) in uRust-name mapping: "
+                    ^ commas_quote unknown ^ "\nRecord " ^ quote rec_name
+                    ^ " has fields: " ^ commas_quote fields)
+      end
+
+   fun register_lenses_with_micro_rust rec_name overrides thy =
+      let val fields = get_fields rec_name thy in
+        fold (register_lens_with_micro_rust rec_name overrides) fields thy
+      end
+
+   \<comment>\<open>Pretty-print, as a bullet list, the definitions and theorems
+     \<^verbatim>\<open>micro_rust_record\<close> emits for a record (one bullet per artifact), so the
+     (otherwise opaque) autogen output is replaced by the concrete names a user
+     can reference. The trailing bullets record the uRust field-access names
+     (\<open>urust_name \<mapsto> hol_field\<close>, collapsing to the bare field where no override
+     applies) and the localizable class instance.\<close>
+   fun summarise_micro_rust_record rec_name fields overrides with_fields =
+      let fun urust_of f =
+            case AList.lookup (op =) overrides f of
+              SOME (rust_name, _) => rust_name
+            | NONE                => f
+          fun field_facts f =
+            let val base = rec_name ^ "_" ^ f in
+              [base ^ "_lens", base ^ "_lens_view_update_modify", base ^ "_lens_valid",
+               base ^ "_focus", base ^ "_focus_view_update_modify", base ^ "_focus_code",
+               base ^ "_update_explicit", base ^ "_update_localI"]
+            end
+          fun render_field_map f =
+            let val rust_name = urust_of f in
+              if rust_name = f then f else rust_name ^ " \<mapsto> " ^ f
+            end
+          val urust_facts =
+            if with_fields then map (fn f => "uRust field access: " ^ render_field_map f) fields
+            else []
+          val bullets =
+            maps field_facts fields @ urust_facts @ [rec_name ^ " :: localizable"]
+      in
+        Pretty.writeln (Pretty.chunks (map (fn s => Pretty.str ("• " ^ s)) bullets))
+      end
+
+   fun make_lenses ((with_fields, rec_name), overrides) _ lthy =
+      let val _ =
+            if with_fields orelse null overrides then ()
+            else error "micro_rust_record: a uRust-name mapping cannot be combined \
+                       \with [no_fields], which suppresses field registration"
+          val fields = get_fields rec_name lthy
+          val _ = check_override_fields rec_name fields overrides
+          val _ = summarise_micro_rust_record rec_name fields overrides with_fields
+      in
+        lthy
+     |> lens_autogen_defs                                                                          rec_name
+     |> lens_autogen_defining_equations     @{attributes [micro_rust_record_simps, focus_simps]}   rec_name
+     |> lens_autogen_prove_lens_validity    @{attributes [micro_rust_record_intros, focus_intros,
+                                                          micro_rust_record_simps, focus_simps]}   rec_name
+     |> lens_autogen_prove_update_equations @{attributes [micro_rust_record_simps, focus_simps]}
+                                            @{attributes [micro_rust_record_intros, focus_intros]} rec_name
+     |> focus_autogen_make_field_foci @{attributes [focus_components]} rec_name
+     |> (if with_fields then
+           register_lenses_with_micro_rust rec_name overrides
+         else
+           I)
+     |> instantiate_localizable_class rec_name
+      end
+
+   \<comment>\<open>Parse an optional \<^verbatim>\<open>(hol_field = "urust_name", \<dots>)\<close> mapping after the
+     record name. Each \<^verbatim>\<open>"urust_name"\<close> is position-tracked so its use-site
+     markup points back at the literal in the command.\<close>
+   val parse_field_overrides =
+      Scan.optional
+        (Parse.$$$ "(" |--
+           Parse.enum1 "," (Parse.short_ident -- (Parse.$$$ "=" |-- Parse.position Parse.string))
+         --| Parse.$$$ ")")
+        []
 
    val _ =
       Outer_Syntax.local_theory' \<^command_keyword>\<open>micro_rust_record\<close> "make lenses for datatype record"
-       (((Scan.optional ((Args.bracks (Args.$$$ "no_fields")) >> K false) true) -- Parse.short_ident) >> make_lenses)
+       ((((Scan.optional ((Args.bracks (Args.$$$ "no_fields")) >> K false) true) -- Parse.short_ident)
+            -- parse_field_overrides) >> make_lenses)
 \<close>
 
 subsection\<open>The embedding\<close>
@@ -268,6 +212,14 @@ syntax
   "_shallow_identifier_as_literal" :: \<open>urust_identifier \<Rightarrow> logic\<close>
   "_shallow_identifier_as_function" :: \<open>urust_identifier \<Rightarrow> logic\<close>
   "_shallow_identifier_as_field" :: \<open>urust_identifier \<Rightarrow> logic\<close>
+
+  \<comment> \<open>Lower a uRust identifier in BINDER-INTRODUCTION position (let-pattern
+     leaf, for-loop binder, etc.) to a plain \<^verbatim>\<open>Free\<close> suitable as the binder
+     slot of \<open>_abs\<close>. Distinct from \<open>_shallow_identifier_as_literal\<close>: pure
+     binders never consult the dispatch table --- their identifier IS the
+     binder, and any registered uRust notation of the same name is shadowed
+     by the let.\<close>
+  "_shallow_pattern_id" :: \<open>urust_identifier \<Rightarrow> logic\<close>
 
   "_shallow_match_branches" :: \<open>urust_match_branches \<Rightarrow> urust_shallow_match_branches\<close>
   "_shallow_match_branch" :: \<open>urust_match_branch  \<Rightarrow> urust_shallow_match_branch \<close>
@@ -291,10 +243,12 @@ term\<open>let (x, _ :: int) = (5,6) in x+12\<close>
 end
 
 
-translations
-  "_shallow_identifier_as_function (_urust_path_string_identifier s)" \<rightharpoonup> "_shallow_unparsed_path_string s"
-  "_shallow_identifier_as_literal (_urust_path_string_identifier s)" \<rightharpoonup> "_shallow_unparsed_path_string s"
-  "_shallow_identifier_as_field (_urust_path_string_identifier s)" \<rightharpoonup> "_shallow_unparsed_path_string s"
+\<comment>\<open>Path-style names like \<^verbatim>\<open>Foo::Bar\<close> are resolved by the
+  \<^verbatim>\<open>parse_translation\<close> for \<^verbatim>\<open>_shallow_identifier_as_*\<close> (see
+  \<open>lookup_id_tr\<close> below): it looks the name up in the
+  \<^ML_structure>\<open>Micro_Rust_Names\<close> table and falls back to the bare
+  identifier on miss, so paths participate in the same multi-backend,
+  type-driven dispatch as plain identifiers.\<close>
 
 translations
   \<comment>\<open>The shallow embedding of a HOL term is the corresponding literal\<close>
@@ -478,8 +432,11 @@ translations
     \<rightharpoonup> "CONST Core_Expression.bind (_shallow exp) (_abs (_shallow_let_pattern pattern) (_shallow cont))"
   "_shallow (_urust_bind_immutable' pattern exp cont)"
     \<rightharpoonup> "CONST Core_Expression.bind (_shallow exp) (_abs (_shallow_let_pattern pattern) (_shallow cont))"
+  \<comment>\<open>Let-pattern leaves use the binder-position resolver --- their
+    identifier IS the binder, so we must not emit a \<^verbatim>\<open>urust_dispatch\<close>
+    marker here (it would crash \<^ML>\<open>Syntax_Trans.abs_tr\<close>).\<close>
   "_shallow_let_pattern (_urust_match_pattern_constr_no_args id)"
-    \<rightharpoonup> "_shallow_identifier_as_literal id"
+    \<rightharpoonup> "_shallow_pattern_id id"
   "_shallow_let_pattern _urust_match_pattern_other"
     \<rightharpoonup> "_idtdummy"
   "_shallow_let_pattern (_urust_match_pattern_grouped pat)"
@@ -597,10 +554,21 @@ translations
   "_shallow (_urust_closure_with_args args exp)"
     \<rightharpoonup> "CONST literal (_shallow_abstract_args args exp)"
 
-  "_shallow_abstract_args (_urust_formal_single (_urust_identifier_hol_id arg)) exp"
-    \<rightharpoonup> "\<lambda>arg. CONST FunctionBody (_shallow exp)"
-  "_shallow_abstract_args (_urust_formal_app (_urust_identifier_hol_id arg) args) exp"
-    \<rightharpoonup> "\<lambda>arg. _shallow_abstract_args args exp"
+  \<comment>\<open>Closure-formal lowering routes the binder through \<^verbatim>\<open>_abs\<close> (and
+    hence \<^ML>\<open>Syntax_Trans.abs_tr\<close>) so the source position carried by
+    the formal's \<open>id_position\<close> survives into a \<open>_constrainAbs\<close>
+    wrapper. The decoder then emits \<open>Markup.bound\<close> at the binder's
+    source range, paired with each in-scope use site --- which is what
+    makes ctrl-click on a closure-body identifier jump back to the
+    \<^verbatim>\<open>|x|\<close> binder.
+
+    The previous form \<open>\<lambda>arg. _\<close> using a translations meta-variable
+    discarded the \<open>_constrain\<close> wrapper at substitution time and so
+    produced binder-markup-less closures.\<close>
+  "_shallow_abstract_args (_urust_formal_single id) exp"
+    \<rightharpoonup> "_abs id (CONST FunctionBody (_shallow exp))"
+  "_shallow_abstract_args (_urust_formal_app id args) exp"
+    \<rightharpoonup> "_abs id (_shallow_abstract_args args exp)"
 
   "_shallow_apply_params f (_urust_param_app p params)"
     \<rightharpoonup> "_shallow_apply_params (f p) params"
@@ -827,6 +795,12 @@ translations
     \<rightharpoonup> "_urust_shallow_match_pattern_zero"
   "_shallow_match_pattern (_urust_match_pattern_one)"
     \<rightharpoonup> "_urust_shallow_match_pattern_one"
+  \<comment>\<open>Match-arm constructor heads continue to route through the
+    value-position \<^verbatim>\<open>_shallow_identifier_as_literal\<close>: \<open>case_tr\<close>
+    downstream tolerates a \<^verbatim>\<open>urust_dispatch\<close> marker as the head and
+    the term_check phase resolves it after type inference (which is
+    necessary for value-position match arms like \<open>match x { number::three => \<dots> }\<close>
+    where the registration target is a non-constructor constant).\<close>
   "_shallow_match_pattern (_urust_match_pattern_constr_no_args id)"
     \<rightharpoonup> "_urust_shallow_match_pattern_constr_no_args (_shallow_identifier_as_literal id)"
   "_shallow_match_pattern (_urust_match_pattern_constr_with_args id args)"
@@ -875,29 +849,112 @@ translations
   "_shallow (_urust_while_let (_urust_antiquotation fuel) ptrn expr body)"
     \<rightharpoonup> "_urust_shallow_while_let fuel (_shallow_match_pattern ptrn) (_shallow expr) (_shallow body)"
 
-
-abbreviation urust_constructor_some :: \<open>'a \<Rightarrow> ('s, 'a option, 'abort, 'i, 'o) function_body\<close> where
-   \<open>urust_constructor_some \<equiv> lift_fun1 Some\<close>
-abbreviation urust_constructor_ok :: \<open>'a \<Rightarrow> ('s, ('a, 'e) result, 'abort, 'i, 'o) function_body\<close> where
-   \<open>urust_constructor_ok \<equiv> lift_fun1 Ok\<close>
-abbreviation urust_constructor_err :: \<open>'e \<Rightarrow> ('s, ('a, 'e) result, 'abort, 'i, 'o) function_body\<close> where
-   \<open>urust_constructor_err \<equiv> lift_fun1 Err\<close>
-
-notation_nano_rust_function urust_constructor_some ("Some")
-notation_nano_rust_function urust_constructor_ok   ("Ok")
-notation_nano_rust_function urust_constructor_err  ("Err")
+micro_rust_notation \<open>lift_fun1 Some\<close> ("Some")
+micro_rust_notation \<open>lift_fun1 Ok\<close>   ("Ok")
+micro_rust_notation \<open>lift_fun1 Err\<close>  ("Err")
 
 text\<open>By default, we map all identifiers to HOL through the identity function on their names.
-We have to register this as a parse translation rather than a rule to give precedence to namings
-registers via \<^text>\<open>notation_nano_rust\<close>, which use translation rules.\<close>
+We register this as a parse translation rather than a rule so that names registered via
+\<^theory_text>\<open>micro_rust_notation\<close> (which the translation looks up in
+\<^ML_structure>\<open>Micro_Rust_Names\<close>) take precedence.\<close>
 
-\<comment>\<open>NB: We could save some manual invocations of \<^text>\<open>notation_nano_rust\<close> if we changed the
+\<comment>\<open>NB: We could save some manual invocations of \<^theory_text>\<open>micro_rust_notation\<close> if we changed the
 default renaming convention here, and e.g. prepend all field names with \<^verbatim>\<open>field_lens_\<close>,
 for example.\<close>
-parse_translation\<open>[(\<^syntax_const>\<open>_urust_identifier_id\<close>, K hd),
-                   (\<^syntax_const>\<open>_shallow_identifier_as_literal\<close>, K hd),
-                   (\<^syntax_const>\<open>_shallow_identifier_as_function\<close>, K hd),
-                   (\<^syntax_const>\<open>_shallow_identifier_as_field\<close>, K hd)]\<close>
+parse_translation\<open>
+let
+  \<comment>\<open>Lower a uRust identifier in \<open>kind\<close>-position to HOL: if \<open>name\<close> has any
+    backends registered in \<^ML_structure>\<open>Micro_Rust_Names\<close>, emit a typed
+    \<^const>\<open>urust_dispatch\<close> marker that the term_check phase resolves
+    against the occurrence's inferred type. Otherwise fall back to the
+    bare identifier (the historical \<open>K hd\<close> behaviour: a fresh free
+    variable named \<open>name\<close> --- which is what unregistered uRust
+    identifiers should still produce).
+
+    The arg arrives as a position-tagged identifier
+    \<open>_constrain $ Free name $ Free <pos>\<close> after the \<open>id_position\<close>
+    grammar; strip positions only for the lookup, not for the fallback
+    return value (so unregistered names retain their source markup).\<close>
+  \<comment>\<open>Extract the source position(s) of a position-tagged identifier
+    \<open>_constrain $ Free name $ Free <encoded-pos>\<close>. Returns \<open>[]\<close> for
+    untagged identifiers; the use-site markup is then emitted at
+    \<open>Position.none\<close> and silently dropped.\<close>
+  fun source_positions_of (Const (\<^syntax_const>\<open>_constrain\<close>, _) $ _ $ enc) =
+        (case Term_Position.decode_position1 enc of
+          SOME {pos, ...} => [pos]
+        | NONE => [])
+    | source_positions_of _ = [];
+
+  \<comment>\<open>Pick the leftmost decoded source position (if any) to fold into
+    the marker; \<open>Position.none\<close> when nothing is attached.\<close>
+  fun pick_pos source_positions =
+    (case source_positions of p :: _ => p | [] => Position.none);
+
+  \<comment>\<open>Lower a uRust identifier in \<open>kind\<close>-position to HOL. After AST
+     flattening of paths into \<^verbatim>\<open>_urust_identifier_id\<close>, plain identifiers
+     and path identifiers (\<open>foo::bar\<close>) arrive uniformly as
+     \<^verbatim>\<open>Free name\<close> (possibly \<open>_constrain\<close>-wrapped with a source position).
+     For paths the name simply contains \<open>::\<close> separators; downstream
+     consumers only look at the name string, so no shape match is needed.
+
+     We ALWAYS emit a \<^verbatim>\<open>urust_dispatch\<close> marker carrying the original
+     \<open>arg\<close> as a witness. HOL elaboration resolves the witness through
+     normal binding, and the term_check phase uses witness precedence:
+     a \<^verbatim>\<open>Bound\<close> witness (a \<lambda>-binder of the same name) wins over any
+     table registration; a \<^verbatim>\<open>Free\<close> or \<^verbatim>\<open>Const\<close> witness defers to the
+     table, falling back to itself on miss. This is what stops a
+     registered \<open>("mask")\<close> from hijacking a \<open>\<lambda>mask. \<dots> mask \<dots>\<close> use site.
+
+     Path identifiers (\<open>Foo::Bar\<close>) cannot be HOL binders, so the witness
+     elaborates to a \<^verbatim>\<open>Free\<close> with a \<open>::\<close>-containing name; the table
+     lookup proceeds exactly as for plain ids.\<close>
+  fun lookup_id_tr kind ctxt [arg] =
+        (case Term_Position.strip_positions arg of
+          Free (name, _) =>
+            \<comment>\<open>Only emit a marker when the table actually has a registration
+              for this \<open>(kind, name)\<close>. If there is none, return the bare
+              \<open>arg\<close> --- otherwise we'd disrupt downstream constructions
+              like \<open>_abs\<close> binders that expect the binder slot to be a
+              recognisable \<open>Free\<close>/\<open>_constrain\<close>-wrapped shape, not a
+              \<open>urust_dispatch\<close> application.\<close>
+            (case Micro_Rust_Names.lookups ctxt kind name of
+               [] => arg
+             | _ =>
+                 \<comment>\<open>Markup emission is deferred to \<open>Micro_Rust_Dispatch.resolve\<close>:
+                   we emit the use-site markup ONLY when a marker is
+                   actually replaced by a registered backend, never
+                   when the witness ends up winning (\<lambda>-binder shadow).\<close>
+                 Micro_Rust_Dispatch.mk_marker kind name
+                   (pick_pos (source_positions_of arg)) arg)
+        | _ => arg)
+    | lookup_id_tr _ _ ts = hd ts;
+in
+  [(\<^syntax_const>\<open>_urust_identifier_id\<close>, K hd),
+   (\<^syntax_const>\<open>_shallow_identifier_as_literal\<close>,
+      lookup_id_tr Micro_Rust_Names.NLiteral),
+   (\<^syntax_const>\<open>_shallow_identifier_as_function\<close>,
+      lookup_id_tr Micro_Rust_Names.NFunction),
+   (\<^syntax_const>\<open>_shallow_identifier_as_field\<close>,
+      lookup_id_tr Micro_Rust_Names.NField)]
+end
+\<close>
+
+\<comment>\<open>Binder-introduction resolver: a let-pattern leaf or other binder slot.
+  Pure identity --- the identifier IS the binder, so the dispatch table
+  is never consulted. A registered uRust notation of the same name is
+  silently shadowed by the let, mirroring Rust's lexical scoping. Runs
+  at parse-translation time so \<^ML>\<open>Syntax_Trans.abs_tr\<close> sees the bare
+  \<^verbatim>\<open>Free\<close>/\<open>_constrain\<close> shape it expects.
+
+  Match-arm constructor heads do NOT use this resolver --- they keep
+  routing through the value-position \<open>_shallow_identifier_as_literal\<close>
+  so the term_check phase can resolve registered names AFTER type
+  inference (necessary for value-position match arms like
+  \<open>match x { number::three => \<dots> }\<close> where the registration target is a
+  non-constructor constant).\<close>
+parse_translation\<open>
+  [(\<^syntax_const>\<open>_shallow_pattern_id\<close>, fn _ => hd)]
+\<close>
 
 ML\<open>
   fun known_constructor_name ctxt name =
@@ -910,15 +967,31 @@ ML\<open>
       else NONE
     end;
 
-  fun resolve_constructor_id _ (id as Const _) = SOME id
-    | resolve_constructor_id ctxt (Free (name, _)) =
-        Option.map Syntax.const (known_constructor_name ctxt name)
-    | resolve_constructor_id _ _ = NONE;
+  \<comment>\<open>Resolve a constructor identifier \<open>id\<close> to its fully-qualified
+    \<^verbatim>\<open>Const\<close>. We must preserve the original \<^verbatim>\<open>_constrain $ _ $ <pos\<close>
+    wrapper so the decoder's namespace markup ends up at the user's
+    source token --- otherwise pattern heads like \<open>Some\<close> in
+    \<open>match x { Some(y) => \<dots> }\<close> or \<open>if let Some(y) = \<dots>\<close> have no
+    clickable entity ref attached.\<close>
+  fun preserve_position id new_inner =
+    (case id of
+      Const (\<^syntax_const>\<open>_constrain\<close>, T) $ _ $ pos_enc =>
+        Const (\<^syntax_const>\<open>_constrain\<close>, T) $ new_inner $ pos_enc
+    | _ => new_inner);
 
-  fun dest_ident_name ctxt (Free (name, _)) = name
-    | dest_ident_name ctxt (Const (name, _)) = name
-    | dest_ident_name ctxt t =
-        error ("invalid identifier term: " ^ Syntax.string_of_term ctxt t);
+  fun resolve_constructor_id ctxt id =
+    (case Term_Position.strip_positions id of
+      t as Const _ => SOME (preserve_position id t)
+    | Free (name, _) =>
+        Option.map (fn n => preserve_position id (Syntax.const n))
+                   (known_constructor_name ctxt name)
+    | _ => NONE);
+
+  fun dest_ident_name ctxt t =
+    (case Term_Position.strip_positions t of
+      Free (name, _) => name
+    | Const (name, _) => name
+    | _ => error ("invalid identifier term: " ^ Syntax.string_of_term ctxt t));
 
   fun canonical_name s = Long_Name.base_name s;
 

--- a/Shallow_Micro_Rust/Micro_Rust_Shallow_Embedding_Tests.thy
+++ b/Shallow_Micro_Rust/Micro_Rust_Shallow_Embedding_Tests.thy
@@ -995,12 +995,12 @@ record struct_pattern_rec =
 definition foo_struct_expr_lift where
   "foo_struct_expr_lift \<equiv> lift_fun2 Foo"
 
-notation_nano_rust_function foo_struct_expr_lift ("Foo")
+micro_rust_notation (call) foo_struct_expr_lift ("Foo")
 
 definition struct_pattern_dr_struct_expr_lift where
   "struct_pattern_dr_struct_expr_lift \<equiv> lift_fun2 make_struct_pattern_dr"
 
-notation_nano_rust_function struct_pattern_dr_struct_expr_lift ("struct_pattern_dr")
+micro_rust_notation (call) struct_pattern_dr_struct_expr_lift ("struct_pattern_dr")
 
 term\<open>\<lbrakk>
   match (\<llangle>1 :: 32 word\<rrangle>, \<llangle>2 :: 32 word\<rrangle>) {
@@ -1806,6 +1806,141 @@ term \<open>\<lbrakk> s.field3_lens.field2_lens \<rbrakk>\<close>
 no_adhoc_overloading store_dereference_const \<rightleftharpoons> dummy_dereference_field
 end
 
+subsubsection\<open>Custom uRust Field Names\<close>
+
+text\<open>By default \<^verbatim>\<open>micro_rust_record\<close> registers each field's lens under the
+bare HOL field name. Since HOL field names are usually disambiguated with a
+record-name prefix (e.g. \<open>bounds_rec_lo\<close>), this forces that prefix to be
+repeated at every uRust use site. The optional \<^verbatim>\<open>(hol_field = "urust_name", \<dots>)\<close>
+mapping overrides the uRust name per field, so one can write the un-prefixed
+\<open>m.lo\<close> in uRust while the HOL field stays \<open>bounds_rec_lo\<close>.\<close>
+
+datatype_record bounds_rec =
+  bounds_rec_lo :: \<open>64 word\<close>
+  bounds_rec_hi :: \<open>64 word\<close>
+  bounds_rec_flag :: bool
+micro_rust_record bounds_rec
+  (bounds_rec_lo = "lo",
+   bounds_rec_hi = "end",
+   bounds_rec_flag = "flag")
+
+text\<open>Each custom name parses at a uRust use site and resolves to its own,
+correctly-typed field lens. Note \<open>end\<close> is an Isabelle keyword, yet is accepted
+as a field name in \<open>m.end\<close>.\<close>
+
+context
+  fixes m :: bounds_rec
+begin
+term \<open>\<lbrakk> m.lo \<rbrakk>\<close>
+term \<open>\<lbrakk> m.end \<rbrakk>\<close>
+term \<open>\<lbrakk> m.flag \<rbrakk>\<close>
+
+text\<open>The custom name is definitionally the same access as the underlying
+record-prefixed lens — i.e. the override only renames, it does not change the
+target.\<close>
+lemma \<open>\<lbrakk> m.lo \<rbrakk>   = \<lbrakk> m.bounds_rec_bounds_rec_lo_lens \<rbrakk>\<close>   by (rule refl)
+lemma \<open>\<lbrakk> m.end \<rbrakk>  = \<lbrakk> m.bounds_rec_bounds_rec_hi_lens \<rbrakk>\<close>   by (rule refl)
+lemma \<open>\<lbrakk> m.flag \<rbrakk> = \<lbrakk> m.bounds_rec_bounds_rec_flag_lens \<rbrakk>\<close> by (rule refl)
+end
+
+text\<open>Concrete evaluation confirms each custom name reads back the right field:
+\<open>lo\<close>, \<open>end\<close> and \<open>flag\<close> recover the first, second and third
+constructor arguments respectively — so the three names target three distinct
+fields and are not aliased to one.\<close>
+value [simp] \<open>\<lbrakk> \<llangle>make_bounds_rec 1 2 True\<rrangle>.lo \<rbrakk>\<close>   \<comment> \<open>\<open>Expression (Success 1)\<close>\<close>
+value [simp] \<open>\<lbrakk> \<llangle>make_bounds_rec 1 2 True\<rrangle>.end \<rbrakk>\<close>  \<comment> \<open>\<open>Expression (Success 2)\<close>\<close>
+value [simp] \<open>\<lbrakk> \<llangle>make_bounds_rec 1 2 True\<rrangle>.flag \<rbrakk>\<close> \<comment> \<open>\<open>Expression (Success True)\<close>\<close>
+
+text\<open>An override replaces the default name rather than adding to it: once
+\<open>bounds_rec_lo\<close> is mapped to \<open>lo\<close>, the field is reachable in uRust only as
+\<open>m.lo\<close>, not under the record-prefixed HOL name.\<close>
+
+subsubsection\<open>Partial uRust Field-Name Overrides\<close>
+
+text\<open>A mapping need not mention every field: fields omitted from the mapping
+keep their default (bare HOL) name, while listed fields are renamed.\<close>
+
+datatype_record partial_override_rec =
+  por_renamed :: \<open>32 word\<close>
+  por_kept    :: \<open>32 word\<close>
+micro_rust_record partial_override_rec
+  (por_renamed = "renamed")
+
+context
+  fixes p :: partial_override_rec
+begin
+term \<open>\<lbrakk> p.renamed \<rbrakk>\<close>   \<comment> \<open>renamed field uses the override\<close>
+term \<open>\<lbrakk> p.por_kept \<rbrakk>\<close>  \<comment> \<open>omitted field keeps its HOL name\<close>
+end
+
+value [simp] \<open>\<lbrakk> \<llangle>make_partial_override_rec 7 8\<rrangle>.renamed \<rbrakk>\<close>
+value [simp] \<open>\<lbrakk> \<llangle>make_partial_override_rec 7 8\<rrangle>.por_kept \<rbrakk>\<close>
+
+subsubsection\<open>Default Registration (no mapping) Still Works\<close>
+
+text\<open>Omitting the mapping entirely behaves exactly as before: fields are
+registered under their bare HOL names.\<close>
+
+datatype_record no_override_rec =
+  nor_a :: \<open>32 word\<close>
+  nor_b :: bool
+micro_rust_record no_override_rec
+
+context
+  fixes n :: no_override_rec
+begin
+term \<open>\<lbrakk> n.nor_a \<rbrakk>\<close>
+term \<open>\<lbrakk> n.nor_b \<rbrakk>\<close>
+end
+
+subsubsection\<open>Custom Names on Nested Records\<close>
+
+text\<open>Custom field names compose through nested field access just like the
+default names do.\<close>
+
+datatype_record inner_named =
+  inner_named_value :: \<open>32 word\<close>
+micro_rust_record inner_named (inner_named_value = "value")
+
+datatype_record outer_named =
+  outer_named_inner :: inner_named
+  outer_named_flag  :: bool
+micro_rust_record outer_named
+  (outer_named_inner = "inner",
+   outer_named_flag  = "flag")
+
+context
+  fixes o :: outer_named
+begin
+term \<open>\<lbrakk> o.inner \<rbrakk>\<close>
+term \<open>\<lbrakk> o.flag \<rbrakk>\<close>
+value \<open>\<lbrakk> o.inner.value \<rbrakk>\<close>
+end
+
+value [simp] \<open>\<lbrakk> \<llangle>make_outer_named (make_inner_named 99) False\<rrangle>.inner.value \<rbrakk>\<close>
+
+subsubsection\<open>Custom Names in a Locale\<close>
+
+text\<open>The mapping is honoured for \<^verbatim>\<open>micro_rust_record\<close>s declared inside a
+locale, mirroring the default-name locale test above.\<close>
+
+locale micro_rust_record_override_locale_test =
+  fixes answer :: \<open>64 word\<close>
+  assumes \<open>answer = 42\<close>
+begin
+
+datatype_record loc_named =
+  loc_named_lo :: \<open>64 word\<close>
+  loc_named_hi :: \<open>64 word\<close>
+micro_rust_record loc_named
+  (loc_named_lo = "lo",
+   loc_named_hi = "hi")
+
+term \<open>\<lambda> x :: loc_named. \<lbrakk> x.lo + x.hi \<rbrakk>\<close>
+term \<open>\<lambda> x :: ('addr, 'fv, loc_named) ref. \<lbrakk> *x.lo + *x.hi \<rbrakk>\<close>
+
+end
+
 subsection\<open>Macros\<close>
 
 subsubsection\<open>Assertion Macros\<close>
@@ -1973,13 +2108,13 @@ term\<open>3 :: 64 word\<close>
 
 definition number_42 :: nat where \<open>number_42 \<equiv> 42\<close>
 
-notation_nano_rust number_42 ("foo::bar::test1")
-notation_nano_rust number_42 ("foo::bar::test2")
-notation_nano_rust True ("foo::bar::test3")
+micro_rust_notation (literal) number_42 ("foo::bar::test1")
+micro_rust_notation (literal) number_42 ("foo::bar::test2")
+micro_rust_notation (literal) True ("foo::bar::test3")
 
 definition \<open>the_record \<equiv> make_testrec 1 False\<close>
 
-notation_nano_rust the_record ("the::record")
+micro_rust_notation (literal) the_record ("the::record")
 
 term\<open>\<lbrakk>the::record\<rbrakk>\<close>
 term\<open>\<lbrakk>(the::record).field1\<rbrakk>\<close>
@@ -1995,22 +2130,25 @@ datatype test =
     Test1
   | Test2
 
-notation_nano_rust test.Test1 ("test'::Test_1")
-notation_nano_rust test.Test2 ("test::Test'_2")
+micro_rust_notation (literal) test.Test1 ("test::Test_1")
+micro_rust_notation (literal) test.Test2 ("test::Test_2")
 
 definition plus_two :: \<open>'l::len word \<Rightarrow> 'l word\<close> where \<open>plus_two n \<equiv> n + 2\<close>
 definition \<open>plus_two_lift \<equiv> lift_fun1 plus_two\<close>
 
-notation_nano_rust plus_two_lift ("plus2::lifted")
+micro_rust_notation (call)    plus_two_lift ("plus2::lifted")
+micro_rust_notation (literal) plus_two_lift ("plus2::lifted")
+  \<comment>\<open>Registered under both function- and literal-kind: the test below
+     uses \<^verbatim>\<open>plus2::lifted(three)\<close> in function position and
+     \<^verbatim>\<open>let fun = plus2::lifted\<close> in literal position.\<close>
 
 definition three :: \<open>64 word\<close> where \<open>three = 3\<close>
-notation_nano_rust three ("number::three")
+micro_rust_notation (literal) three ("number::three")
 
 term\<open>\<lbrakk> test::Test_1 \<rbrakk>\<close>
 
 term\<open>\<lbrakk>plus2::lifted(three)\<rbrakk>\<close>
 term\<open>\<lbrakk>plus_two_lift(three)\<rbrakk>\<close>
-
 term\<open>\<lbrakk>
   let arg = test::Test_1;
   let fun = plus2::lifted;
@@ -2019,6 +2157,7 @@ term\<open>\<lbrakk>
     test::Test_2 \<Rightarrow> plus2::lifted(three)
   }
 \<rbrakk>\<close>
+
 
 term\<open>\<lbrakk>
   let x = 5;

--- a/Shallow_Micro_Rust/ROOT
+++ b/Shallow_Micro_Rust/ROOT
@@ -19,7 +19,9 @@ session Shallow_Micro_Rust = HOL +
     Num_Case_Expression
     Numeric_Types Numeric_Types_Lemmas
     Global_Store
+    Micro_Rust_Notations
     Micro_Rust_Shallow_Embedding
+    Micro_Rust_Notations_Test
     Micro_Rust_Shallow_Embedding_Tests
     Micro_Rust
     Prompts_And_Responses

--- a/Shallow_Micro_Rust/Range_Type.thy
+++ b/Shallow_Micro_Rust/Range_Type.thy
@@ -59,6 +59,7 @@ subsection\<open>Slice-like behavior from lists\<close>
 
 definition len :: \<open>'a list \<Rightarrow> ('s, 64 word, 'abort, 'i, 'o) function_body\<close> where
   \<open>len xs \<equiv> FunctionBody (literal (of_nat (length xs)))\<close>
+micro_rust_notation (call) len ("len")
 
 definition list_index :: \<open>'a list \<Rightarrow> 'w::len word \<Rightarrow> ('s, 'a, 'abort, 'i, 'o) function_body\<close> where
   \<open>list_index xs idx \<equiv> FunctionBody (

--- a/Shallow_Micro_Rust/Rust_Iterator.thy
+++ b/Shallow_Micro_Rust/Rust_Iterator.thy
@@ -4,7 +4,7 @@
 (*<*)
 theory Rust_Iterator
   imports "HOL-Library.Datatype_Records" Core_Expression
-    Misc.Array Misc.Vector
+    Misc.Array Misc.Vector Micro_Rust_Notations
 begin
 (*>*)
 
@@ -50,6 +50,9 @@ abbreviation compose_func :: \<open>('a \<Rightarrow> ('s, 'b, 'abort, 'i, 'o) f
 definition map :: \<open>('s, 'a, 'abort, 'i, 'o) iterator \<Rightarrow> ('a \<Rightarrow> ('s,'b, 'abort, 'i, 'o) function_body) \<Rightarrow>
     ('s, ('s, 'b, 'abort, 'i, 'o) iterator, 'abort, 'i, 'o) function_body\<close> where
   \<open>map iter f \<equiv> fun_literal (make_iterator (List.map (compose_func f) (iterator_thunks iter)))\<close>
+
+\<comment>\<open>uRust notation for the iterator \<^const>\<open>map\<close> combinator.\<close>
+micro_rust_notation (call) map ("map")
 
 subsection\<open>Looping over iterators\<close>
 


### PR DESCRIPTION
Overhaul how uRust surface notations are registered and how qualified names flow through the parser, and add a few new notations.

* Notation registry: replace the notation_nano_rust* commands with a single table-backed `micro_rust_notation` command. Names are recorded in a `Micro_Rust_Names` table and resolved uniformly by the `_shallow_identifier_as_*` parse translation, instead of via per-name syntax/translations rules and the `RustPathResolution` map. All call sites migrate to `micro_rust_notation (call|field|literal)`.

* Qualified paths: path identifiers (`Foo::Bar`) are flattened at AST time into ordinary `_urust_identifier_id` nodes carrying the joined name, so paths and plain identifiers share one downstream pipeline. Identifier source positions are preserved across longid splitting and match binders, so IDE markup lands on the right source tokens.

* `micro_rust_record` may rename uRust fields independently of their HOL lens names.

* New notations: `len()` for list length, and parser support for the `!`-macros, `matches!(e, pat)`, and `let mut (x, y) = e` binding forms.

Tests updated accordingly.