### PR TITLE
[feat] Byte_Level_Encoding: bool/array/enum encodings + define_byte_enum/define_byte_record

### DIFF
--- a/Byte_Level_Encoding/Byte_Encoding_Array.thy
+++ b/Byte_Level_Encoding/Byte_Encoding_Array.thy
@@ -1,0 +1,202 @@
+(* Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+   SPDX-License-Identifier: MIT *)
+
+(*<*)
+theory Byte_Encoding_Array
+  imports Byte_Encoding_Word_Nat
+begin
+(*>*)
+
+section\<open>Byte encoding for fixed-length arrays\<close>
+
+text\<open>The word and boolean encodings turn a single value into a fixed run of
+bytes.  A fixed-length array \<^verbatim>\<open>[T; N]\<close> instead lays out \<^term>\<open>N\<close> elements,
+each itself encoded as a fixed-width byte run, contiguously.  This section
+provides the generic combinator that turns an element byte-prism of constant
+width \<^term>\<open>w\<close> into a byte-prism onto the fixed-length array type
+\<^typ>\<open>('e, 'l::len) array\<close>, whose type-level length \<^verbatim>\<open>LENGTH('l)\<close> pins the
+element count.
+
+Unlike \<^const>\<open>list_fixlen_prism\<close> — which packages a byte list as a
+\<^emph>\<open>byte\<close> array, one byte per element — here each element occupies \<^term>\<open>w\<close>
+bytes and is decoded through its own prism, so the array decode is \<^emph>\<open>partial\<close>
+(it fails if any element fails to decode, e.g. for an array of booleans).\<close>
+
+subsection\<open>Decoding a byte list into elements\<close>
+
+text\<open>\<^term>\<open>decode_chunks w dec n bs\<close> decodes \<^term>\<open>n\<close> consecutive \<^term>\<open>w\<close>-byte
+chunks of \<^term>\<open>bs\<close> using the element decoder \<^term>\<open>dec\<close>, failing unless the
+input is consumed exactly.  This is an internal helper for
+\<^verbatim>\<open>array_byte_project\<close>; it is \<^emph>\<open>not\<close> a prism projection itself (it has no
+paired embedding — the embedding side is plain \<^const>\<open>concat\<close>).\<close>
+
+fun decode_chunks :: \<open>nat \<Rightarrow> (byte list \<Rightarrow> 'e option) \<Rightarrow> nat \<Rightarrow> byte list \<Rightarrow> 'e list option\<close> where
+  \<open>decode_chunks w dec 0 bs = (if bs = [] then Some [] else None)\<close>
+| \<open>decode_chunks w dec (Suc n) bs =
+     (case dec (take w bs) of None \<Rightarrow> None
+      | Some e \<Rightarrow> (case decode_chunks w dec n (drop w bs) of None \<Rightarrow> None
+                  | Some es \<Rightarrow> Some (e # es)))\<close>
+
+text\<open>Decoding the concatenation of \<^term>\<open>n\<close> embedded elements recovers them
+(the round-trip law, embedding side):\<close>
+
+lemma decode_chunks_concat:
+  assumes \<open>is_valid_prism p\<close>
+      and \<open>\<And>e. length (prism_embed p e) = w\<close>
+      and \<open>length es = n\<close>
+    shows \<open>decode_chunks w (prism_project p) n (concat (map (prism_embed p) es)) = Some es\<close>
+  using assms(3) proof (induction es arbitrary: n)
+  case Nil
+  then show ?case by simp
+next
+  case (Cons e es)
+  then obtain m where m: \<open>n = Suc m\<close>
+    by (cases n) auto
+  have \<open>length es = m\<close>
+    using Cons.prems m by simp
+  then have IH: \<open>decode_chunks w (prism_project p) m (concat (map (prism_embed p) es)) = Some es\<close>
+    by (rule Cons.IH)
+  have tk: \<open>take w (prism_embed p e @ concat (map (prism_embed p) es)) = prism_embed p e\<close>
+    using assms(2) by simp
+  have dr: \<open>drop w (prism_embed p e @ concat (map (prism_embed p) es)) = concat (map (prism_embed p) es)\<close>
+    using assms(2) by simp
+  have pe: \<open>prism_project p (prism_embed p e) = Some e\<close>
+    using assms(1) by (simp add: prism_laws)
+  have \<open>decode_chunks w (prism_project p) (Suc m)
+          (prism_embed p e @ concat (map (prism_embed p) es)) = Some (e # es)\<close>
+    by (simp only: decode_chunks.simps tk dr pe IH option.case)
+  then show ?case
+    using m by simp
+qed
+
+text\<open>Conversely, a successful decode of a length-correct input is the embedding of
+its result (the round-trip law, projection side):\<close>
+
+lemma decode_chunks_inv:
+  assumes \<open>is_valid_prism p\<close>
+      and \<open>\<And>e. length (prism_embed p e) = w\<close>
+      and \<open>length bs = w * n\<close>
+      and \<open>decode_chunks w (prism_project p) n bs = Some es\<close>
+    shows \<open>bs = concat (map (prism_embed p) es)\<close>
+  using assms(3,4) proof (induction n arbitrary: bs es)
+  case 0
+  then show ?case by (simp split: if_splits)
+next
+  case (Suc n)
+  from Suc.prems(2) obtain e es' where
+        pe: \<open>prism_project p (take w bs) = Some e\<close>
+    and rest: \<open>decode_chunks w (prism_project p) n (drop w bs) = Some es'\<close>
+    and es: \<open>es = e # es'\<close>
+    by (auto split: option.splits)
+  from pe assms(1) have te: \<open>take w bs = prism_embed p e\<close>
+    by (simp add: prism_laws)
+  have \<open>length (drop w bs) = w * n\<close>
+    using Suc.prems(1) by simp
+  from this rest have \<open>drop w bs = concat (map (prism_embed p) es')\<close>
+    by (rule Suc.IH)
+  then have \<open>bs = prism_embed p e @ concat (map (prism_embed p) es')\<close>
+    using te by (metis append_take_drop_id)
+  then show ?case
+    by (simp add: es)
+qed
+
+lemma decode_chunks_len:
+  assumes \<open>decode_chunks w dec n bs = Some es\<close>
+    shows \<open>length es = n\<close>
+  using assms proof (induction n arbitrary: bs es)
+  case 0
+  then show ?case by (simp split: if_splits)
+next
+  case (Suc n)
+  then show ?case by (auto split: option.splits)
+qed
+
+lemma concat_embed_len:
+  assumes \<open>\<And>e. length (prism_embed p e) = w\<close>
+    shows \<open>length (concat (map (prism_embed p) es)) = w * length es\<close>
+  using assms by (induction es) (auto simp add: assms)
+
+subsection\<open>The array byte-prism\<close>
+
+text\<open>\<^verbatim>\<open>array_byte_embed\<close> embeds an array by concatenating each element's
+\<^term>\<open>w\<close>-byte embedding; \<^verbatim>\<open>array_byte_project\<close> decodes by splitting the input
+into \<^verbatim>\<open>LENGTH('l)\<close> pieces of width \<^term>\<open>w\<close> (via \<^verbatim>\<open>decode_chunks\<close>) and
+decoding each.  These are the \<^emph>\<open>embed\<close> and \<^emph>\<open>project\<close> halves of
+\<^verbatim>\<open>array_byte_prism\<close>.\<close>
+
+definition array_byte_embed ::
+    \<open>(byte list, 'e) prism \<Rightarrow> ('e, 'l::len) array \<Rightarrow> byte list\<close> where
+  \<open>array_byte_embed p a \<equiv> concat (map (prism_embed p) (array_to_list a))\<close>
+
+definition array_byte_project ::
+    \<open>nat \<Rightarrow> (byte list, 'e) prism \<Rightarrow> byte list \<Rightarrow> ('e, 'l::len) array option\<close> where
+  \<open>array_byte_project w p bs \<equiv>
+     if length bs = w * LENGTH('l)
+     then map_option array_of_list (decode_chunks w (prism_project p) (LENGTH('l)) bs)
+     else None\<close>
+
+definition array_byte_prism ::
+    \<open>nat \<Rightarrow> (byte list, 'e) prism \<Rightarrow> (byte list, ('e, 'l::len) array) prism\<close> where
+  \<open>array_byte_prism w p \<equiv> make_prism (array_byte_embed p) (array_byte_project w p)\<close>
+
+text\<open>The round-trip law for the array follows from the element's law plus the fact
+that each element embeds to exactly \<^term>\<open>w\<close> bytes.\<close>
+
+lemma array_byte_prism_valid:
+  assumes \<open>is_valid_prism p\<close>
+      and \<open>\<And>e. length (prism_embed p e) = w\<close>
+    shows \<open>is_valid_prism (array_byte_prism w p :: (byte list, ('e, 'l::len) array) prism)\<close>
+  unfolding is_valid_prism_def
+proof (intro conjI allI impI)
+  have alen: \<open>\<And>a :: ('e, 'l) array. length (array_to_list a) = LENGTH('l)\<close>
+    by simp
+  fix a :: \<open>('e, 'l) array\<close>
+  have cp: \<open>decode_chunks w (prism_project p) (LENGTH('l))
+              (concat (map (prism_embed p) (array_to_list a))) = Some (array_to_list a)\<close>
+    using assms alen by (rule decode_chunks_concat)
+  have ln: \<open>length (concat (map (prism_embed p) (array_to_list a))) = w * LENGTH('l)\<close>
+    using assms(2) by (simp add: concat_embed_len)
+  show \<open>prism_project (array_byte_prism w p) (prism_embed (array_byte_prism w p) a) = Some a\<close>
+    by (simp add: array_byte_prism_def array_byte_embed_def array_byte_project_def ln cp)
+next
+  fix bs and a :: \<open>('e, 'l) array\<close>
+  assume \<open>prism_project (array_byte_prism w p) bs = Some a\<close>
+  then have lbs: \<open>length bs = w * LENGTH('l)\<close>
+        and cp: \<open>map_option array_of_list (decode_chunks w (prism_project p) (LENGTH('l)) bs) = Some a\<close>
+    by (auto simp add: array_byte_prism_def array_byte_project_def split: if_splits)
+  from cp obtain es where es: \<open>decode_chunks w (prism_project p) (LENGTH('l)) bs = Some es\<close>
+                      and a: \<open>a = array_of_list es\<close>
+    by auto
+  from assms lbs es have bsc: \<open>bs = concat (map (prism_embed p) es)\<close>
+    by (rule decode_chunks_inv)
+  have \<open>length es = LENGTH('l)\<close>
+    using es by (rule decode_chunks_len)
+  then have \<open>array_to_list a = es\<close>
+    using a by (simp add: list_to_array_to_list)
+  then show \<open>bs = prism_embed (array_byte_prism w p) a\<close>
+    using bsc by (simp add: array_byte_prism_def array_byte_embed_def)
+qed
+
+text\<open>The array prism is fixed-width: every array embeds to \<^verbatim>\<open>w * LENGTH('l)\<close>
+bytes, and every successful projection consumes exactly that many.  These let an
+array appear as a field of a larger fixed-layout record.\<close>
+
+lemma array_byte_prism_embed_len:
+  assumes \<open>\<And>e. length (prism_embed p e) = w\<close>
+    shows \<open>length (prism_embed (array_byte_prism w p :: (byte list, ('e, 'l::len) array) prism) a)
+             = w * LENGTH('l)\<close>
+  using assms by (simp add: array_byte_prism_def array_byte_embed_def concat_embed_len)
+
+lemma array_byte_prism_project_len:
+  assumes \<open>prism_project (array_byte_prism w p :: (byte list, ('e, 'l::len) array) prism) bs = Some a\<close>
+    shows \<open>length bs = w * LENGTH('l)\<close>
+  using assms by (auto simp add: array_byte_prism_def array_byte_project_def split: if_splits)
+
+text\<open>A concrete array encoding is obtained by instantiating the element prism
+with a fixed-width element codec — for example \<^verbatim>\<open>array_byte_prism 8
+word64_byte_list_prism_le\<close> for a \<^verbatim>\<open>[u64; N]\<close> field — whose validity follows
+from \<^verbatim>\<open>array_byte_prism_valid\<close> and the element's embedding-length fact.\<close>
+
+(*<*)
+end
+(*>*)

--- a/Byte_Level_Encoding/Byte_Encoding_Array.thy
+++ b/Byte_Level_Encoding/Byte_Encoding_Array.thy
@@ -193,7 +193,7 @@ lemma array_byte_prism_project_len:
   using assms by (auto simp add: array_byte_prism_def array_byte_project_def split: if_splits)
 
 text\<open>A concrete array encoding is obtained by instantiating the element prism
-with a fixed-width element codec — for example \<^verbatim>\<open>array_byte_prism 8
+with a fixed-width element prism — for example \<^verbatim>\<open>array_byte_prism 8
 word64_byte_list_prism_le\<close> for a \<^verbatim>\<open>[u64; N]\<close> field — whose validity follows
 from \<^verbatim>\<open>array_byte_prism_valid\<close> and the element's embedding-length fact.\<close>
 

--- a/Byte_Level_Encoding/Byte_Encoding_Array.thy
+++ b/Byte_Level_Encoding/Byte_Encoding_Array.thy
@@ -3,7 +3,7 @@
 
 (*<*)
 theory Byte_Encoding_Array
-  imports Byte_Encoding_Word_Nat
+  imports Byte_Encoding_Word_Nat Byte_Encoding_Prisms
 begin
 (*>*)
 
@@ -196,6 +196,70 @@ text\<open>A concrete array encoding is obtained by instantiating the element pr
 with a fixed-width element prism — for example \<^verbatim>\<open>array_byte_prism 8
 word64_byte_list_prism_le\<close> for a \<^verbatim>\<open>[u64; N]\<close> field — whose validity follows
 from \<^verbatim>\<open>array_byte_prism_valid\<close> and the element's embedding-length fact.\<close>
+
+subsection\<open>Fixed-width facts for the array and pad leaves\<close>
+
+text\<open>A pad field \<^verbatim>\<open>[u8; N]\<close> is exactly \<^const>\<open>list_fixlen_prism\<close> (a byte list to a
+length-\<^term>\<open>N\<close> byte array), of fixed width \<^verbatim>\<open>LENGTH('l)\<close>.\<close>
+
+lemma fixed_width_pad:
+  \<open>fixed_width_prism (LENGTH('l::len)) (list_fixlen_prism :: (byte list, (byte, 'l) array) prism)\<close>
+proof (rule fixed_width_prismI)
+  show \<open>is_valid_prism (list_fixlen_prism :: (byte list, (byte, 'l) array) prism)\<close>
+    by (rule list_fixlen_prism_valid)
+next
+  fix a show \<open>length (prism_embed (list_fixlen_prism :: (byte list, (byte, 'l) array) prism) a)
+                = LENGTH('l)\<close>
+    by (simp add: list_fixlen_prism_def list_fixlen_embed_def)
+next
+  fix bs and a :: \<open>(byte, 'l) array\<close>
+  assume \<open>prism_project (list_fixlen_prism :: (byte list, (byte, 'l) array) prism) bs = Some a\<close>
+  then show \<open>length bs = LENGTH('l)\<close>
+    by (auto simp add: list_fixlen_prism_def list_fixlen_project_def split: if_splits)
+qed
+
+text\<open>A word-array field \<^verbatim>\<open>[uW; N]\<close> is \<^const>\<open>array_byte_prism\<close> over a fixed-width
+element prism; the array is then fixed-width \<^verbatim>\<open>w * LENGTH('l)\<close>.\<close>
+
+lemma fixed_width_array:
+  assumes \<open>fixed_width_prism w p\<close>
+    shows \<open>fixed_width_prism (w * LENGTH('l::len))
+             (array_byte_prism w p :: (byte list, ('e, 'l) array) prism)\<close>
+proof (rule fixed_width_prismI)
+  from assms have vp: \<open>is_valid_prism p\<close>
+    and wp: \<open>\<And>e. length (prism_embed p e) = w\<close>
+    by (auto simp add: fixed_width_prism_def)
+  show \<open>is_valid_prism (array_byte_prism w p :: (byte list, ('e, 'l) array) prism)\<close>
+    using vp wp by (rule array_byte_prism_valid)
+next
+  from assms have wp: \<open>\<And>e. length (prism_embed p e) = w\<close>
+    by (simp add: fixed_width_prism_def)
+  fix a show \<open>length (prism_embed (array_byte_prism w p :: (byte list, ('e, 'l) array) prism) a)
+                = w * LENGTH('l)\<close>
+    using wp by (rule array_byte_prism_embed_len)
+next
+  fix bs and a :: \<open>('e, 'l) array\<close>
+  assume \<open>prism_project (array_byte_prism w p :: (byte list, ('e, 'l) array) prism) bs = Some a\<close>
+  then show \<open>length bs = w * LENGTH('l)\<close>
+    by (rule array_byte_prism_project_len)
+qed
+
+subsection\<open>Remaining-returning array prism\<close>
+
+text\<open>Bridging the consume-all \<^const>\<open>array_byte_prism\<close> to a remaining-returning prism
+via \<^const>\<open>split_prism\<close>: it peels the \<^verbatim>\<open>w * LENGTH('l)\<close> bytes of the array off the
+front and hands the rest back, so an array can be chained as a parser.  The one
+array induction stays in \<^verbatim>\<open>array_byte_prism_valid\<close>; the bridge adds none.\<close>
+
+definition array_split_prism ::
+    \<open>nat \<Rightarrow> (byte list, 'e) prism \<Rightarrow> (byte list, ('e, 'l::len) array \<times> byte list) prism\<close> where
+  \<open>array_split_prism w p \<equiv> split_prism (w * LENGTH('l)) (array_byte_prism w p)\<close>
+
+lemma array_split_prism_valid:
+  assumes \<open>fixed_width_prism w p\<close>
+    shows \<open>is_valid_prism (array_split_prism w p :: (byte list, ('e, 'l::len) array \<times> byte list) prism)\<close>
+  unfolding array_split_prism_def
+  by (rule split_prism_valid) (rule fixed_width_array[OF assms])
 
 (*<*)
 end

--- a/Byte_Level_Encoding/Byte_Encoding_Bool.thy
+++ b/Byte_Level_Encoding/Byte_Encoding_Bool.thy
@@ -1,0 +1,42 @@
+(* Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+   SPDX-License-Identifier: MIT *)
+
+(*<*)
+theory Byte_Encoding_Bool
+  imports Byte_Encoding_Word_Nat
+begin
+(*>*)
+
+section\<open>Byte encoding for booleans\<close>
+
+text\<open>A boolean occupies a single byte: \<^verbatim>\<open>True\<close> is encoded as \<^verbatim>\<open>1\<close> and
+\<^verbatim>\<open>False\<close> as \<^verbatim>\<open>0\<close>. Unlike the word encodings, decoding is \<^emph>\<open>partial\<close>: only
+the bytes \<^verbatim>\<open>0\<close> and \<^verbatim>\<open>1\<close> are valid encodings, so the projection returns
+\<^term>\<open>None\<close> on any other byte. The encoding is therefore a genuine prism
+rather than an isomorphism, in the same spirit as the niche encoding for
+optional non-null pointers (see \<^verbatim>\<open>Niche_Encoding_Option_NonNull\<close>).
+
+Unlike the word encodings, a boolean occupies a single byte, so there is no
+endianness and no intermediate array/list layer: the encoding is a prism
+directly from \<^typ>\<open>byte\<close>.\<close>
+
+definition bool_to_byte :: \<open>bool \<Rightarrow> byte\<close> where
+  \<open>bool_to_byte b = (if b then 1 else 0)\<close>
+
+definition byte_to_bool :: \<open>byte \<Rightarrow> bool option\<close> where
+  \<open>byte_to_bool w = (if w = 0 then Some False else if w = 1 then Some True else None)\<close>
+
+definition bool_byte_prism :: \<open>(byte, bool) prism\<close> where
+  \<open>bool_byte_prism \<equiv> make_prism bool_to_byte byte_to_bool\<close>
+
+lemma bool_byte_prism_valid:
+  shows \<open>is_valid_prism bool_byte_prism\<close>
+by (auto simp add: is_valid_prism_def bool_byte_prism_def bool_to_byte_def byte_to_bool_def
+  split: if_splits)
+
+lift_definition bool_byte_focus :: \<open>(byte, bool) focus\<close> is \<open>prism_to_focus_raw bool_byte_prism\<close>
+using bool_byte_prism_valid prism_to_focus_raw_valid by blast
+
+(*<*)
+end
+(*>*)

--- a/Byte_Level_Encoding/Byte_Encoding_Enum.thy
+++ b/Byte_Level_Encoding/Byte_Encoding_Enum.thy
@@ -17,12 +17,11 @@ projects to \<^term>\<open>None\<close>.
 
 Unlike the fixed word encodings, an enumeration has no canonical numeric layout:
 each concrete enum chooses its own discriminant assignment.  The encoding is
-therefore a \<^emph>\<open>combinator\<close> parameterised by a discriminant codec
+therefore a \<^emph>\<open>combinator\<close> parameterised by a discriminant encoding
 \<^term>\<open>to_byte\<close> / \<^term>\<open>from_byte\<close>; a concrete enum becomes an instance by
 supplying the two functions and discharging the two round-trip facts (a legal
 discriminant decodes back to its constructor; an illegal one decodes to
-\<^term>\<open>None\<close>).  This mirrors the Verus \<^verbatim>\<open>define_enum!\<close> macro, whose generated
-\<^verbatim>\<open>lemma_<E>_roundtrip\<close> obligations are exactly these two facts.\<close>
+\<^term>\<open>None\<close>).\<close>
 
 subsection\<open>The enum byte-prism combinator\<close>
 
@@ -30,7 +29,7 @@ definition enum_byte_prism :: \<open>('e \<Rightarrow> byte) \<Rightarrow> (byte
   \<open>enum_byte_prism to_byte from_byte \<equiv> make_prism to_byte from_byte\<close>
 
 text\<open>Validity is the enum round-trip law: it follows from the two facts that a
-concrete enum's discriminant codec must satisfy.\<close>
+concrete enum's discriminant encoding must satisfy.\<close>
 
 lemma enum_byte_prism_valid:
   assumes \<open>\<And>e. from_byte (to_byte e) = Some e\<close>
@@ -44,7 +43,7 @@ text\<open>A concrete enum becomes an instance by supplying \<^term>\<open>to_by
 lifts to a focus exactly as the boolean encoding does
 (\<^const>\<open>bool_byte_focus\<close>).  The generic combinator itself stops at the
 conditional validity law, since the lift to a focus requires the discriminant
-codec to be fixed; the \<^verbatim>\<open>define_byte_enum\<close> command below automates the
+encoding to be fixed; the \<^verbatim>\<open>define_byte_enum\<close> command below automates the
 per-instance boilerplate.\<close>
 
 subsection\<open>The \<^verbatim>\<open>define_byte_enum\<close> command\<close>
@@ -55,46 +54,45 @@ a name and a discriminant assignment
 \<^verbatim>\<open>define_byte_enum <T> = <C0>: <d0> | <C1>: <d1> | ...\<close>
 
 it defines the enumeration type (via the \<^verbatim>\<open>enum\<close> command), generates the
-discriminant codec \<^verbatim>\<open><T>_to_byte\<close> / \<^verbatim>\<open><T>_from_byte\<close>, defines
+discriminant encoding \<^verbatim>\<open><T>_to_byte\<close> / \<^verbatim>\<open><T>_from_byte\<close>, defines
 \<^verbatim>\<open><T>_byte_prism\<close> as an instance of \<^const>\<open>enum_byte_prism\<close>, and proves the
-round-trip law \<^verbatim>\<open><T>_byte_prism_valid\<close> automatically.  This is the Isabelle
-analogue of the Verus \<^verbatim>\<open>define_enum!\<close> macro.\<close>
+round-trip law \<^verbatim>\<open><T>_byte_prism_valid\<close> automatically.\<close>
 
 ML_file \<open>byte_encoding_enum_cmd.ML\<close>
 
 subsection\<open>Worked example\<close>
 
-text\<open>\<^verbatim>\<open>SerifyVcpuActionType\<close> is a live-update enum.  Defined in one line by the
-command, with the type, discriminant codec, prism, and round-trip proof all
-generated automatically.\<close>
+text\<open>A three-constructor enumeration, defined in one line by the command, with the
+type, discriminant encoding, prism, and round-trip proof all generated
+automatically.\<close>
 
-define_byte_enum serify_vcpu_action_type =
-    SVAT_None: 0 | SVAT_AdvancePc: 1 | SVAT_InjectException: 2
+define_byte_enum demo_enum =
+    DE_First: 0 | DE_Second: 1 | DE_Third: 2
 
 text\<open>The command generated the type and all four artifacts.  We check them:\<close>
 
 \<comment>\<open>The type and its constructors exist.\<close>
-term \<open>SVAT_None\<close> term \<open>SVAT_AdvancePc\<close> term \<open>SVAT_InjectException\<close>
+term \<open>DE_First\<close> term \<open>DE_Second\<close> term \<open>DE_Third\<close>
 
-\<comment>\<open>The codec and prism exist, with the expected types.\<close>
-term \<open>serify_vcpu_action_type_to_byte :: serify_vcpu_action_type \<Rightarrow> byte\<close>
-term \<open>serify_vcpu_action_type_from_byte :: byte \<Rightarrow> serify_vcpu_action_type option\<close>
-term \<open>serify_vcpu_action_type_byte_prism :: (byte, serify_vcpu_action_type) prism\<close>
+\<comment>\<open>The encoding functions and prism exist, with the expected types.\<close>
+term \<open>demo_enum_to_byte :: demo_enum \<Rightarrow> byte\<close>
+term \<open>demo_enum_from_byte :: byte \<Rightarrow> demo_enum option\<close>
+term \<open>demo_enum_byte_prism :: (byte, demo_enum) prism\<close>
 
 \<comment>\<open>The round-trip law was proven automatically.\<close>
-lemma \<open>is_valid_prism serify_vcpu_action_type_byte_prism\<close>
-  by (rule serify_vcpu_action_type_byte_prism_valid)
+lemma \<open>is_valid_prism demo_enum_byte_prism\<close>
+  by (rule demo_enum_byte_prism_valid)
 
-\<comment>\<open>The generated codec encodes the discriminants as specified.\<close>
-lemma \<open>serify_vcpu_action_type_to_byte SVAT_None = 0\<close>
-  and \<open>serify_vcpu_action_type_to_byte SVAT_AdvancePc = 1\<close>
-  and \<open>serify_vcpu_action_type_to_byte SVAT_InjectException = 2\<close>
-  by (simp_all add: serify_vcpu_action_type_to_byte_def)
+\<comment>\<open>The generated encoding maps the discriminants as specified.\<close>
+lemma \<open>demo_enum_to_byte DE_First = 0\<close>
+  and \<open>demo_enum_to_byte DE_Second = 1\<close>
+  and \<open>demo_enum_to_byte DE_Third = 2\<close>
+  by (simp_all add: demo_enum_to_byte_def)
 
 \<comment>\<open>Decoding inverts encoding, and an illegal discriminant fails.\<close>
-lemma \<open>serify_vcpu_action_type_from_byte 1 = Some SVAT_AdvancePc\<close>
-  and \<open>serify_vcpu_action_type_from_byte 7 = None\<close>
-  by (simp_all add: serify_vcpu_action_type_from_byte_def)
+lemma \<open>demo_enum_from_byte 1 = Some DE_Second\<close>
+  and \<open>demo_enum_from_byte 7 = None\<close>
+  by (simp_all add: demo_enum_from_byte_def)
 
 (*<*)
 end

--- a/Byte_Level_Encoding/Byte_Encoding_Enum.thy
+++ b/Byte_Level_Encoding/Byte_Encoding_Enum.thy
@@ -1,0 +1,101 @@
+(* Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+   SPDX-License-Identifier: MIT *)
+
+(*<*)
+theory Byte_Encoding_Enum
+  imports Byte_Encoding_Bool "Enum_Theory.Enum_Theory"
+  keywords "define_byte_enum" :: thy_decl
+begin
+(*>*)
+
+section\<open>Byte encoding for enumerations\<close>
+
+text\<open>An enumeration is encoded as a single \<^emph>\<open>discriminant\<close> byte.  Like the
+boolean encoding — of which this is the generalisation — decoding is
+\<^emph>\<open>partial\<close>: only the bytes that name a constructor are valid, every other byte
+projects to \<^term>\<open>None\<close>.
+
+Unlike the fixed word encodings, an enumeration has no canonical numeric layout:
+each concrete enum chooses its own discriminant assignment.  The encoding is
+therefore a \<^emph>\<open>combinator\<close> parameterised by a discriminant codec
+\<^term>\<open>to_byte\<close> / \<^term>\<open>from_byte\<close>; a concrete enum becomes an instance by
+supplying the two functions and discharging the two round-trip facts (a legal
+discriminant decodes back to its constructor; an illegal one decodes to
+\<^term>\<open>None\<close>).  This mirrors the Verus \<^verbatim>\<open>define_enum!\<close> macro, whose generated
+\<^verbatim>\<open>lemma_<E>_roundtrip\<close> obligations are exactly these two facts.\<close>
+
+subsection\<open>The enum byte-prism combinator\<close>
+
+definition enum_byte_prism :: \<open>('e \<Rightarrow> byte) \<Rightarrow> (byte \<Rightarrow> 'e option) \<Rightarrow> (byte, 'e) prism\<close> where
+  \<open>enum_byte_prism to_byte from_byte \<equiv> make_prism to_byte from_byte\<close>
+
+text\<open>Validity is the enum round-trip law: it follows from the two facts that a
+concrete enum's discriminant codec must satisfy.\<close>
+
+lemma enum_byte_prism_valid:
+  assumes \<open>\<And>e. from_byte (to_byte e) = Some e\<close>
+      and \<open>\<And>w e. from_byte w = Some e \<Longrightarrow> to_byte e = w\<close>
+    shows \<open>is_valid_prism (enum_byte_prism to_byte from_byte)\<close>
+using assms by (auto simp add: is_valid_prism_def enum_byte_prism_def)
+
+text\<open>A concrete enum becomes an instance by supplying \<^term>\<open>to_byte\<close> /
+\<^term>\<open>from_byte\<close> and discharging the two round-trip facts;
+\<^verbatim>\<open>enum_byte_prism_valid\<close> then yields validity unconditionally, and the prism
+lifts to a focus exactly as the boolean encoding does
+(\<^const>\<open>bool_byte_focus\<close>).  The generic combinator itself stops at the
+conditional validity law, since the lift to a focus requires the discriminant
+codec to be fixed; the \<^verbatim>\<open>define_byte_enum\<close> command below automates the
+per-instance boilerplate.\<close>
+
+subsection\<open>The \<^verbatim>\<open>define_byte_enum\<close> command\<close>
+
+text\<open>The \<^verbatim>\<open>define_byte_enum\<close> command automates the instance boilerplate.  Given
+a name and a discriminant assignment
+
+\<^verbatim>\<open>define_byte_enum <T> = <C0>: <d0> | <C1>: <d1> | ...\<close>
+
+it defines the enumeration type (via the \<^verbatim>\<open>enum\<close> command), generates the
+discriminant codec \<^verbatim>\<open><T>_to_byte\<close> / \<^verbatim>\<open><T>_from_byte\<close>, defines
+\<^verbatim>\<open><T>_byte_prism\<close> as an instance of \<^const>\<open>enum_byte_prism\<close>, and proves the
+round-trip law \<^verbatim>\<open><T>_byte_prism_valid\<close> automatically.  This is the Isabelle
+analogue of the Verus \<^verbatim>\<open>define_enum!\<close> macro.\<close>
+
+ML_file \<open>byte_encoding_enum_cmd.ML\<close>
+
+subsection\<open>Worked example\<close>
+
+text\<open>\<^verbatim>\<open>SerifyVcpuActionType\<close> is a live-update enum.  Defined in one line by the
+command, with the type, discriminant codec, prism, and round-trip proof all
+generated automatically.\<close>
+
+define_byte_enum serify_vcpu_action_type =
+    SVAT_None: 0 | SVAT_AdvancePc: 1 | SVAT_InjectException: 2
+
+text\<open>The command generated the type and all four artifacts.  We check them:\<close>
+
+\<comment>\<open>The type and its constructors exist.\<close>
+term \<open>SVAT_None\<close> term \<open>SVAT_AdvancePc\<close> term \<open>SVAT_InjectException\<close>
+
+\<comment>\<open>The codec and prism exist, with the expected types.\<close>
+term \<open>serify_vcpu_action_type_to_byte :: serify_vcpu_action_type \<Rightarrow> byte\<close>
+term \<open>serify_vcpu_action_type_from_byte :: byte \<Rightarrow> serify_vcpu_action_type option\<close>
+term \<open>serify_vcpu_action_type_byte_prism :: (byte, serify_vcpu_action_type) prism\<close>
+
+\<comment>\<open>The round-trip law was proven automatically.\<close>
+lemma \<open>is_valid_prism serify_vcpu_action_type_byte_prism\<close>
+  by (rule serify_vcpu_action_type_byte_prism_valid)
+
+\<comment>\<open>The generated codec encodes the discriminants as specified.\<close>
+lemma \<open>serify_vcpu_action_type_to_byte SVAT_None = 0\<close>
+  and \<open>serify_vcpu_action_type_to_byte SVAT_AdvancePc = 1\<close>
+  and \<open>serify_vcpu_action_type_to_byte SVAT_InjectException = 2\<close>
+  by (simp_all add: serify_vcpu_action_type_to_byte_def)
+
+\<comment>\<open>Decoding inverts encoding, and an illegal discriminant fails.\<close>
+lemma \<open>serify_vcpu_action_type_from_byte 1 = Some SVAT_AdvancePc\<close>
+  and \<open>serify_vcpu_action_type_from_byte 7 = None\<close>
+  by (simp_all add: serify_vcpu_action_type_from_byte_def)
+
+(*<*)
+end
+(*>*)

--- a/Byte_Level_Encoding/Byte_Encoding_Enum.thy
+++ b/Byte_Level_Encoding/Byte_Encoding_Enum.thy
@@ -41,10 +41,33 @@ text\<open>A concrete enum becomes an instance by supplying \<^term>\<open>to_by
 \<^term>\<open>from_byte\<close> and discharging the two round-trip facts;
 \<^verbatim>\<open>enum_byte_prism_valid\<close> then yields validity unconditionally, and the prism
 lifts to a focus exactly as the boolean encoding does
-(\<^const>\<open>bool_byte_focus\<close>).  The generic combinator itself stops at the
-conditional validity law, since the lift to a focus requires the discriminant
-encoding to be fixed; the \<^verbatim>\<open>define_byte_enum\<close> command below automates the
-per-instance boilerplate.\<close>
+(\<^const>\<open>bool_byte_focus\<close>).\<close>
+
+subsection\<open>Lifting the enum prism to a focus\<close>
+
+text\<open>To use an enum as a field of a parser we need it as a \<^emph>\<open>focus\<close>, not just a
+prism.  A parser needs a proper (typedef) focus, which only \<^verbatim>\<open>lift_definition\<close> can
+build; \<^verbatim>\<open>lift_definition\<close> in turn requires the lifted raw focus to be valid for
+\<^emph>\<open>all\<close> \<^term>\<open>to_byte\<close> / \<^term>\<open>from_byte\<close>.  The enum focus is valid only when the
+two round-trip facts hold, so we lift a \<^emph>\<open>guarded\<close> raw focus: the real focus when
+they hold, and the always-valid \<^const>\<open>dummy_focus\<close> otherwise.  A concrete enum
+always satisfies the facts, so the dummy branch is never taken;
+\<^verbatim>\<open>enum_byte_focus_valid\<close> records validity under that assumption.  This is the same
+device as the array focus, and lets one generic definition serve every enum
+without a per-instance \<^verbatim>\<open>lift_definition\<close>.\<close>
+
+lift_definition enum_byte_focus :: \<open>('e \<Rightarrow> byte) \<Rightarrow> (byte \<Rightarrow> 'e option) \<Rightarrow> (byte, 'e) focus\<close> is
+  \<open>\<lambda>to_byte from_byte.
+     if (\<forall>e. from_byte (to_byte e) = Some e) \<and> (\<forall>w e. from_byte w = Some e \<longrightarrow> to_byte e = w)
+     then prism_to_focus_raw (enum_byte_prism to_byte from_byte)
+     else dummy_focus\<close>
+  by (auto simp add: dummy_focus_is_valid prism_to_focus_raw_valid enum_byte_prism_valid)
+
+lemma enum_byte_focus_valid:
+  assumes \<open>\<And>e. from_byte (to_byte e) = Some e\<close>
+      and \<open>\<And>w e. from_byte w = Some e \<Longrightarrow> to_byte e = w\<close>
+    shows \<open>is_valid_focus (Rep_focus (enum_byte_focus to_byte from_byte))\<close>
+  using assms by (simp add: enum_byte_focus.rep_eq prism_to_focus_raw_valid enum_byte_prism_valid)
 
 subsection\<open>The \<^verbatim>\<open>define_byte_enum\<close> command\<close>
 

--- a/Byte_Level_Encoding/Byte_Encoding_Prisms.thy
+++ b/Byte_Level_Encoding/Byte_Encoding_Prisms.thy
@@ -1,0 +1,146 @@
+(* Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+   SPDX-License-Identifier: MIT *)
+
+(*<*)
+theory Byte_Encoding_Prisms
+  imports Byte_Encoding_Word_Nat
+begin
+(*>*)
+
+section\<open>Generic prism material for byte encodings\<close>
+
+text\<open>This theory collects the byte-encoding prism machinery that is generic, that
+is, not tied to any particular record layout: the \<^verbatim>\<open>fixed_width_prism\<close> predicate,
+the fixed-width facts for the word leaf prisms, and the \<^verbatim>\<open>split_prism\<close> bridge from
+a consume-all prism to a remaining-returning one.  It is imported by the other
+\<^verbatim>\<open>Byte_Encoding_xxx\<close> theories.\<close>
+
+subsection\<open>Fixed-width byte prisms\<close>
+
+text\<open>A byte-list prism is \<^emph>\<open>fixed-width\<close> at \<^term>\<open>n\<close> when it is valid, every
+embedding has length \<^term>\<open>n\<close>, and every successful projection consumes exactly
+\<^term>\<open>n\<close> bytes.  The width lets a pair split a concatenation at the right
+boundary, and the projection-length fact is what makes the width \<^emph>\<open>compose\<close>.\<close>
+
+definition fixed_width_prism :: \<open>nat \<Rightarrow> (byte list, 'a) prism \<Rightarrow> bool\<close> where
+  \<open>fixed_width_prism n p \<longleftrightarrow> is_valid_prism p \<and> (\<forall>a. length (prism_embed p a) = n)
+      \<and> (\<forall>bs a. prism_project p bs = Some a \<longrightarrow> length bs = n)\<close>
+
+lemma fixed_width_prismI:
+  assumes \<open>is_valid_prism p\<close>
+      and \<open>\<And>a. length (prism_embed p a) = n\<close>
+      and \<open>\<And>bs a. prism_project p bs = Some a \<Longrightarrow> length bs = n\<close>
+    shows \<open>fixed_width_prism n p\<close>
+  using assms by (auto simp add: fixed_width_prism_def)
+
+lemma fixed_width_prism_valid:
+  assumes \<open>fixed_width_prism n p\<close>
+    shows \<open>is_valid_prism p\<close>
+  using assms by (simp add: fixed_width_prism_def)
+
+subsection\<open>Leaf fields: the fixed-width word prisms\<close>
+
+text\<open>The little-endian word byte-list prisms are fixed-width (2/4/8/16 bytes), so
+they serve as the leaf fields of a record.  These are the facts a record
+combinator looks up for each \<^verbatim>\<open>u16\<close>/\<^verbatim>\<open>u32\<close>/\<^verbatim>\<open>u64\<close>/\<^verbatim>\<open>u128\<close> field.\<close>
+
+lemma fixed_width_word16_le: \<open>fixed_width_prism 2 word16_byte_list_prism_le\<close>
+proof (rule fixed_width_prismI)
+  show \<open>is_valid_prism word16_byte_list_prism_le\<close>
+    by (rule word_byte_array_prism_validity)
+next
+  fix a show \<open>length (prism_embed word16_byte_list_prism_le a) = 2\<close>
+    by (simp add: word_byte_array_prism_defs word_byte_array_iso_prism_defs prism_compose_def
+        iso_prism_def list_fixlen_prism_def list_fixlen_embed_def)
+next
+  fix bs a assume \<open>prism_project word16_byte_list_prism_le bs = Some a\<close>
+  then show \<open>length bs = 2\<close>
+    by (auto simp add: word_byte_array_prism_defs prism_compose_def list_fixlen_prism_def
+        list_fixlen_project_def bind_eq_Some_conv split: if_splits)
+qed
+
+lemma fixed_width_word32_le: \<open>fixed_width_prism 4 word32_byte_list_prism_le\<close>
+proof (rule fixed_width_prismI)
+  show \<open>is_valid_prism word32_byte_list_prism_le\<close>
+    by (rule word_byte_array_prism_validity)
+next
+  fix a show \<open>length (prism_embed word32_byte_list_prism_le a) = 4\<close>
+    by (simp add: word_byte_array_prism_defs word_byte_array_iso_prism_defs prism_compose_def
+        iso_prism_def list_fixlen_prism_def list_fixlen_embed_def)
+next
+  fix bs a assume \<open>prism_project word32_byte_list_prism_le bs = Some a\<close>
+  then show \<open>length bs = 4\<close>
+    by (auto simp add: word_byte_array_prism_defs prism_compose_def list_fixlen_prism_def
+        list_fixlen_project_def bind_eq_Some_conv split: if_splits)
+qed
+
+lemma fixed_width_word64_le: \<open>fixed_width_prism 8 word64_byte_list_prism_le\<close>
+proof (rule fixed_width_prismI)
+  show \<open>is_valid_prism word64_byte_list_prism_le\<close>
+    by (rule word_byte_array_prism_validity)
+next
+  fix a show \<open>length (prism_embed word64_byte_list_prism_le a) = 8\<close>
+    by (simp add: word_byte_array_prism_defs word_byte_array_iso_prism_defs prism_compose_def
+        iso_prism_def list_fixlen_prism_def list_fixlen_embed_def)
+next
+  fix bs a assume \<open>prism_project word64_byte_list_prism_le bs = Some a\<close>
+  then show \<open>length bs = 8\<close>
+    by (auto simp add: word_byte_array_prism_defs prism_compose_def list_fixlen_prism_def
+        list_fixlen_project_def bind_eq_Some_conv split: if_splits)
+qed
+
+lemma fixed_width_word128_le: \<open>fixed_width_prism 16 word128_byte_list_prism_le\<close>
+proof (rule fixed_width_prismI)
+  show \<open>is_valid_prism word128_byte_list_prism_le\<close>
+    by (rule word128_byte_array_prism_validity)
+next
+  fix a show \<open>length (prism_embed word128_byte_list_prism_le a) = 16\<close>
+    by (simp add: word_byte_array_prism_defs word_byte_array_iso_prism_defs prism_compose_def
+        iso_prism_def list_fixlen_prism_def list_fixlen_embed_def)
+next
+  fix bs a assume \<open>prism_project word128_byte_list_prism_le bs = Some a\<close>
+  then show \<open>length bs = 16\<close>
+    by (auto simp add: word_byte_array_prism_defs prism_compose_def list_fixlen_prism_def
+        list_fixlen_project_def bind_eq_Some_conv split: if_splits)
+qed
+
+subsection\<open>Turning a fixed-width prism into a remaining-returning prism\<close>
+
+text\<open>A consume-all byte prism decodes an entire byte list into one value.  A
+parser instead peels off the bytes it needs and hands the rest back, so it can be
+chained.  \<^verbatim>\<open>split_prism n p\<close> is that bridge: for a fixed-width prism \<^term>\<open>p\<close> of
+width \<^term>\<open>n\<close>, it peels \<^term>\<open>n\<close> bytes, decodes them through \<^term>\<open>p\<close>, and
+pairs the result with the remaining bytes.  Its validity is take/drop reasoning
+only; no induction is involved.\<close>
+
+definition split_prism :: \<open>nat \<Rightarrow> (byte list, 'x) prism \<Rightarrow> (byte list, 'x \<times> byte list) prism\<close> where
+  \<open>split_prism n p \<equiv> make_prism
+     (\<lambda>(x, rest). prism_embed p x @ rest)
+     (\<lambda>bs. map_option (\<lambda>x. (x, drop n bs)) (prism_project p (take n bs)))\<close>
+
+lemma split_prism_valid:
+  assumes \<open>fixed_width_prism n p\<close>
+    shows \<open>is_valid_prism (split_prism n p)\<close>
+proof -
+  from assms have vp: \<open>is_valid_prism p\<close>
+    and wp: \<open>\<And>a. length (prism_embed p a) = n\<close>
+    by (auto simp add: fixed_width_prism_def)
+  have pe: \<open>prism_project p (prism_embed p x) = Some x\<close> for x
+    using vp by (simp add: prism_laws)
+  have pj: \<open>bs = prism_embed p x @ drop n bs\<close> if \<open>prism_project p (take n bs) = Some x\<close> for bs x
+  proof -
+    from that vp have \<open>take n bs = prism_embed p x\<close>
+      by (simp add: prism_laws)
+    then have \<open>prism_embed p x @ drop n bs = take n bs @ drop n bs\<close>
+      by simp
+    then show ?thesis
+      by (simp add: append_take_drop_id)
+  qed
+  show ?thesis
+    unfolding is_valid_prism_def split_prism_def
+    by (auto simp add: wp pe pj split: prod.splits)
+qed
+
+(*<*)
+end
+(*>*)

--- a/Byte_Level_Encoding/Byte_Encoding_Prisms.thy
+++ b/Byte_Level_Encoding/Byte_Encoding_Prisms.thy
@@ -141,6 +141,29 @@ proof -
     by (auto simp add: wp pe pj split: prod.splits)
 qed
 
+subsection\<open>The single-byte identity prism\<close>
+
+text\<open>A \<^verbatim>\<open>u8\<close> is a single byte carried unchanged.  \<^verbatim>\<open>byte_id_prism\<close> is the byte-list
+prism for one raw byte: embedding wraps it in a singleton list, projecting reads
+exactly one byte and fails otherwise.  It is the element prism of a pad field
+\<^verbatim>\<open>[u8; N]\<close> (an array of raw bytes), and is fixed-width \<^term>\<open>1\<close>.\<close>
+
+definition byte_id_prism :: \<open>(byte list, byte) prism\<close> where
+  \<open>byte_id_prism \<equiv> make_prism (\<lambda>b. [b]) (\<lambda>bs. case bs of [b] \<Rightarrow> Some b | _ \<Rightarrow> None)\<close>
+
+lemma fixed_width_byte_id: \<open>fixed_width_prism 1 byte_id_prism\<close>
+proof (rule fixed_width_prismI)
+  show \<open>is_valid_prism byte_id_prism\<close>
+    unfolding is_valid_prism_def byte_id_prism_def by (auto split: list.splits)
+next
+  fix a show \<open>length (prism_embed byte_id_prism a) = 1\<close>
+    by (simp add: byte_id_prism_def)
+next
+  fix bs a assume \<open>prism_project byte_id_prism bs = Some a\<close>
+  then show \<open>length bs = 1\<close>
+    by (auto simp add: byte_id_prism_def split: list.splits)
+qed
+
 (*<*)
 end
 (*>*)

--- a/Byte_Level_Encoding/Byte_Encoding_Record.thy
+++ b/Byte_Level_Encoding/Byte_Encoding_Record.thy
@@ -47,7 +47,7 @@ lemma fixed_width_prism_valid:
     shows \<open>is_valid_prism p\<close>
   using assms by (simp add: fixed_width_prism_def)
 
-subsection\<open>Leaf fields: the fixed-width word codecs\<close>
+subsection\<open>Leaf fields: the fixed-width word prisms\<close>
 
 text\<open>The little-endian word byte-list prisms are fixed-width (2/4/8/16 bytes), so
 they serve as the leaf fields of a record.  These are the facts a record
@@ -113,12 +113,12 @@ next
         list_fixlen_project_def bind_eq_Some_conv split: if_splits)
 qed
 
-subsection\<open>Leaf fields: single-byte codecs (\<^verbatim>\<open>bool\<close>, enums)\<close>
+subsection\<open>Leaf fields: single-byte prisms (\<^verbatim>\<open>bool\<close>, enums)\<close>
 
 text\<open>The boolean and enum encodings are single-\<^emph>\<open>byte\<close> prisms
 (\<^typ>\<open>(byte, 'a) prism\<close>), whereas a record field is a \<^emph>\<open>byte-list\<close> prism
 (\<^typ>\<open>(byte list, 'a) prism\<close>).  \<^verbatim>\<open>single_byte_prism\<close> lifts any single-byte
-codec to a one-element byte list, so a \<^verbatim>\<open>bool\<close> or enum can appear as a field.\<close>
+prism to a one-element byte list, so a \<^verbatim>\<open>bool\<close> or enum can appear as a field.\<close>
 
 definition single_byte_prism :: \<open>(byte, 'a) prism \<Rightarrow> (byte list, 'a) prism\<close> where
   \<open>single_byte_prism p \<equiv> make_prism
@@ -142,7 +142,7 @@ next
     by (auto simp add: single_byte_prism_def split: list.splits)
 qed
 
-text\<open>The boolean field codec, and its fixed width.\<close>
+text\<open>The boolean field prism, and its fixed width.\<close>
 
 definition bool_byte_list_prism :: \<open>(byte list, bool) prism\<close> where
   \<open>bool_byte_list_prism \<equiv> single_byte_prism bool_byte_prism\<close>
@@ -183,7 +183,7 @@ next
 qed
 
 text\<open>A word-array field \<^verbatim>\<open>[uW; N]\<close> is \<^const>\<open>array_byte_prism\<close> over a fixed-width
-element codec; the array is then fixed-width \<^verbatim>\<open>w * LENGTH('l)\<close>.\<close>
+element prism; the array is then fixed-width \<^verbatim>\<open>w * LENGTH('l)\<close>.\<close>
 
 lemma fixed_width_array:
   assumes \<open>fixed_width_prism w p\<close>
@@ -350,29 +350,29 @@ Given a name and a field assignment
 \<^verbatim>\<open>define_byte_record <T> = <f0>: <ty0> | <f1>: <ty1> | ...\<close>
 
 it defines the record type (via \<^verbatim>\<open>datatype_record\<close>), builds \<^verbatim>\<open><T>_byte_prism\<close>
-by nesting \<^const>\<open>prod_byte_prism\<close> over the per-field codecs and relabelling the
+by nesting \<^const>\<open>prod_byte_prism\<close> over the per-field prisms and relabelling the
 resulting tuple to the named record via \<^const>\<open>iso_prism\<close>, and proves the
-round-trip law \<^verbatim>\<open><T>_byte_prism_valid\<close> automatically.  This is the Isabelle
-analogue of the Verus \<^verbatim>\<open>define_payload!\<close> macro.  Currently supports word fields
-(\<^verbatim>\<open>u16\<close>/\<^verbatim>\<open>u32\<close>/\<^verbatim>\<open>u64\<close>/\<^verbatim>\<open>u128\<close>).\<close>
+round-trip law \<^verbatim>\<open><T>_byte_prism_valid\<close> automatically.  Field types may be
+\<^verbatim>\<open>u8\<close>/\<^verbatim>\<open>u16\<close>/\<^verbatim>\<open>u32\<close>/\<^verbatim>\<open>u64\<close>/\<^verbatim>\<open>u128\<close>, \<^verbatim>\<open>bool\<close>, a pad \<^verbatim>\<open>[u8; N]\<close>, a word array
+\<^verbatim>\<open>[uW; N]\<close>, an enum, or a nested record.\<close>
 
 ML_file \<open>byte_encoding_record_cmd.ML\<close>
 
-subsection\<open>Worked example\<close>
+subsection\<open>Worked examples\<close>
 
-text\<open>\<^verbatim>\<open>VsidToSidPayload\<close> is a two-field live-update record.  Defined in one line
-by the command, with the type, codec prism, and round-trip proof all generated.\<close>
+text\<open>A two-field record, defined in one line by the command, with the type, byte
+prism, and round-trip proof all generated.\<close>
 
-define_byte_record vsid_to_sid =
-    vts_vsid: u32 | vts_sid: u32
+define_byte_record pair_rec =
+    pair_x: u32 | pair_y: u32
 
 \<comment>\<open>The type, its fields, and the prism exist.\<close>
-term \<open>vts_vsid\<close> term \<open>vts_sid\<close>
-term \<open>vsid_to_sid_byte_prism :: (byte list, vsid_to_sid) prism\<close>
+term \<open>pair_x\<close> term \<open>pair_y\<close>
+term \<open>pair_rec_byte_prism :: (byte list, pair_rec) prism\<close>
 
 \<comment>\<open>The round-trip law was proven automatically.\<close>
-lemma \<open>is_valid_prism vsid_to_sid_byte_prism\<close>
-  by (rule vsid_to_sid_byte_prism_valid)
+lemma \<open>is_valid_prism pair_rec_byte_prism\<close>
+  by (rule pair_rec_byte_prism_valid)
 
 text\<open>A record mixing word and boolean fields.\<close>
 
@@ -392,43 +392,43 @@ lemma \<open>is_valid_prism padded_rec_byte_prism\<close>
   by (rule padded_rec_byte_prism_valid)
 
 text\<open>A record nested as a field of another record (naming convention: the field
-type \<^verbatim>\<open>vsid_to_sid\<close> resolves to \<^verbatim>\<open>vsid_to_sid_byte_prism\<close> and
-\<^verbatim>\<open>fixed_width_vsid_to_sid\<close>, both generated above).\<close>
+type \<^verbatim>\<open>pair_rec\<close> resolves to \<^verbatim>\<open>pair_rec_byte_prism\<close> and
+\<^verbatim>\<open>fixed_width_pair_rec\<close>, both generated above).\<close>
 
 define_byte_record outer_rec =
-    or_tag: u16 | or_inner: vsid_to_sid
+    or_tag: u16 | or_inner: pair_rec
 
 lemma \<open>is_valid_prism outer_rec_byte_prism\<close>
   by (rule outer_rec_byte_prism_valid)
 
 text\<open>A record with an enum field (naming convention: the field type
-\<^verbatim>\<open>serify_vcpu_action_type\<close> — defined by \<^verbatim>\<open>define_byte_enum\<close> — resolves to its
-single-byte prism, lifted to a one-byte list field).\<close>
+\<^verbatim>\<open>demo_enum\<close> — defined by \<^verbatim>\<open>define_byte_enum\<close> — resolves to its single-byte
+prism, lifted to a one-byte list field).\<close>
 
 define_byte_record action_rec =
-    ar_cpu: u16 | ar_action: serify_vcpu_action_type
+    ar_cpu: u16 | ar_action: demo_enum
 
 lemma \<open>is_valid_prism action_rec_byte_prism\<close>
   by (rule action_rec_byte_prism_valid)
 
 subsection\<open>Worked example: the command versus the same record by hand\<close>
 
-text\<open>This is the real live-update \<^verbatim>\<open>MmioRangePayload\<close>
-(\<^verbatim>\<open>{ start: u64, end: u64, prefetchable: bool, index: u8, pad0: [u8; 6] }\<close>),
-a 24-byte fixed-layout record mixing words, a boolean, a single byte, and a pad
-run.  It illustrates what the command saves: first the codec written \<^emph>\<open>by
-hand\<close> (record type, the nested field prism, and the round-trip proof), then the
-\<^emph>\<open>same\<close> record in one line via \<^verbatim>\<open>define_byte_record\<close>.\<close>
+text\<open>A 24-byte fixed-layout record
+\<^verbatim>\<open>{ a: u64, b: u64, c: bool, d: u8, pad: [u8; 6] }\<close> mixing words, a boolean, a
+single byte, and a pad run.  It illustrates what the command saves: first the
+prism written \<^emph>\<open>by hand\<close> (record type, the nested field prism, and the
+round-trip proof), then the \<^emph>\<open>same\<close> record in one line via
+\<^verbatim>\<open>define_byte_record\<close>.\<close>
 
-datatype_record mmio_range_manual =
-  mrm_start        :: \<open>64 word\<close>
-  mrm_end          :: \<open>64 word\<close>
-  mrm_prefetchable :: \<open>bool\<close>
-  mrm_index        :: \<open>byte\<close>
-  mrm_pad0         :: \<open>(byte, 6) array\<close>
+datatype_record demo_record_manual =
+  drm_a   :: \<open>64 word\<close>
+  drm_b   :: \<open>64 word\<close>
+  drm_c   :: \<open>bool\<close>
+  drm_d   :: \<open>byte\<close>
+  drm_pad :: \<open>(byte, 6) array\<close>
 
-definition mmio_range_manual_byte_prism :: \<open>(byte list, mmio_range_manual) prism\<close> where
-  \<open>mmio_range_manual_byte_prism \<equiv>
+definition demo_record_manual_byte_prism :: \<open>(byte list, demo_record_manual) prism\<close> where
+  \<open>demo_record_manual_byte_prism \<equiv>
      prism_compose
        (prod_byte_prism 8 word64_byte_list_prism_le
          (prod_byte_prism 8 word64_byte_list_prism_le
@@ -436,11 +436,11 @@ definition mmio_range_manual_byte_prism :: \<open>(byte list, mmio_range_manual)
              (prod_byte_prism 1 byte_byte_list_prism
                (list_fixlen_prism :: (byte list, (byte, 6) array) prism)))))
        (iso_prism
-          (\<lambda>(s, e, p, i, pad). make_mmio_range_manual s e p i pad)
-          (\<lambda>r. (mrm_start r, mrm_end r, mrm_prefetchable r, mrm_index r, mrm_pad0 r)))\<close>
+          (\<lambda>(a, b, c, d, pad). make_demo_record_manual a b c d pad)
+          (\<lambda>r. (drm_a r, drm_b r, drm_c r, drm_d r, drm_pad r)))\<close>
 
-lemma mmio_range_manual_byte_prism_valid: \<open>is_valid_prism mmio_range_manual_byte_prism\<close>
-  unfolding mmio_range_manual_byte_prism_def
+lemma demo_record_manual_byte_prism_valid: \<open>is_valid_prism demo_record_manual_byte_prism\<close>
+  unfolding demo_record_manual_byte_prism_def
   apply (rule prism_compose_valid)
    apply (rule prod_byte_prism_valid)
     apply (rule fixed_width_word64_le)
@@ -457,12 +457,12 @@ lemma mmio_range_manual_byte_prism_valid: \<open>is_valid_prism mmio_range_manua
 
 text\<open>The same record, in one line.\<close>
 
-define_byte_record mmio_range_auto =
-    mra_start: u64 | mra_end: u64 | mra_prefetchable: bool
-  | mra_index: u8 | mra_pad0: \<open>[u8; 6]\<close>
+define_byte_record demo_record_auto =
+    dra_a: u64 | dra_b: u64 | dra_c: bool
+  | dra_d: u8 | dra_pad: \<open>[u8; 6]\<close>
 
-lemma \<open>is_valid_prism mmio_range_auto_byte_prism\<close>
-  by (rule mmio_range_auto_byte_prism_valid)
+lemma \<open>is_valid_prism demo_record_auto_byte_prism\<close>
+  by (rule demo_record_auto_byte_prism_valid)
 
 
 (*<*)

--- a/Byte_Level_Encoding/Byte_Encoding_Record.thy
+++ b/Byte_Level_Encoding/Byte_Encoding_Record.thy
@@ -3,7 +3,7 @@
 
 (*<*)
 theory Byte_Encoding_Record
-  imports Byte_Encoding_Word_Nat Byte_Encoding_Bool Byte_Encoding_Array Byte_Encoding_Enum
+  imports Byte_Encoding_Prisms Byte_Encoding_Word_Nat Byte_Encoding_Bool Byte_Encoding_Array Byte_Encoding_Enum
     "HOL-Library.Datatype_Records"
   keywords "define_byte_record" :: thy_decl
 begin
@@ -23,95 +23,6 @@ The combinator needs to know where one field ends and the next begins, so the
 length \<^term>\<open>nA\<close>, which is the split point on decode.  (As with arrays, a plain
 \<^const>\<open>concat\<close> loses the field boundary, so the width information — carried by
 \<^verbatim>\<open>fixed_width_prism\<close> — is what makes the pair invertible.)\<close>
-
-subsection\<open>Fixed-width byte prisms\<close>
-
-text\<open>A byte-list prism is \<^emph>\<open>fixed-width\<close> at \<^term>\<open>n\<close> when it is valid, every
-embedding has length \<^term>\<open>n\<close>, and every successful projection consumes exactly
-\<^term>\<open>n\<close> bytes.  The width lets a pair split a concatenation at the right
-boundary, and the projection-length fact is what makes the width \<^emph>\<open>compose\<close>.\<close>
-
-definition fixed_width_prism :: \<open>nat \<Rightarrow> (byte list, 'a) prism \<Rightarrow> bool\<close> where
-  \<open>fixed_width_prism n p \<longleftrightarrow> is_valid_prism p \<and> (\<forall>a. length (prism_embed p a) = n)
-      \<and> (\<forall>bs a. prism_project p bs = Some a \<longrightarrow> length bs = n)\<close>
-
-lemma fixed_width_prismI:
-  assumes \<open>is_valid_prism p\<close>
-      and \<open>\<And>a. length (prism_embed p a) = n\<close>
-      and \<open>\<And>bs a. prism_project p bs = Some a \<Longrightarrow> length bs = n\<close>
-    shows \<open>fixed_width_prism n p\<close>
-  using assms by (auto simp add: fixed_width_prism_def)
-
-lemma fixed_width_prism_valid:
-  assumes \<open>fixed_width_prism n p\<close>
-    shows \<open>is_valid_prism p\<close>
-  using assms by (simp add: fixed_width_prism_def)
-
-subsection\<open>Leaf fields: the fixed-width word prisms\<close>
-
-text\<open>The little-endian word byte-list prisms are fixed-width (2/4/8/16 bytes), so
-they serve as the leaf fields of a record.  These are the facts a record
-combinator looks up for each \<^verbatim>\<open>u16\<close>/\<^verbatim>\<open>u32\<close>/\<^verbatim>\<open>u64\<close>/\<^verbatim>\<open>u128\<close> field.\<close>
-
-lemma fixed_width_word16_le: \<open>fixed_width_prism 2 word16_byte_list_prism_le\<close>
-proof (rule fixed_width_prismI)
-  show \<open>is_valid_prism word16_byte_list_prism_le\<close>
-    by (rule word_byte_array_prism_validity)
-next
-  fix a show \<open>length (prism_embed word16_byte_list_prism_le a) = 2\<close>
-    by (simp add: word_byte_array_prism_defs word_byte_array_iso_prism_defs prism_compose_def
-        iso_prism_def list_fixlen_prism_def list_fixlen_embed_def)
-next
-  fix bs a assume \<open>prism_project word16_byte_list_prism_le bs = Some a\<close>
-  then show \<open>length bs = 2\<close>
-    by (auto simp add: word_byte_array_prism_defs prism_compose_def list_fixlen_prism_def
-        list_fixlen_project_def bind_eq_Some_conv split: if_splits)
-qed
-
-lemma fixed_width_word32_le: \<open>fixed_width_prism 4 word32_byte_list_prism_le\<close>
-proof (rule fixed_width_prismI)
-  show \<open>is_valid_prism word32_byte_list_prism_le\<close>
-    by (rule word_byte_array_prism_validity)
-next
-  fix a show \<open>length (prism_embed word32_byte_list_prism_le a) = 4\<close>
-    by (simp add: word_byte_array_prism_defs word_byte_array_iso_prism_defs prism_compose_def
-        iso_prism_def list_fixlen_prism_def list_fixlen_embed_def)
-next
-  fix bs a assume \<open>prism_project word32_byte_list_prism_le bs = Some a\<close>
-  then show \<open>length bs = 4\<close>
-    by (auto simp add: word_byte_array_prism_defs prism_compose_def list_fixlen_prism_def
-        list_fixlen_project_def bind_eq_Some_conv split: if_splits)
-qed
-
-lemma fixed_width_word64_le: \<open>fixed_width_prism 8 word64_byte_list_prism_le\<close>
-proof (rule fixed_width_prismI)
-  show \<open>is_valid_prism word64_byte_list_prism_le\<close>
-    by (rule word_byte_array_prism_validity)
-next
-  fix a show \<open>length (prism_embed word64_byte_list_prism_le a) = 8\<close>
-    by (simp add: word_byte_array_prism_defs word_byte_array_iso_prism_defs prism_compose_def
-        iso_prism_def list_fixlen_prism_def list_fixlen_embed_def)
-next
-  fix bs a assume \<open>prism_project word64_byte_list_prism_le bs = Some a\<close>
-  then show \<open>length bs = 8\<close>
-    by (auto simp add: word_byte_array_prism_defs prism_compose_def list_fixlen_prism_def
-        list_fixlen_project_def bind_eq_Some_conv split: if_splits)
-qed
-
-lemma fixed_width_word128_le: \<open>fixed_width_prism 16 word128_byte_list_prism_le\<close>
-proof (rule fixed_width_prismI)
-  show \<open>is_valid_prism word128_byte_list_prism_le\<close>
-    by (rule word128_byte_array_prism_validity)
-next
-  fix a show \<open>length (prism_embed word128_byte_list_prism_le a) = 16\<close>
-    by (simp add: word_byte_array_prism_defs word_byte_array_iso_prism_defs prism_compose_def
-        iso_prism_def list_fixlen_prism_def list_fixlen_embed_def)
-next
-  fix bs a assume \<open>prism_project word128_byte_list_prism_le bs = Some a\<close>
-  then show \<open>length bs = 16\<close>
-    by (auto simp add: word_byte_array_prism_defs prism_compose_def list_fixlen_prism_def
-        list_fixlen_project_def bind_eq_Some_conv split: if_splits)
-qed
 
 subsection\<open>Leaf fields: single-byte prisms (\<^verbatim>\<open>bool\<close>, enums)\<close>
 

--- a/Byte_Level_Encoding/Byte_Encoding_Record.thy
+++ b/Byte_Level_Encoding/Byte_Encoding_Record.thy
@@ -72,53 +72,6 @@ lemma fixed_width_u8: \<open>fixed_width_prism 1 byte_byte_list_prism\<close>
   unfolding byte_byte_list_prism_def
   by (rule fixed_width_single_byte[OF iso_prism_valid]) simp_all
 
-subsection\<open>Leaf fields: pad and word arrays\<close>
-
-text\<open>A pad field \<^verbatim>\<open>[u8; N]\<close> is exactly \<^const>\<open>list_fixlen_prism\<close> (a byte list to a
-length-\<^term>\<open>N\<close> byte array), of fixed width \<^verbatim>\<open>LENGTH('l)\<close>.\<close>
-
-lemma fixed_width_pad:
-  \<open>fixed_width_prism (LENGTH('l::len)) (list_fixlen_prism :: (byte list, (byte, 'l) array) prism)\<close>
-proof (rule fixed_width_prismI)
-  show \<open>is_valid_prism (list_fixlen_prism :: (byte list, (byte, 'l) array) prism)\<close>
-    by (rule list_fixlen_prism_valid)
-next
-  fix a show \<open>length (prism_embed (list_fixlen_prism :: (byte list, (byte, 'l) array) prism) a)
-                = LENGTH('l)\<close>
-    by (simp add: list_fixlen_prism_def list_fixlen_embed_def)
-next
-  fix bs and a :: \<open>(byte, 'l) array\<close>
-  assume \<open>prism_project (list_fixlen_prism :: (byte list, (byte, 'l) array) prism) bs = Some a\<close>
-  then show \<open>length bs = LENGTH('l)\<close>
-    by (auto simp add: list_fixlen_prism_def list_fixlen_project_def split: if_splits)
-qed
-
-text\<open>A word-array field \<^verbatim>\<open>[uW; N]\<close> is \<^const>\<open>array_byte_prism\<close> over a fixed-width
-element prism; the array is then fixed-width \<^verbatim>\<open>w * LENGTH('l)\<close>.\<close>
-
-lemma fixed_width_array:
-  assumes \<open>fixed_width_prism w p\<close>
-    shows \<open>fixed_width_prism (w * LENGTH('l::len))
-             (array_byte_prism w p :: (byte list, ('e, 'l) array) prism)\<close>
-proof (rule fixed_width_prismI)
-  from assms have vp: \<open>is_valid_prism p\<close>
-    and wp: \<open>\<And>e. length (prism_embed p e) = w\<close>
-    by (auto simp add: fixed_width_prism_def)
-  show \<open>is_valid_prism (array_byte_prism w p :: (byte list, ('e, 'l) array) prism)\<close>
-    using vp wp by (rule array_byte_prism_valid)
-next
-  from assms have wp: \<open>\<And>e. length (prism_embed p e) = w\<close>
-    by (simp add: fixed_width_prism_def)
-  fix a show \<open>length (prism_embed (array_byte_prism w p :: (byte list, ('e, 'l) array) prism) a)
-                = w * LENGTH('l)\<close>
-    using wp by (rule array_byte_prism_embed_len)
-next
-  fix bs and a :: \<open>('e, 'l) array\<close>
-  assume \<open>prism_project (array_byte_prism w p :: (byte list, ('e, 'l) array) prism) bs = Some a\<close>
-  then show \<open>length bs = w * LENGTH('l)\<close>
-    by (rule array_byte_prism_project_len)
-qed
-
 subsection\<open>The pair combinator\<close>
 
 text\<open>\<^verbatim>\<open>prod_byte_prism\<close> places \<^term>\<open>pA\<close>'s bytes (width \<^term>\<open>nA\<close>) before

--- a/Byte_Level_Encoding/Byte_Encoding_Record.thy
+++ b/Byte_Level_Encoding/Byte_Encoding_Record.thy
@@ -3,331 +3,92 @@
 
 (*<*)
 theory Byte_Encoding_Record
-  imports Byte_Encoding_Prisms Byte_Encoding_Word_Nat Byte_Encoding_Bool Byte_Encoding_Array Byte_Encoding_Enum
-    "HOL-Library.Datatype_Records"
+  imports Byte_Parser Byte_Encoding_Enum
   keywords "define_byte_record" :: thy_decl
 begin
 (*>*)
 
-section\<open>Byte encoding for fixed-layout records\<close>
+section\<open>Byte-parser serialization for fixed-layout records\<close>
 
-text\<open>A fixed-layout record lays its fields out contiguously: the byte encoding of
-\<^verbatim>\<open>{ f0, f1, ... }\<close> is the concatenation of each field's byte encoding.  This
-section provides the combinator \<^verbatim>\<open>prod_byte_prism\<close> that pairs two field
-byte-prisms, placing the first field's bytes (of fixed width \<^term>\<open>nA\<close>) before
-the second's.  Multi-field records are obtained by nesting the combinator and
-relabelling the resulting nested tuple to a named record via \<^const>\<open>iso_prism\<close>.
-
-The combinator needs to know where one field ends and the next begins, so the
-\<^emph>\<open>first\<close> field must be \<^emph>\<open>fixed-width\<close>: its embedding always has the same
-length \<^term>\<open>nA\<close>, which is the split point on decode.  (As with arrays, a plain
-\<^const>\<open>concat\<close> loses the field boundary, so the width information — carried by
-\<^verbatim>\<open>fixed_width_prism\<close> — is what makes the pair invertible.)\<close>
-
-subsection\<open>Leaf fields: single-byte prisms (\<^verbatim>\<open>bool\<close>, enums)\<close>
-
-text\<open>The boolean and enum encodings are single-\<^emph>\<open>byte\<close> prisms
-(\<^typ>\<open>(byte, 'a) prism\<close>), whereas a record field is a \<^emph>\<open>byte-list\<close> prism
-(\<^typ>\<open>(byte list, 'a) prism\<close>).  \<^verbatim>\<open>single_byte_prism\<close> lifts any single-byte
-prism to a one-element byte list, so a \<^verbatim>\<open>bool\<close> or enum can appear as a field.\<close>
-
-definition single_byte_prism :: \<open>(byte, 'a) prism \<Rightarrow> (byte list, 'a) prism\<close> where
-  \<open>single_byte_prism p \<equiv> make_prism
-     (\<lambda>a. [prism_embed p a])
-     (\<lambda>bs. case bs of [b] \<Rightarrow> prism_project p b | _ \<Rightarrow> None)\<close>
-
-lemma fixed_width_single_byte:
-  assumes \<open>is_valid_prism p\<close>
-    shows \<open>fixed_width_prism 1 (single_byte_prism p)\<close>
-proof (rule fixed_width_prismI)
-  show \<open>is_valid_prism (single_byte_prism p)\<close>
-    using assms
-    unfolding is_valid_prism_def single_byte_prism_def
-    by (auto split: list.splits)
-next
-  fix a show \<open>length (prism_embed (single_byte_prism p) a) = 1\<close>
-    by (simp add: single_byte_prism_def)
-next
-  fix bs a assume \<open>prism_project (single_byte_prism p) bs = Some a\<close>
-  then show \<open>length bs = 1\<close>
-    by (auto simp add: single_byte_prism_def split: list.splits)
-qed
-
-text\<open>The boolean field prism, and its fixed width.\<close>
-
-definition bool_byte_list_prism :: \<open>(byte list, bool) prism\<close> where
-  \<open>bool_byte_list_prism \<equiv> single_byte_prism bool_byte_prism\<close>
-
-lemma fixed_width_bool: \<open>fixed_width_prism 1 bool_byte_list_prism\<close>
-  unfolding bool_byte_list_prism_def
-  by (rule fixed_width_single_byte[OF bool_byte_prism_valid])
-
-text\<open>A \<^verbatim>\<open>u8\<close> field is a single byte: the identity prism on \<^typ>\<open>byte\<close>, lifted to
-a one-element byte list.\<close>
-
-definition byte_byte_list_prism :: \<open>(byte list, byte) prism\<close> where
-  \<open>byte_byte_list_prism \<equiv> single_byte_prism (iso_prism (\<lambda>b. b) (\<lambda>b. b))\<close>
-
-lemma fixed_width_u8: \<open>fixed_width_prism 1 byte_byte_list_prism\<close>
-  unfolding byte_byte_list_prism_def
-  by (rule fixed_width_single_byte[OF iso_prism_valid]) simp_all
-
-subsection\<open>The pair combinator\<close>
-
-text\<open>\<^verbatim>\<open>prod_byte_prism\<close> places \<^term>\<open>pA\<close>'s bytes (width \<^term>\<open>nA\<close>) before
-\<^term>\<open>pB\<close>'s.  Embedding concatenates; projecting splits at \<^term>\<open>nA\<close> and runs
-each side's projector.\<close>
-
-definition prod_byte_embed ::
-    \<open>(byte list, 'a) prism \<Rightarrow> (byte list, 'b) prism \<Rightarrow> 'a \<times> 'b \<Rightarrow> byte list\<close> where
-  \<open>prod_byte_embed pA pB \<equiv> \<lambda>(a, b). prism_embed pA a @ prism_embed pB b\<close>
-
-definition prod_byte_project ::
-    \<open>nat \<Rightarrow> (byte list, 'a) prism \<Rightarrow> (byte list, 'b) prism \<Rightarrow> byte list \<Rightarrow> ('a \<times> 'b) option\<close> where
-  \<open>prod_byte_project nA pA pB bs \<equiv>
-     Option.bind (prism_project pA (take nA bs)) (\<lambda>a.
-     Option.bind (prism_project pB (drop nA bs)) (\<lambda>b. Some (a, b)))\<close>
-
-definition prod_byte_prism ::
-    \<open>nat \<Rightarrow> (byte list, 'a) prism \<Rightarrow> (byte list, 'b) prism \<Rightarrow> (byte list, 'a \<times> 'b) prism\<close> where
-  \<open>prod_byte_prism nA pA pB \<equiv> make_prism (prod_byte_embed pA pB) (prod_byte_project nA pA pB)\<close>
-
-text\<open>Validity of the pair: the round-trip law for the composite follows from each
-field's law plus the fact that \<^term>\<open>pA\<close>'s embedding has the exact width
-\<^term>\<open>nA\<close> at which we split.\<close>
-
-lemma prod_byte_prism_valid:
-  assumes \<open>fixed_width_prism nA pA\<close>
-      and \<open>is_valid_prism pB\<close>
-    shows \<open>is_valid_prism (prod_byte_prism nA pA pB)\<close>
-proof -
-  from assms(1) have vA: \<open>is_valid_prism pA\<close>
-    and wA: \<open>\<And>a. length (prism_embed pA a) = nA\<close>
-    by (auto simp add: fixed_width_prism_def)
-  show ?thesis
-    unfolding is_valid_prism_def
-  proof (intro conjI allI impI)
-    fix ab :: \<open>'a \<times> 'b\<close>
-    obtain a b where ab: \<open>ab = (a, b)\<close>
-      by (cases ab)
-    have eA: \<open>prism_project pA (prism_embed pA a) = Some a\<close>
-      using vA by (simp add: prism_laws)
-    have eB: \<open>prism_project pB (prism_embed pB b) = Some b\<close>
-      using assms(2) by (simp add: prism_laws)
-    show \<open>prism_project (prod_byte_prism nA pA pB) (prism_embed (prod_byte_prism nA pA pB) ab) = Some ab\<close>
-      by (simp add: ab prod_byte_prism_def prod_byte_embed_def prod_byte_project_def wA eA eB)
-  next
-    fix bs ab
-    assume \<open>prism_project (prod_byte_prism nA pA pB) bs = Some ab\<close>
-    then obtain a b where pa: \<open>prism_project pA (take nA bs) = Some a\<close>
-                      and pb: \<open>prism_project pB (drop nA bs) = Some b\<close>
-                      and ab: \<open>ab = (a, b)\<close>
-      by (auto simp add: prod_byte_prism_def prod_byte_project_def bind_eq_Some_conv)
-    from pa vA have ta: \<open>take nA bs = prism_embed pA a\<close>
-      by (simp add: prism_laws)
-    from pb assms(2) have da: \<open>drop nA bs = prism_embed pB b\<close>
-      by (simp add: prism_laws)
-    have \<open>bs = take nA bs @ drop nA bs\<close>
-      by simp
-    then show \<open>bs = prism_embed (prod_byte_prism nA pA pB) ab\<close>
-      by (simp add: ab prod_byte_prism_def prod_byte_embed_def ta da)
-  qed
-qed
-
-text\<open>The pair is itself fixed-width (\<^term>\<open>nA + nB\<close>).  This closure lets fields
-chain — the result becomes the \<^term>\<open>pA\<close> of the next pair — and lets a whole
-record nest as a field of another.\<close>
-
-lemma prod_byte_prism_fixed_width:
-  assumes \<open>fixed_width_prism nA pA\<close>
-      and \<open>fixed_width_prism nB pB\<close>
-    shows \<open>fixed_width_prism (nA + nB) (prod_byte_prism nA pA pB)\<close>
-proof -
-  from assms have vB: \<open>is_valid_prism pB\<close>
-    and wA: \<open>\<And>a. length (prism_embed pA a) = nA\<close>
-    and wB: \<open>\<And>b. length (prism_embed pB b) = nB\<close>
-    and lA: \<open>\<And>bs a. prism_project pA bs = Some a \<Longrightarrow> length bs = nA\<close>
-    and lB: \<open>\<And>bs b. prism_project pB bs = Some b \<Longrightarrow> length bs = nB\<close>
-    by (auto simp add: fixed_width_prism_def)
-  have valid: \<open>is_valid_prism (prod_byte_prism nA pA pB)\<close>
-    using assms(1) vB by (rule prod_byte_prism_valid)
-  moreover have \<open>length (prism_embed (prod_byte_prism nA pA pB) ab) = nA + nB\<close> for ab
-    by (cases ab) (simp add: prod_byte_prism_def prod_byte_embed_def wA wB)
-  moreover have \<open>length bs = nA + nB\<close>
-    if \<open>prism_project (prod_byte_prism nA pA pB) bs = Some ab\<close> for bs ab
-  proof -
-    from that obtain a b where pa: \<open>prism_project pA (take nA bs) = Some a\<close>
-                           and pb: \<open>prism_project pB (drop nA bs) = Some b\<close>
-      by (auto simp add: prod_byte_prism_def prod_byte_project_def bind_eq_Some_conv)
-    from pa lA have \<open>length (take nA bs) = nA\<close>
-      by blast
-    moreover from pb lB have \<open>length (drop nA bs) = nB\<close>
-      by blast
-    ultimately show ?thesis
-      by simp
-  qed
-  ultimately show ?thesis
-    by (simp add: fixed_width_prism_def)
-qed
-
-subsection\<open>Relabelling a nested tuple as a named record\<close>
-
-text\<open>Wrapping the raw pair (a nested tuple) in a record type is a pure
-\<^const>\<open>iso_prism\<close>: it relabels the value without touching the bytes, so it
-preserves both validity and the fixed width.  This is what turns a chain of
-fields into a payload of a named \<^verbatim>\<open>datatype_record\<close>.\<close>
-
-lemma fixed_width_compose_iso:
-  assumes \<open>fixed_width_prism n pA\<close>
-      and \<open>\<And>x. f (g x) = x\<close>
-      and \<open>\<And>y. g (f y) = y\<close>
-    shows \<open>fixed_width_prism n (prism_compose pA (iso_prism f g))\<close>
-proof -
-  from assms(1) have vA: \<open>is_valid_prism pA\<close>
-    and wA: \<open>\<And>a. length (prism_embed pA a) = n\<close>
-    and lA: \<open>\<And>bs a. prism_project pA bs = Some a \<Longrightarrow> length bs = n\<close>
-    by (auto simp add: fixed_width_prism_def)
-  have viso: \<open>is_valid_prism (iso_prism f g)\<close>
-    using assms(2,3) by (rule iso_prism_valid)
-  show ?thesis
-    unfolding fixed_width_prism_def
-  proof (intro conjI allI impI)
-    show \<open>is_valid_prism (prism_compose pA (iso_prism f g))\<close>
-      using vA viso by (rule prism_compose_valid)
-  next
-    fix a
-    show \<open>length (prism_embed (prism_compose pA (iso_prism f g)) a) = n\<close>
-      by (simp add: prism_compose_def iso_prism_def wA)
-  next
-    fix bs a
-    assume \<open>prism_project (prism_compose pA (iso_prism f g)) bs = Some a\<close>
-    then show \<open>length bs = n\<close>
-      using lA by (auto simp add: prism_compose_def iso_prism_def bind_eq_Some_conv)
-  qed
-qed
+text\<open>A fixed-layout record lays its fields out contiguously: its byte encoding is
+the concatenation of the field encodings, in order.  The \<^verbatim>\<open>define_byte_record\<close>
+command automates the whole record: from a one-line field declaration it defines
+the record type, builds a byte parser by sequencing the per-field parsers with
+\<open>--\<^sub>\<integral>\<close> and relabelling the resulting nested tuple to the record via
+\<^const>\<open>iso_focus\<close>, and derives the round-trip law.  Because a parser is a
+validity-carrying focus, that round-trip law is obtained for free rather than
+proved field by field.\<close>
 
 subsection\<open>The \<^verbatim>\<open>define_byte_record\<close> command\<close>
 
-text\<open>The \<^verbatim>\<open>define_byte_record\<close> command automates the per-record boilerplate.
-Given a name and a field assignment
+text\<open>Given a name and a field assignment
 
 \<^verbatim>\<open>define_byte_record <T> = <f0>: <ty0> | <f1>: <ty1> | ...\<close>
 
-it defines the record type (via \<^verbatim>\<open>datatype_record\<close>), builds \<^verbatim>\<open><T>_byte_prism\<close>
-by nesting \<^const>\<open>prod_byte_prism\<close> over the per-field prisms and relabelling the
-resulting tuple to the named record via \<^const>\<open>iso_prism\<close>, and proves the
-round-trip law \<^verbatim>\<open><T>_byte_prism_valid\<close> automatically.  Field types may be
+it defines the record type (via \<^verbatim>\<open>datatype_record\<close>), the record parser
+\<^verbatim>\<open><T>_parser\<close>, the closed focus \<^verbatim>\<open><T>_focus\<close> = \<^const>\<open>run_parser_all\<close> of the
+parser, and its round-trip law \<^verbatim>\<open><T>_focus_valid\<close>.  Field types may be
 \<^verbatim>\<open>u8\<close>/\<^verbatim>\<open>u16\<close>/\<^verbatim>\<open>u32\<close>/\<^verbatim>\<open>u64\<close>/\<^verbatim>\<open>u128\<close>, \<^verbatim>\<open>bool\<close>, a pad \<^verbatim>\<open>[u8; N]\<close>, a word array
-\<^verbatim>\<open>[uW; N]\<close>, an enum, or a nested record.\<close>
+\<^verbatim>\<open>[uW; N]\<close>, an enum (from \<^verbatim>\<open>define_byte_enum\<close>), or a nested record (from a prior
+\<^verbatim>\<open>define_byte_record\<close>).  A nested record reuses its \<^verbatim>\<open><T>_parser\<close>, so records
+compose.\<close>
 
 ML_file \<open>byte_encoding_record_cmd.ML\<close>
 
-subsection\<open>Worked examples\<close>
+subsection\<open>Worked example\<close>
 
-text\<open>A two-field record, defined in one line by the command, with the type, byte
-prism, and round-trip proof all generated.\<close>
+context includes code_parser_notation begin
+
+text\<open>A small record, to be used as a nested field below.\<close>
 
 define_byte_record pair_rec =
     pair_x: u32 | pair_y: u32
 
-\<comment>\<open>The type, its fields, and the prism exist.\<close>
-term \<open>pair_x\<close> term \<open>pair_y\<close>
-term \<open>pair_rec_byte_prism :: (byte list, pair_rec) prism\<close>
+text\<open>A single record exercising every field kind at once: word fields, an enum
+(\<^verbatim>\<open>demo_enum\<close>, from \<^verbatim>\<open>define_byte_enum\<close>), a boolean, a \<^verbatim>\<open>u8\<close>, a pad \<^verbatim>\<open>[u8; N]\<close>, a
+nested record (\<^verbatim>\<open>pair_rec\<close>, reusing its parser), and a word array \<^verbatim>\<open>[uW; N]\<close>.
+The command generates the type, the parser, the closed focus, and the round-trip
+law; array/pad field types are written in a cartouche.\<close>
 
-\<comment>\<open>The round-trip law was proven automatically.\<close>
-lemma \<open>is_valid_prism pair_rec_byte_prism\<close>
-  by (rule pair_rec_byte_prism_valid)
+define_byte_record demo_record =
+    dr_tag: u16 | dr_kind: demo_enum | dr_flag: bool | dr_id: u8
+  | dr_pad: \<open>[u8; 3]\<close> | dr_inner: pair_rec | dr_vec: \<open>[u64; 2]\<close>
 
-text\<open>A record mixing word and boolean fields.\<close>
+text\<open>The round-trip law was generated automatically.\<close>
 
-define_byte_record mixed_rec =
-    mr_count: u16 | mr_flag: bool | mr_addr: u64
+lemma \<open>is_valid_focus (Rep_focus demo_record_focus)\<close>
+  by (rule demo_record_focus_valid)
 
-lemma \<open>is_valid_prism mixed_rec_byte_prism\<close>
-  by (rule mixed_rec_byte_prism_valid)
+text\<open>The generated parser is executable.  The 32 input bytes lay out as: \<^verbatim>\<open>dr_tag\<close>
+(2), \<^verbatim>\<open>dr_kind\<close> (1), \<^verbatim>\<open>dr_flag\<close> (1), \<^verbatim>\<open>dr_id\<close> (1), \<^verbatim>\<open>dr_pad\<close> (3), \<^verbatim>\<open>dr_inner\<close> (8),
+\<^verbatim>\<open>dr_vec\<close> (16).  We decode them, then re-encode with an identity update and recover
+the input.\<close>
 
-text\<open>A record with pad and word-array fields.  Array/pad field types are written
-in a cartouche.\<close>
+definition demo_record_bytes :: \<open>byte list\<close> where
+  \<open>demo_record_bytes \<equiv>
+     [0x34, 0x12, 0x01, 0x01, 0x2A, 0xAA, 0xBB, 0xCC,
+      0x01, 0x00, 0x00, 0x00, 0x02, 0x00, 0x00, 0x00,
+      0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08,
+      0x09, 0x0A, 0x0B, 0x0C, 0x0D, 0x0E, 0x0F, 0x10]\<close>
 
-define_byte_record padded_rec =
-    pr_id: u32 | pr_pad: \<open>[u8; 4]\<close> | pr_vec: \<open>[u64; 3]\<close>
+value[code] \<open>decode demo_record_parser demo_record_bytes\<close>
 
-lemma \<open>is_valid_prism padded_rec_byte_prism\<close>
-  by (rule padded_rec_byte_prism_valid)
+text\<open>Decoding yields exactly the expected record value.\<close>
 
-text\<open>A record nested as a field of another record (naming convention: the field
-type \<^verbatim>\<open>pair_rec\<close> resolves to \<^verbatim>\<open>pair_rec_byte_prism\<close> and
-\<^verbatim>\<open>fixed_width_pair_rec\<close>, both generated above).\<close>
+lemma \<open>decode demo_record_parser demo_record_bytes =
+         Some (make_demo_record
+                 0x1234 DE_Second True 0x2A
+                 (array_of_list [0xAA, 0xBB, 0xCC])
+                 (make_pair_rec 1 2)
+                 (array_of_list [0x0807060504030201, 0x100F0E0D0C0B0A09]))\<close>
+  by eval
 
-define_byte_record outer_rec =
-    or_tag: u16 | or_inner: pair_rec
+text\<open>Re-encoding with an identity update recovers the input bytes.\<close>
 
-lemma \<open>is_valid_prism outer_rec_byte_prism\<close>
-  by (rule outer_rec_byte_prism_valid)
+lemma \<open>encode demo_record_parser (\<lambda>x. x) demo_record_bytes = demo_record_bytes\<close>
+  by eval
 
-text\<open>A record with an enum field (naming convention: the field type
-\<^verbatim>\<open>demo_enum\<close> — defined by \<^verbatim>\<open>define_byte_enum\<close> — resolves to its single-byte
-prism, lifted to a one-byte list field).\<close>
-
-define_byte_record action_rec =
-    ar_cpu: u16 | ar_action: demo_enum
-
-lemma \<open>is_valid_prism action_rec_byte_prism\<close>
-  by (rule action_rec_byte_prism_valid)
-
-subsection\<open>Worked example: the command versus the same record by hand\<close>
-
-text\<open>A 24-byte fixed-layout record
-\<^verbatim>\<open>{ a: u64, b: u64, c: bool, d: u8, pad: [u8; 6] }\<close> mixing words, a boolean, a
-single byte, and a pad run.  It illustrates what the command saves: first the
-prism written \<^emph>\<open>by hand\<close> (record type, the nested field prism, and the
-round-trip proof), then the \<^emph>\<open>same\<close> record in one line via
-\<^verbatim>\<open>define_byte_record\<close>.\<close>
-
-datatype_record demo_record_manual =
-  drm_a   :: \<open>64 word\<close>
-  drm_b   :: \<open>64 word\<close>
-  drm_c   :: \<open>bool\<close>
-  drm_d   :: \<open>byte\<close>
-  drm_pad :: \<open>(byte, 6) array\<close>
-
-definition demo_record_manual_byte_prism :: \<open>(byte list, demo_record_manual) prism\<close> where
-  \<open>demo_record_manual_byte_prism \<equiv>
-     prism_compose
-       (prod_byte_prism 8 word64_byte_list_prism_le
-         (prod_byte_prism 8 word64_byte_list_prism_le
-           (prod_byte_prism 1 bool_byte_list_prism
-             (prod_byte_prism 1 byte_byte_list_prism
-               (list_fixlen_prism :: (byte list, (byte, 6) array) prism)))))
-       (iso_prism
-          (\<lambda>(a, b, c, d, pad). make_demo_record_manual a b c d pad)
-          (\<lambda>r. (drm_a r, drm_b r, drm_c r, drm_d r, drm_pad r)))\<close>
-
-lemma demo_record_manual_byte_prism_valid: \<open>is_valid_prism demo_record_manual_byte_prism\<close>
-  unfolding demo_record_manual_byte_prism_def
-  apply (rule prism_compose_valid)
-   apply (rule prod_byte_prism_valid)
-    apply (rule fixed_width_word64_le)
-   apply (rule prod_byte_prism_valid)
-    apply (rule fixed_width_word64_le)
-   apply (rule prod_byte_prism_valid)
-    apply (rule fixed_width_bool)
-   apply (rule prod_byte_prism_valid)
-    apply (rule fixed_width_u8)
-   apply (rule fixed_width_prism_valid[OF fixed_width_pad])
-  apply (rule iso_prism_valid)
-   apply (simp_all split: prod.split)
-  done
-
-text\<open>The same record, in one line.\<close>
-
-define_byte_record demo_record_auto =
-    dra_a: u64 | dra_b: u64 | dra_c: bool
-  | dra_d: u8 | dra_pad: \<open>[u8; 6]\<close>
-
-lemma \<open>is_valid_prism demo_record_auto_byte_prism\<close>
-  by (rule demo_record_auto_byte_prism_valid)
-
+end
 
 (*<*)
 end

--- a/Byte_Level_Encoding/Byte_Encoding_Record.thy
+++ b/Byte_Level_Encoding/Byte_Encoding_Record.thy
@@ -1,0 +1,470 @@
+(* Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+   SPDX-License-Identifier: MIT *)
+
+(*<*)
+theory Byte_Encoding_Record
+  imports Byte_Encoding_Word_Nat Byte_Encoding_Bool Byte_Encoding_Array Byte_Encoding_Enum
+    "HOL-Library.Datatype_Records"
+  keywords "define_byte_record" :: thy_decl
+begin
+(*>*)
+
+section\<open>Byte encoding for fixed-layout records\<close>
+
+text\<open>A fixed-layout record lays its fields out contiguously: the byte encoding of
+\<^verbatim>\<open>{ f0, f1, ... }\<close> is the concatenation of each field's byte encoding.  This
+section provides the combinator \<^verbatim>\<open>prod_byte_prism\<close> that pairs two field
+byte-prisms, placing the first field's bytes (of fixed width \<^term>\<open>nA\<close>) before
+the second's.  Multi-field records are obtained by nesting the combinator and
+relabelling the resulting nested tuple to a named record via \<^const>\<open>iso_prism\<close>.
+
+The combinator needs to know where one field ends and the next begins, so the
+\<^emph>\<open>first\<close> field must be \<^emph>\<open>fixed-width\<close>: its embedding always has the same
+length \<^term>\<open>nA\<close>, which is the split point on decode.  (As with arrays, a plain
+\<^const>\<open>concat\<close> loses the field boundary, so the width information — carried by
+\<^verbatim>\<open>fixed_width_prism\<close> — is what makes the pair invertible.)\<close>
+
+subsection\<open>Fixed-width byte prisms\<close>
+
+text\<open>A byte-list prism is \<^emph>\<open>fixed-width\<close> at \<^term>\<open>n\<close> when it is valid, every
+embedding has length \<^term>\<open>n\<close>, and every successful projection consumes exactly
+\<^term>\<open>n\<close> bytes.  The width lets a pair split a concatenation at the right
+boundary, and the projection-length fact is what makes the width \<^emph>\<open>compose\<close>.\<close>
+
+definition fixed_width_prism :: \<open>nat \<Rightarrow> (byte list, 'a) prism \<Rightarrow> bool\<close> where
+  \<open>fixed_width_prism n p \<longleftrightarrow> is_valid_prism p \<and> (\<forall>a. length (prism_embed p a) = n)
+      \<and> (\<forall>bs a. prism_project p bs = Some a \<longrightarrow> length bs = n)\<close>
+
+lemma fixed_width_prismI:
+  assumes \<open>is_valid_prism p\<close>
+      and \<open>\<And>a. length (prism_embed p a) = n\<close>
+      and \<open>\<And>bs a. prism_project p bs = Some a \<Longrightarrow> length bs = n\<close>
+    shows \<open>fixed_width_prism n p\<close>
+  using assms by (auto simp add: fixed_width_prism_def)
+
+lemma fixed_width_prism_valid:
+  assumes \<open>fixed_width_prism n p\<close>
+    shows \<open>is_valid_prism p\<close>
+  using assms by (simp add: fixed_width_prism_def)
+
+subsection\<open>Leaf fields: the fixed-width word codecs\<close>
+
+text\<open>The little-endian word byte-list prisms are fixed-width (2/4/8/16 bytes), so
+they serve as the leaf fields of a record.  These are the facts a record
+combinator looks up for each \<^verbatim>\<open>u16\<close>/\<^verbatim>\<open>u32\<close>/\<^verbatim>\<open>u64\<close>/\<^verbatim>\<open>u128\<close> field.\<close>
+
+lemma fixed_width_word16_le: \<open>fixed_width_prism 2 word16_byte_list_prism_le\<close>
+proof (rule fixed_width_prismI)
+  show \<open>is_valid_prism word16_byte_list_prism_le\<close>
+    by (rule word_byte_array_prism_validity)
+next
+  fix a show \<open>length (prism_embed word16_byte_list_prism_le a) = 2\<close>
+    by (simp add: word_byte_array_prism_defs word_byte_array_iso_prism_defs prism_compose_def
+        iso_prism_def list_fixlen_prism_def list_fixlen_embed_def)
+next
+  fix bs a assume \<open>prism_project word16_byte_list_prism_le bs = Some a\<close>
+  then show \<open>length bs = 2\<close>
+    by (auto simp add: word_byte_array_prism_defs prism_compose_def list_fixlen_prism_def
+        list_fixlen_project_def bind_eq_Some_conv split: if_splits)
+qed
+
+lemma fixed_width_word32_le: \<open>fixed_width_prism 4 word32_byte_list_prism_le\<close>
+proof (rule fixed_width_prismI)
+  show \<open>is_valid_prism word32_byte_list_prism_le\<close>
+    by (rule word_byte_array_prism_validity)
+next
+  fix a show \<open>length (prism_embed word32_byte_list_prism_le a) = 4\<close>
+    by (simp add: word_byte_array_prism_defs word_byte_array_iso_prism_defs prism_compose_def
+        iso_prism_def list_fixlen_prism_def list_fixlen_embed_def)
+next
+  fix bs a assume \<open>prism_project word32_byte_list_prism_le bs = Some a\<close>
+  then show \<open>length bs = 4\<close>
+    by (auto simp add: word_byte_array_prism_defs prism_compose_def list_fixlen_prism_def
+        list_fixlen_project_def bind_eq_Some_conv split: if_splits)
+qed
+
+lemma fixed_width_word64_le: \<open>fixed_width_prism 8 word64_byte_list_prism_le\<close>
+proof (rule fixed_width_prismI)
+  show \<open>is_valid_prism word64_byte_list_prism_le\<close>
+    by (rule word_byte_array_prism_validity)
+next
+  fix a show \<open>length (prism_embed word64_byte_list_prism_le a) = 8\<close>
+    by (simp add: word_byte_array_prism_defs word_byte_array_iso_prism_defs prism_compose_def
+        iso_prism_def list_fixlen_prism_def list_fixlen_embed_def)
+next
+  fix bs a assume \<open>prism_project word64_byte_list_prism_le bs = Some a\<close>
+  then show \<open>length bs = 8\<close>
+    by (auto simp add: word_byte_array_prism_defs prism_compose_def list_fixlen_prism_def
+        list_fixlen_project_def bind_eq_Some_conv split: if_splits)
+qed
+
+lemma fixed_width_word128_le: \<open>fixed_width_prism 16 word128_byte_list_prism_le\<close>
+proof (rule fixed_width_prismI)
+  show \<open>is_valid_prism word128_byte_list_prism_le\<close>
+    by (rule word128_byte_array_prism_validity)
+next
+  fix a show \<open>length (prism_embed word128_byte_list_prism_le a) = 16\<close>
+    by (simp add: word_byte_array_prism_defs word_byte_array_iso_prism_defs prism_compose_def
+        iso_prism_def list_fixlen_prism_def list_fixlen_embed_def)
+next
+  fix bs a assume \<open>prism_project word128_byte_list_prism_le bs = Some a\<close>
+  then show \<open>length bs = 16\<close>
+    by (auto simp add: word_byte_array_prism_defs prism_compose_def list_fixlen_prism_def
+        list_fixlen_project_def bind_eq_Some_conv split: if_splits)
+qed
+
+subsection\<open>Leaf fields: single-byte codecs (\<^verbatim>\<open>bool\<close>, enums)\<close>
+
+text\<open>The boolean and enum encodings are single-\<^emph>\<open>byte\<close> prisms
+(\<^typ>\<open>(byte, 'a) prism\<close>), whereas a record field is a \<^emph>\<open>byte-list\<close> prism
+(\<^typ>\<open>(byte list, 'a) prism\<close>).  \<^verbatim>\<open>single_byte_prism\<close> lifts any single-byte
+codec to a one-element byte list, so a \<^verbatim>\<open>bool\<close> or enum can appear as a field.\<close>
+
+definition single_byte_prism :: \<open>(byte, 'a) prism \<Rightarrow> (byte list, 'a) prism\<close> where
+  \<open>single_byte_prism p \<equiv> make_prism
+     (\<lambda>a. [prism_embed p a])
+     (\<lambda>bs. case bs of [b] \<Rightarrow> prism_project p b | _ \<Rightarrow> None)\<close>
+
+lemma fixed_width_single_byte:
+  assumes \<open>is_valid_prism p\<close>
+    shows \<open>fixed_width_prism 1 (single_byte_prism p)\<close>
+proof (rule fixed_width_prismI)
+  show \<open>is_valid_prism (single_byte_prism p)\<close>
+    using assms
+    unfolding is_valid_prism_def single_byte_prism_def
+    by (auto split: list.splits)
+next
+  fix a show \<open>length (prism_embed (single_byte_prism p) a) = 1\<close>
+    by (simp add: single_byte_prism_def)
+next
+  fix bs a assume \<open>prism_project (single_byte_prism p) bs = Some a\<close>
+  then show \<open>length bs = 1\<close>
+    by (auto simp add: single_byte_prism_def split: list.splits)
+qed
+
+text\<open>The boolean field codec, and its fixed width.\<close>
+
+definition bool_byte_list_prism :: \<open>(byte list, bool) prism\<close> where
+  \<open>bool_byte_list_prism \<equiv> single_byte_prism bool_byte_prism\<close>
+
+lemma fixed_width_bool: \<open>fixed_width_prism 1 bool_byte_list_prism\<close>
+  unfolding bool_byte_list_prism_def
+  by (rule fixed_width_single_byte[OF bool_byte_prism_valid])
+
+text\<open>A \<^verbatim>\<open>u8\<close> field is a single byte: the identity prism on \<^typ>\<open>byte\<close>, lifted to
+a one-element byte list.\<close>
+
+definition byte_byte_list_prism :: \<open>(byte list, byte) prism\<close> where
+  \<open>byte_byte_list_prism \<equiv> single_byte_prism (iso_prism (\<lambda>b. b) (\<lambda>b. b))\<close>
+
+lemma fixed_width_u8: \<open>fixed_width_prism 1 byte_byte_list_prism\<close>
+  unfolding byte_byte_list_prism_def
+  by (rule fixed_width_single_byte[OF iso_prism_valid]) simp_all
+
+subsection\<open>Leaf fields: pad and word arrays\<close>
+
+text\<open>A pad field \<^verbatim>\<open>[u8; N]\<close> is exactly \<^const>\<open>list_fixlen_prism\<close> (a byte list to a
+length-\<^term>\<open>N\<close> byte array), of fixed width \<^verbatim>\<open>LENGTH('l)\<close>.\<close>
+
+lemma fixed_width_pad:
+  \<open>fixed_width_prism (LENGTH('l::len)) (list_fixlen_prism :: (byte list, (byte, 'l) array) prism)\<close>
+proof (rule fixed_width_prismI)
+  show \<open>is_valid_prism (list_fixlen_prism :: (byte list, (byte, 'l) array) prism)\<close>
+    by (rule list_fixlen_prism_valid)
+next
+  fix a show \<open>length (prism_embed (list_fixlen_prism :: (byte list, (byte, 'l) array) prism) a)
+                = LENGTH('l)\<close>
+    by (simp add: list_fixlen_prism_def list_fixlen_embed_def)
+next
+  fix bs and a :: \<open>(byte, 'l) array\<close>
+  assume \<open>prism_project (list_fixlen_prism :: (byte list, (byte, 'l) array) prism) bs = Some a\<close>
+  then show \<open>length bs = LENGTH('l)\<close>
+    by (auto simp add: list_fixlen_prism_def list_fixlen_project_def split: if_splits)
+qed
+
+text\<open>A word-array field \<^verbatim>\<open>[uW; N]\<close> is \<^const>\<open>array_byte_prism\<close> over a fixed-width
+element codec; the array is then fixed-width \<^verbatim>\<open>w * LENGTH('l)\<close>.\<close>
+
+lemma fixed_width_array:
+  assumes \<open>fixed_width_prism w p\<close>
+    shows \<open>fixed_width_prism (w * LENGTH('l::len))
+             (array_byte_prism w p :: (byte list, ('e, 'l) array) prism)\<close>
+proof (rule fixed_width_prismI)
+  from assms have vp: \<open>is_valid_prism p\<close>
+    and wp: \<open>\<And>e. length (prism_embed p e) = w\<close>
+    by (auto simp add: fixed_width_prism_def)
+  show \<open>is_valid_prism (array_byte_prism w p :: (byte list, ('e, 'l) array) prism)\<close>
+    using vp wp by (rule array_byte_prism_valid)
+next
+  from assms have wp: \<open>\<And>e. length (prism_embed p e) = w\<close>
+    by (simp add: fixed_width_prism_def)
+  fix a show \<open>length (prism_embed (array_byte_prism w p :: (byte list, ('e, 'l) array) prism) a)
+                = w * LENGTH('l)\<close>
+    using wp by (rule array_byte_prism_embed_len)
+next
+  fix bs and a :: \<open>('e, 'l) array\<close>
+  assume \<open>prism_project (array_byte_prism w p :: (byte list, ('e, 'l) array) prism) bs = Some a\<close>
+  then show \<open>length bs = w * LENGTH('l)\<close>
+    by (rule array_byte_prism_project_len)
+qed
+
+subsection\<open>The pair combinator\<close>
+
+text\<open>\<^verbatim>\<open>prod_byte_prism\<close> places \<^term>\<open>pA\<close>'s bytes (width \<^term>\<open>nA\<close>) before
+\<^term>\<open>pB\<close>'s.  Embedding concatenates; projecting splits at \<^term>\<open>nA\<close> and runs
+each side's projector.\<close>
+
+definition prod_byte_embed ::
+    \<open>(byte list, 'a) prism \<Rightarrow> (byte list, 'b) prism \<Rightarrow> 'a \<times> 'b \<Rightarrow> byte list\<close> where
+  \<open>prod_byte_embed pA pB \<equiv> \<lambda>(a, b). prism_embed pA a @ prism_embed pB b\<close>
+
+definition prod_byte_project ::
+    \<open>nat \<Rightarrow> (byte list, 'a) prism \<Rightarrow> (byte list, 'b) prism \<Rightarrow> byte list \<Rightarrow> ('a \<times> 'b) option\<close> where
+  \<open>prod_byte_project nA pA pB bs \<equiv>
+     Option.bind (prism_project pA (take nA bs)) (\<lambda>a.
+     Option.bind (prism_project pB (drop nA bs)) (\<lambda>b. Some (a, b)))\<close>
+
+definition prod_byte_prism ::
+    \<open>nat \<Rightarrow> (byte list, 'a) prism \<Rightarrow> (byte list, 'b) prism \<Rightarrow> (byte list, 'a \<times> 'b) prism\<close> where
+  \<open>prod_byte_prism nA pA pB \<equiv> make_prism (prod_byte_embed pA pB) (prod_byte_project nA pA pB)\<close>
+
+text\<open>Validity of the pair: the round-trip law for the composite follows from each
+field's law plus the fact that \<^term>\<open>pA\<close>'s embedding has the exact width
+\<^term>\<open>nA\<close> at which we split.\<close>
+
+lemma prod_byte_prism_valid:
+  assumes \<open>fixed_width_prism nA pA\<close>
+      and \<open>is_valid_prism pB\<close>
+    shows \<open>is_valid_prism (prod_byte_prism nA pA pB)\<close>
+proof -
+  from assms(1) have vA: \<open>is_valid_prism pA\<close>
+    and wA: \<open>\<And>a. length (prism_embed pA a) = nA\<close>
+    by (auto simp add: fixed_width_prism_def)
+  show ?thesis
+    unfolding is_valid_prism_def
+  proof (intro conjI allI impI)
+    fix ab :: \<open>'a \<times> 'b\<close>
+    obtain a b where ab: \<open>ab = (a, b)\<close>
+      by (cases ab)
+    have eA: \<open>prism_project pA (prism_embed pA a) = Some a\<close>
+      using vA by (simp add: prism_laws)
+    have eB: \<open>prism_project pB (prism_embed pB b) = Some b\<close>
+      using assms(2) by (simp add: prism_laws)
+    show \<open>prism_project (prod_byte_prism nA pA pB) (prism_embed (prod_byte_prism nA pA pB) ab) = Some ab\<close>
+      by (simp add: ab prod_byte_prism_def prod_byte_embed_def prod_byte_project_def wA eA eB)
+  next
+    fix bs ab
+    assume \<open>prism_project (prod_byte_prism nA pA pB) bs = Some ab\<close>
+    then obtain a b where pa: \<open>prism_project pA (take nA bs) = Some a\<close>
+                      and pb: \<open>prism_project pB (drop nA bs) = Some b\<close>
+                      and ab: \<open>ab = (a, b)\<close>
+      by (auto simp add: prod_byte_prism_def prod_byte_project_def bind_eq_Some_conv)
+    from pa vA have ta: \<open>take nA bs = prism_embed pA a\<close>
+      by (simp add: prism_laws)
+    from pb assms(2) have da: \<open>drop nA bs = prism_embed pB b\<close>
+      by (simp add: prism_laws)
+    have \<open>bs = take nA bs @ drop nA bs\<close>
+      by simp
+    then show \<open>bs = prism_embed (prod_byte_prism nA pA pB) ab\<close>
+      by (simp add: ab prod_byte_prism_def prod_byte_embed_def ta da)
+  qed
+qed
+
+text\<open>The pair is itself fixed-width (\<^term>\<open>nA + nB\<close>).  This closure lets fields
+chain — the result becomes the \<^term>\<open>pA\<close> of the next pair — and lets a whole
+record nest as a field of another.\<close>
+
+lemma prod_byte_prism_fixed_width:
+  assumes \<open>fixed_width_prism nA pA\<close>
+      and \<open>fixed_width_prism nB pB\<close>
+    shows \<open>fixed_width_prism (nA + nB) (prod_byte_prism nA pA pB)\<close>
+proof -
+  from assms have vB: \<open>is_valid_prism pB\<close>
+    and wA: \<open>\<And>a. length (prism_embed pA a) = nA\<close>
+    and wB: \<open>\<And>b. length (prism_embed pB b) = nB\<close>
+    and lA: \<open>\<And>bs a. prism_project pA bs = Some a \<Longrightarrow> length bs = nA\<close>
+    and lB: \<open>\<And>bs b. prism_project pB bs = Some b \<Longrightarrow> length bs = nB\<close>
+    by (auto simp add: fixed_width_prism_def)
+  have valid: \<open>is_valid_prism (prod_byte_prism nA pA pB)\<close>
+    using assms(1) vB by (rule prod_byte_prism_valid)
+  moreover have \<open>length (prism_embed (prod_byte_prism nA pA pB) ab) = nA + nB\<close> for ab
+    by (cases ab) (simp add: prod_byte_prism_def prod_byte_embed_def wA wB)
+  moreover have \<open>length bs = nA + nB\<close>
+    if \<open>prism_project (prod_byte_prism nA pA pB) bs = Some ab\<close> for bs ab
+  proof -
+    from that obtain a b where pa: \<open>prism_project pA (take nA bs) = Some a\<close>
+                           and pb: \<open>prism_project pB (drop nA bs) = Some b\<close>
+      by (auto simp add: prod_byte_prism_def prod_byte_project_def bind_eq_Some_conv)
+    from pa lA have \<open>length (take nA bs) = nA\<close>
+      by blast
+    moreover from pb lB have \<open>length (drop nA bs) = nB\<close>
+      by blast
+    ultimately show ?thesis
+      by simp
+  qed
+  ultimately show ?thesis
+    by (simp add: fixed_width_prism_def)
+qed
+
+subsection\<open>Relabelling a nested tuple as a named record\<close>
+
+text\<open>Wrapping the raw pair (a nested tuple) in a record type is a pure
+\<^const>\<open>iso_prism\<close>: it relabels the value without touching the bytes, so it
+preserves both validity and the fixed width.  This is what turns a chain of
+fields into a payload of a named \<^verbatim>\<open>datatype_record\<close>.\<close>
+
+lemma fixed_width_compose_iso:
+  assumes \<open>fixed_width_prism n pA\<close>
+      and \<open>\<And>x. f (g x) = x\<close>
+      and \<open>\<And>y. g (f y) = y\<close>
+    shows \<open>fixed_width_prism n (prism_compose pA (iso_prism f g))\<close>
+proof -
+  from assms(1) have vA: \<open>is_valid_prism pA\<close>
+    and wA: \<open>\<And>a. length (prism_embed pA a) = n\<close>
+    and lA: \<open>\<And>bs a. prism_project pA bs = Some a \<Longrightarrow> length bs = n\<close>
+    by (auto simp add: fixed_width_prism_def)
+  have viso: \<open>is_valid_prism (iso_prism f g)\<close>
+    using assms(2,3) by (rule iso_prism_valid)
+  show ?thesis
+    unfolding fixed_width_prism_def
+  proof (intro conjI allI impI)
+    show \<open>is_valid_prism (prism_compose pA (iso_prism f g))\<close>
+      using vA viso by (rule prism_compose_valid)
+  next
+    fix a
+    show \<open>length (prism_embed (prism_compose pA (iso_prism f g)) a) = n\<close>
+      by (simp add: prism_compose_def iso_prism_def wA)
+  next
+    fix bs a
+    assume \<open>prism_project (prism_compose pA (iso_prism f g)) bs = Some a\<close>
+    then show \<open>length bs = n\<close>
+      using lA by (auto simp add: prism_compose_def iso_prism_def bind_eq_Some_conv)
+  qed
+qed
+
+subsection\<open>The \<^verbatim>\<open>define_byte_record\<close> command\<close>
+
+text\<open>The \<^verbatim>\<open>define_byte_record\<close> command automates the per-record boilerplate.
+Given a name and a field assignment
+
+\<^verbatim>\<open>define_byte_record <T> = <f0>: <ty0> | <f1>: <ty1> | ...\<close>
+
+it defines the record type (via \<^verbatim>\<open>datatype_record\<close>), builds \<^verbatim>\<open><T>_byte_prism\<close>
+by nesting \<^const>\<open>prod_byte_prism\<close> over the per-field codecs and relabelling the
+resulting tuple to the named record via \<^const>\<open>iso_prism\<close>, and proves the
+round-trip law \<^verbatim>\<open><T>_byte_prism_valid\<close> automatically.  This is the Isabelle
+analogue of the Verus \<^verbatim>\<open>define_payload!\<close> macro.  Currently supports word fields
+(\<^verbatim>\<open>u16\<close>/\<^verbatim>\<open>u32\<close>/\<^verbatim>\<open>u64\<close>/\<^verbatim>\<open>u128\<close>).\<close>
+
+ML_file \<open>byte_encoding_record_cmd.ML\<close>
+
+subsection\<open>Worked example\<close>
+
+text\<open>\<^verbatim>\<open>VsidToSidPayload\<close> is a two-field live-update record.  Defined in one line
+by the command, with the type, codec prism, and round-trip proof all generated.\<close>
+
+define_byte_record vsid_to_sid =
+    vts_vsid: u32 | vts_sid: u32
+
+\<comment>\<open>The type, its fields, and the prism exist.\<close>
+term \<open>vts_vsid\<close> term \<open>vts_sid\<close>
+term \<open>vsid_to_sid_byte_prism :: (byte list, vsid_to_sid) prism\<close>
+
+\<comment>\<open>The round-trip law was proven automatically.\<close>
+lemma \<open>is_valid_prism vsid_to_sid_byte_prism\<close>
+  by (rule vsid_to_sid_byte_prism_valid)
+
+text\<open>A record mixing word and boolean fields.\<close>
+
+define_byte_record mixed_rec =
+    mr_count: u16 | mr_flag: bool | mr_addr: u64
+
+lemma \<open>is_valid_prism mixed_rec_byte_prism\<close>
+  by (rule mixed_rec_byte_prism_valid)
+
+text\<open>A record with pad and word-array fields.  Array/pad field types are written
+in a cartouche.\<close>
+
+define_byte_record padded_rec =
+    pr_id: u32 | pr_pad: \<open>[u8; 4]\<close> | pr_vec: \<open>[u64; 3]\<close>
+
+lemma \<open>is_valid_prism padded_rec_byte_prism\<close>
+  by (rule padded_rec_byte_prism_valid)
+
+text\<open>A record nested as a field of another record (naming convention: the field
+type \<^verbatim>\<open>vsid_to_sid\<close> resolves to \<^verbatim>\<open>vsid_to_sid_byte_prism\<close> and
+\<^verbatim>\<open>fixed_width_vsid_to_sid\<close>, both generated above).\<close>
+
+define_byte_record outer_rec =
+    or_tag: u16 | or_inner: vsid_to_sid
+
+lemma \<open>is_valid_prism outer_rec_byte_prism\<close>
+  by (rule outer_rec_byte_prism_valid)
+
+text\<open>A record with an enum field (naming convention: the field type
+\<^verbatim>\<open>serify_vcpu_action_type\<close> — defined by \<^verbatim>\<open>define_byte_enum\<close> — resolves to its
+single-byte prism, lifted to a one-byte list field).\<close>
+
+define_byte_record action_rec =
+    ar_cpu: u16 | ar_action: serify_vcpu_action_type
+
+lemma \<open>is_valid_prism action_rec_byte_prism\<close>
+  by (rule action_rec_byte_prism_valid)
+
+subsection\<open>Worked example: the command versus the same record by hand\<close>
+
+text\<open>This is the real live-update \<^verbatim>\<open>MmioRangePayload\<close>
+(\<^verbatim>\<open>{ start: u64, end: u64, prefetchable: bool, index: u8, pad0: [u8; 6] }\<close>),
+a 24-byte fixed-layout record mixing words, a boolean, a single byte, and a pad
+run.  It illustrates what the command saves: first the codec written \<^emph>\<open>by
+hand\<close> (record type, the nested field prism, and the round-trip proof), then the
+\<^emph>\<open>same\<close> record in one line via \<^verbatim>\<open>define_byte_record\<close>.\<close>
+
+datatype_record mmio_range_manual =
+  mrm_start        :: \<open>64 word\<close>
+  mrm_end          :: \<open>64 word\<close>
+  mrm_prefetchable :: \<open>bool\<close>
+  mrm_index        :: \<open>byte\<close>
+  mrm_pad0         :: \<open>(byte, 6) array\<close>
+
+definition mmio_range_manual_byte_prism :: \<open>(byte list, mmio_range_manual) prism\<close> where
+  \<open>mmio_range_manual_byte_prism \<equiv>
+     prism_compose
+       (prod_byte_prism 8 word64_byte_list_prism_le
+         (prod_byte_prism 8 word64_byte_list_prism_le
+           (prod_byte_prism 1 bool_byte_list_prism
+             (prod_byte_prism 1 byte_byte_list_prism
+               (list_fixlen_prism :: (byte list, (byte, 6) array) prism)))))
+       (iso_prism
+          (\<lambda>(s, e, p, i, pad). make_mmio_range_manual s e p i pad)
+          (\<lambda>r. (mrm_start r, mrm_end r, mrm_prefetchable r, mrm_index r, mrm_pad0 r)))\<close>
+
+lemma mmio_range_manual_byte_prism_valid: \<open>is_valid_prism mmio_range_manual_byte_prism\<close>
+  unfolding mmio_range_manual_byte_prism_def
+  apply (rule prism_compose_valid)
+   apply (rule prod_byte_prism_valid)
+    apply (rule fixed_width_word64_le)
+   apply (rule prod_byte_prism_valid)
+    apply (rule fixed_width_word64_le)
+   apply (rule prod_byte_prism_valid)
+    apply (rule fixed_width_bool)
+   apply (rule prod_byte_prism_valid)
+    apply (rule fixed_width_u8)
+   apply (rule fixed_width_prism_valid[OF fixed_width_pad])
+  apply (rule iso_prism_valid)
+   apply (simp_all split: prod.split)
+  done
+
+text\<open>The same record, in one line.\<close>
+
+define_byte_record mmio_range_auto =
+    mra_start: u64 | mra_end: u64 | mra_prefetchable: bool
+  | mra_index: u8 | mra_pad0: \<open>[u8; 6]\<close>
+
+lemma \<open>is_valid_prism mmio_range_auto_byte_prism\<close>
+  by (rule mmio_range_auto_byte_prism_valid)
+
+
+(*<*)
+end
+(*>*)

--- a/Byte_Level_Encoding/Byte_Level_Encoding.thy
+++ b/Byte_Level_Encoding/Byte_Level_Encoding.thy
@@ -5,6 +5,10 @@
 theory Byte_Level_Encoding
   imports
     Byte_Encoding_Word_Nat
+    Byte_Encoding_Bool
+    Byte_Encoding_Array
+    Byte_Encoding_Enum
+    Byte_Encoding_Record
     Byte_Parser
     Focus_Parser
     Niche_Encoding_Option_NonNull

--- a/Byte_Level_Encoding/Byte_Parser.thy
+++ b/Byte_Level_Encoding/Byte_Parser.thy
@@ -3,8 +3,8 @@
 
 (*<*)
 theory Byte_Parser
-  imports Lenses_And_Other_Optics.Lenses_And_Other_Optics Byte_Encoding_Word_Nat Focus_Parser
-    "Word_Lib.Hex_Words" "HOL-Library.Datatype_Records"
+  imports Lenses_And_Other_Optics.Lenses_And_Other_Optics Byte_Encoding_Word_Nat Byte_Encoding_Bool
+    Focus_Parser "Word_Lib.Hex_Words" "HOL-Library.Datatype_Records"
 begin
 (*>*)
 
@@ -19,9 +19,11 @@ begin
 text\<open>Read a word\<close>
 
 definition \<open>parse_byte \<equiv> parse_single :: byte byte_parser\<close>
+definition \<open>parse_bool \<equiv> parse_byte >>\<^sub>\<integral> bool_byte_focus\<close>
 definition \<open>parse_word16 \<equiv> parse_array2 >>\<^sub>\<integral> word16_byte_array_focus_le\<close>
 definition \<open>parse_word32 \<equiv> parse_array4 >>\<^sub>\<integral> word32_byte_array_focus_le\<close>
 definition \<open>parse_word64 \<equiv> parse_array8 >>\<^sub>\<integral> word64_byte_array_focus_le\<close>
+definition \<open>parse_word128 \<equiv> parse_array16 >>\<^sub>\<integral> word128_byte_array_focus_le\<close>
 
 end 
 

--- a/Byte_Level_Encoding/Byte_Parser.thy
+++ b/Byte_Level_Encoding/Byte_Parser.thy
@@ -4,7 +4,7 @@
 (*<*)
 theory Byte_Parser
   imports Lenses_And_Other_Optics.Lenses_And_Other_Optics Byte_Encoding_Word_Nat Byte_Encoding_Bool
-    Focus_Parser "Word_Lib.Hex_Words" "HOL-Library.Datatype_Records"
+    Byte_Encoding_Array Focus_Parser "Word_Lib.Hex_Words" "HOL-Library.Datatype_Records"
 begin
 (*>*)
 
@@ -25,7 +25,37 @@ definition \<open>parse_word32 \<equiv> parse_array4 >>\<^sub>\<integral> word32
 definition \<open>parse_word64 \<equiv> parse_array8 >>\<^sub>\<integral> word64_byte_array_focus_le\<close>
 definition \<open>parse_word128 \<equiv> parse_array16 >>\<^sub>\<integral> word128_byte_array_focus_le\<close>
 
-end 
+end
+
+subsection\<open>Parsing a fixed-length word array\<close>
+
+text\<open>A word array \<^verbatim>\<open>[uW; N]\<close> parser, sibling to the word parsers above: for an
+element prism \<^term>\<open>p\<close> of fixed width \<^term>\<open>w\<close> it peels \<^term>\<open>w * N\<close> bytes off the
+front and decodes them into a length-\<^term>\<open>N\<close> array, handing the rest back.  A
+parser needs a proper (typedef) focus, which only \<^verbatim>\<open>lift_definition\<close> can build;
+\<^verbatim>\<open>lift_definition\<close> in turn requires the lifted raw focus to be valid for \<^emph>\<open>all\<close>
+\<^term>\<open>w\<close>/\<^term>\<open>p\<close>.  The array focus is valid only when the element prism is
+fixed-width, so we lift a \<^emph>\<open>guarded\<close> raw focus: the real focus when the element
+is fixed-width, and the always-valid \<^const>\<open>dummy_focus\<close> otherwise.  Real call
+sites always supply a fixed-width element prism, so the dummy branch is never
+taken; \<^verbatim>\<open>array_parser_valid\<close> records the round-trip law under that assumption.\<close>
+
+lift_definition array_focus ::
+    \<open>nat \<Rightarrow> (byte list, 'e) prism \<Rightarrow> (byte list, ('e, 'l::len) array \<times> byte list) focus\<close> is
+  \<open>\<lambda>w p. if fixed_width_prism w p
+         then prism_to_focus_raw (array_split_prism w p :: (byte list, ('e, 'l) array \<times> byte list) prism)
+         else dummy_focus\<close>
+  by (simp add: dummy_focus_is_valid prism_to_focus_raw_valid array_split_prism_valid)
+
+definition array_parser ::
+    \<open>nat \<Rightarrow> (byte list, 'e) prism \<Rightarrow> (byte list, ('e, 'l::len) array) focus_parser\<close> where
+  \<open>array_parser w p \<equiv> FocusParser (array_focus w p)\<close>
+
+lemma array_parser_valid:
+  assumes \<open>fixed_width_prism w p\<close>
+    shows \<open>is_valid_focus (Rep_focus
+             (array_focus w p :: (byte list, ('e, 'l::len) array \<times> byte list) focus))\<close>
+  using assms by (simp add: array_focus.rep_eq array_split_prism_valid prism_to_focus_raw_valid)
 
 subsection\<open>Examples\<close>
 

--- a/Byte_Level_Encoding/Byte_Parser.thy
+++ b/Byte_Level_Encoding/Byte_Parser.thy
@@ -57,6 +57,29 @@ lemma array_parser_valid:
              (array_focus w p :: (byte list, ('e, 'l::len) array \<times> byte list) focus))\<close>
   using assms by (simp add: array_focus.rep_eq array_split_prism_valid prism_to_focus_raw_valid)
 
+subsection\<open>Relabelling a parsed tuple as a named record\<close>
+
+text\<open>A record parser is the \<open>--\<^sub>\<integral>\<close> chain of its field parsers, which produces a
+nested tuple, followed by a relabelling of that tuple as the named record.  The
+relabelling is an isomorphism \<^term>\<open>f\<close> / \<^term>\<open>g\<close> (tuple to record and back).
+As a focus it needs \<^verbatim>\<open>lift_definition\<close> (a typedef focus), which requires validity
+for \<^emph>\<open>all\<close> \<^term>\<open>f\<close> / \<^term>\<open>g\<close>; the iso focus is valid only when the two are
+mutually inverse.  As with the array and enum foci, we lift a \<^emph>\<open>guarded\<close> raw
+focus: the real iso when \<^term>\<open>f\<close> / \<^term>\<open>g\<close> are inverse, and the always-valid
+\<^const>\<open>dummy_focus\<close> otherwise.  One generic definition then serves every record,
+so the record command needs only a plain definition per record, not a
+per-record \<^verbatim>\<open>lift_definition\<close>.\<close>
+
+lift_definition iso_focus :: \<open>('a \<Rightarrow> 'b) \<Rightarrow> ('b \<Rightarrow> 'a) \<Rightarrow> ('a, 'b) focus\<close> is
+  \<open>\<lambda>f g. if (\<forall>x. g (f x) = x) \<and> (\<forall>y. f (g y) = y) then iso\<^sub>\<integral> f g else dummy_focus\<close>
+  by (auto simp add: dummy_focus_is_valid iso_focus_raw_valid)
+
+lemma iso_focus_valid:
+  assumes \<open>\<And>x. g (f x) = x\<close>
+      and \<open>\<And>y. f (g y) = y\<close>
+    shows \<open>is_valid_focus (Rep_focus (iso_focus f g))\<close>
+  using assms by (simp add: iso_focus.rep_eq iso_focus_raw_valid)
+
 subsection\<open>Examples\<close>
 
 (*<*)

--- a/Byte_Level_Encoding/Focus_Parser.thy
+++ b/Byte_Level_Encoding/Focus_Parser.thy
@@ -87,6 +87,8 @@ abbreviation parse_array4 :: \<open>('a list, ('a, 4) array) focus_parser\<close
   \<open>parse_array4 \<equiv> parse_array\<close>
 abbreviation parse_array8 :: \<open>('a list, ('a, 8) array) focus_parser\<close> where
   \<open>parse_array8 \<equiv> parse_array\<close>
+abbreviation parse_array16 :: \<open>('a list, ('a, 16) array) focus_parser\<close> where
+  \<open>parse_array16 \<equiv> parse_array\<close>
 
 (*<*)
 end

--- a/Byte_Level_Encoding/ROOT
+++ b/Byte_Level_Encoding/ROOT
@@ -7,8 +7,13 @@ session Byte_Level_Encoding = HOL +
     "Word_Lib"
     Lenses_And_Other_Optics
     Misc
+    Enum_Theory
   theories
     Byte_Encoding_Word_Nat
+    Byte_Encoding_Bool
+    Byte_Encoding_Array
+    Byte_Encoding_Enum
+    Byte_Encoding_Record
     Byte_Parser
     Focus_Parser
     Niche_Encoding_Option_NonNull

--- a/Byte_Level_Encoding/ROOT
+++ b/Byte_Level_Encoding/ROOT
@@ -10,6 +10,7 @@ session Byte_Level_Encoding = HOL +
     Enum_Theory
   theories
     Byte_Encoding_Word_Nat
+    Byte_Encoding_Prisms
     Byte_Encoding_Bool
     Byte_Encoding_Array
     Byte_Encoding_Enum

--- a/Byte_Level_Encoding/byte_encoding_enum_cmd.ML
+++ b/Byte_Level_Encoding/byte_encoding_enum_cmd.ML
@@ -1,0 +1,114 @@
+(* Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+   SPDX-License-Identifier: MIT *)
+
+(* The `define_byte_enum` command.  Given a name and a list of (constructor,
+   discriminant byte) pairs, it
+     (1) defines the enumeration type via the existing `enum` command,
+     (2) generates the discriminant codec `<T>_to_byte` / `<T>_from_byte`,
+     (3) defines `<T>_byte_prism` as an instance of `enum_byte_prism`, and
+     (4) proves `<T>_byte_prism_valid` (the round-trip law) automatically.
+   This is the Isabelle analogue of the Verus `define_enum!` macro: the type
+   and its byte serialization, with the round-trip proof discharged
+   automatically. *)
+
+signature BYTE_ENCODING_ENUM_CMD =
+sig
+  val define_byte_enum: binding -> (binding * int) list -> local_theory -> local_theory
+end
+
+structure Byte_Encoding_Enum_Cmd : BYTE_ENCODING_ENUM_CMD =
+struct
+
+(* Define a constant `<bind>` with body given as a string, returning its
+   defining theorem and the updated context. *)
+fun define_from_string bind rhs_str lthy =
+  let
+    val rhs = Syntax.read_term lthy rhs_str
+    val ((_, (_, def_thm)), lthy') = lthy
+      |> Local_Theory.define ((bind, NoSyn), ((Binding.suffix_name "_def" bind, []), rhs))
+  in
+    (def_thm, lthy')
+  end
+
+fun define_byte_enum typ_binding (specs : (binding * int) list) lthy =
+  let
+    val _ = if null specs then error "define_byte_enum: empty enum not allowed" else ()
+    val typ_name = Binding.name_of typ_binding
+    val ctors = map fst specs
+    val ctor_names = map Binding.name_of ctors
+    val discrs = map snd specs
+
+    (* Step 1: define the enumeration type via the existing `enum` command,
+       inside a nested target so its declarations (case syntax, [simp] rules)
+       are committed before we build terms that refer to them. *)
+    val lthy1 = lthy
+      |> Local_Theory.begin_nested |> snd
+      |> Enum_Cmd.enum_cmd (typ_binding, map (fn c => (c, [])) ctors)
+      |> Local_Theory.end_nested
+
+    (* Step 2: <T>_to_byte e = (<T>.case d0 d1 ... dn e :: byte) *)
+    val to_byte_bind = Binding.suffix_name "_to_byte" typ_binding
+    val case_args = space_implode " " (map string_of_int discrs)
+    val to_byte_str =
+      "(\<lambda>e. " ^ typ_name ^ ".case " ^ case_args ^ " e) :: " ^ typ_name ^ " \<Rightarrow> byte"
+    val (to_byte_def, lthy2) = define_from_string to_byte_bind to_byte_str lthy1
+
+    (* Step 3: <T>_from_byte w = if w = d0 then Some C0 else ... else None *)
+    val from_byte_bind = Binding.suffix_name "_from_byte" typ_binding
+    val clauses =
+      map (fn (c, d) =>
+            "if w = " ^ string_of_int d ^ " then Some " ^ typ_name ^ "." ^ c ^ " else ")
+          (ctor_names ~~ discrs)
+    val from_byte_str =
+      "\<lambda>w::byte. " ^ implode clauses ^ "None"
+    val (from_byte_def, lthy3) = define_from_string from_byte_bind from_byte_str lthy2
+
+    (* Step 4: <T>_byte_prism = enum_byte_prism <T>_to_byte <T>_from_byte *)
+    val prism_bind = Binding.suffix_name "_byte_prism" typ_binding
+    val prism_str =
+      "enum_byte_prism " ^ Binding.name_of to_byte_bind ^ " " ^ Binding.name_of from_byte_bind
+    val (prism_def, lthy4) = define_from_string prism_bind prism_str lthy3
+
+    (* Step 5: prove <T>_byte_prism_valid automatically.
+
+       After `enum_byte_prism_valid` we face two goals:
+         (1)  from_byte (to_byte e) = Some e
+         (2)  from_byte w = Some e ==> to_byte e = w
+       Goal (1) is discharged by induction on `e` (the enum command provides
+       `<T>.induct`): each constructor reduces `to_byte` to its discriminant and
+       then `from_byte` decodes it back.  Goal (2) is a case split on the nested
+       `if` in `from_byte`. *)
+    val induct_thm = Proof_Context.get_thm lthy4 (typ_name ^ ".induct")
+    val case_simps = Proof_Context.get_thms lthy4 (typ_name ^ ".cases")
+    val valid_prop =
+      Syntax.read_prop lthy4 ("is_valid_prism " ^ Binding.name_of prism_bind)
+    val codec_simps = to_byte_def :: from_byte_def :: case_simps
+    val simp_ctxt =
+      fold Splitter.add_split @{thms if_split if_split_asm} (lthy4 addsimps codec_simps)
+
+    val valid_thm = Goal.prove lthy4 [] [] valid_prop
+      (fn {context = ctxt, ...} =>
+        Local_Defs.unfold_tac ctxt [prism_def]
+        THEN resolve_tac ctxt @{thms enum_byte_prism_valid} 1
+        (* Goal 1: induct on e, reducing each constructor case.  The same simp
+           (with the if-splits and the constructor reduction rules) also closes
+           the goal-2 cases. *)
+        THEN resolve_tac ctxt [induct_thm] 1
+        THEN ALLGOALS (asm_full_simp_tac simp_ctxt))
+    val valid_bind = Binding.suffix_name "_byte_prism_valid" typ_binding
+    val (_, lthy5) = lthy4
+      |> Local_Theory.note ((valid_bind, []), [valid_thm])
+  in
+    lthy5
+  end
+
+end
+
+(* Parser: `define_byte_enum <name> = <C0>: <d0> | <C1>: <d1> | ...` *)
+val _ =
+  Outer_Syntax.local_theory \<^command_keyword>\<open>define_byte_enum\<close>
+    "define an enumeration type together with its byte serialization"
+    (Parse.binding --
+      (Parse.$$$ "=" |--
+        Parse.enum1 "|" (Parse.binding --| Parse.$$$ ":" -- Parse.nat))
+      >> (fn (b, specs) => Byte_Encoding_Enum_Cmd.define_byte_enum b specs))

--- a/Byte_Level_Encoding/byte_encoding_enum_cmd.ML
+++ b/Byte_Level_Encoding/byte_encoding_enum_cmd.ML
@@ -81,9 +81,9 @@ fun define_byte_enum typ_binding (specs : (binding * int) list) lthy =
     val case_simps = Proof_Context.get_thms lthy4 (typ_name ^ ".cases")
     val valid_prop =
       Syntax.read_prop lthy4 ("is_valid_prism " ^ Binding.name_of prism_bind)
-    val codec_simps = to_byte_def :: from_byte_def :: case_simps
+    val encoding_simps = to_byte_def :: from_byte_def :: case_simps
     val simp_ctxt =
-      fold Splitter.add_split @{thms if_split if_split_asm} (lthy4 addsimps codec_simps)
+      fold Splitter.add_split @{thms if_split if_split_asm} (lthy4 addsimps encoding_simps)
 
     val valid_thm = Goal.prove lthy4 [] [] valid_prop
       (fn {context = ctxt, ...} =>
@@ -97,8 +97,56 @@ fun define_byte_enum typ_binding (specs : (binding * int) list) lthy =
     val valid_bind = Binding.suffix_name "_byte_prism_valid" typ_binding
     val (_, lthy5) = lthy4
       |> Local_Theory.note ((valid_bind, []), [valid_thm])
+
+    (* Step 6: declare the encoding definitions as code equations, so the enum's
+       encoding is executable (needed once the enum focus below is run in a
+       parser).  The prism/to_byte/from_byte are plain definitions; their
+       defining equations become the code equations. *)
+    val lthy6 = lthy5
+      |> Code.declare_default_eqns [(prism_def, true), (to_byte_def, true), (from_byte_def, true)]
+
+    (* Step 7: define <T>_focus = enum_byte_focus <T>_to_byte <T>_from_byte.
+       This is the enum as a (typedef) focus, ready to be composed into a parser
+       by the record command.  It is a plain definition on the generic guarded
+       enum_byte_focus, so no per-enum lift_definition is needed. *)
+    val focus_bind = Binding.suffix_name "_focus" typ_binding
+    val focus_str =
+      "enum_byte_focus " ^ Binding.name_of to_byte_bind ^ " " ^ Binding.name_of from_byte_bind
+    val (_, lthy7) = define_from_string focus_bind focus_str lthy6
+
+    (* Step 8: <T>_focus_rep [code abstract] --- discharge the guard of the
+       generic enum_byte_focus so the focus is executable.  First prove the guard
+       (the two round-trip facts, by induction/if-split as in Step 5); then the
+       focus reduces to its real branch prism_to_focus_raw <T>_byte_prism. *)
+    val focus_name = Binding.name_of focus_bind
+    val focus_def = Proof_Context.get_thm lthy7 (focus_name ^ "_def")
+    val to_str = Binding.name_of to_byte_bind
+    val from_str = Binding.name_of from_byte_bind
+    val guard_prop =
+      Syntax.read_prop lthy7
+        ("(\<forall>e. " ^ from_str ^ " (" ^ to_str ^ " e) = Some e) \<and> " ^
+         "(\<forall>w e. " ^ from_str ^ " w = Some e \<longrightarrow> " ^ to_str ^ " e = w)")
+    val rep_simp_ctxt =
+      fold Splitter.add_split @{thms if_split if_split_asm} (lthy7 addsimps encoding_simps)
+    val guard_thm = Goal.prove lthy7 [] [] guard_prop
+      (fn {context = ctxt, ...} =>
+        (resolve_tac ctxt @{thms conjI} 1
+         THEN resolve_tac ctxt @{thms allI} 1
+         THEN resolve_tac ctxt [induct_thm] 1
+         THEN ALLGOALS (asm_full_simp_tac rep_simp_ctxt))
+        THEN ALLGOALS (asm_full_simp_tac rep_simp_ctxt))
+    val rep_prop =
+      Syntax.read_prop lthy7
+        ("Rep_focus " ^ focus_name ^ " = prism_to_focus_raw " ^ Binding.name_of prism_bind)
+    val rep_thm = Goal.prove lthy7 [] [] rep_prop
+      (fn {context = ctxt, ...} =>
+        Local_Defs.unfold_tac ctxt [focus_def]
+        THEN asm_full_simp_tac
+               (lthy7 addsimps [@{thm enum_byte_focus.rep_eq}, @{thm if_P} OF [guard_thm], prism_def]) 1)
+    val lthy8 = lthy7
+      |> Code.declare_abstract_eqn rep_thm
   in
-    lthy5
+    lthy8
   end
 
 end

--- a/Byte_Level_Encoding/byte_encoding_enum_cmd.ML
+++ b/Byte_Level_Encoding/byte_encoding_enum_cmd.ML
@@ -4,12 +4,11 @@
 (* The `define_byte_enum` command.  Given a name and a list of (constructor,
    discriminant byte) pairs, it
      (1) defines the enumeration type via the existing `enum` command,
-     (2) generates the discriminant codec `<T>_to_byte` / `<T>_from_byte`,
+     (2) generates the discriminant encoding `<T>_to_byte` / `<T>_from_byte`,
      (3) defines `<T>_byte_prism` as an instance of `enum_byte_prism`, and
      (4) proves `<T>_byte_prism_valid` (the round-trip law) automatically.
-   This is the Isabelle analogue of the Verus `define_enum!` macro: the type
-   and its byte serialization, with the round-trip proof discharged
-   automatically. *)
+   The type and its byte serialization from one declaration, with the
+   round-trip proof discharged automatically. *)
 
 signature BYTE_ENCODING_ENUM_CMD =
 sig

--- a/Byte_Level_Encoding/byte_encoding_enum_cmd.ML
+++ b/Byte_Level_Encoding/byte_encoding_enum_cmd.ML
@@ -78,10 +78,12 @@ fun define_byte_enum typ_binding (specs : (binding * int) list) lthy =
        then `from_byte` decodes it back.  Goal (2) is a case split on the nested
        `if` in `from_byte`. *)
     val induct_thm = Proof_Context.get_thm lthy4 (typ_name ^ ".induct")
-    val case_simps = Proof_Context.get_thms lthy4 (typ_name ^ ".cases")
     val valid_prop =
       Syntax.read_prop lthy4 ("is_valid_prism " ^ Binding.name_of prism_bind)
-    val encoding_simps = to_byte_def :: from_byte_def :: case_simps
+    (* The <T>.cases reduction rules are already [simp] (declared by the enum
+       command), so we add only the encoding definitions.  Re-adding the case
+       rules would trigger "Ignoring duplicate rewrite rule" warnings. *)
+    val encoding_simps = [to_byte_def, from_byte_def]
     val simp_ctxt =
       fold Splitter.add_split @{thms if_split if_split_asm} (lthy4 addsimps encoding_simps)
 

--- a/Byte_Level_Encoding/byte_encoding_record_cmd.ML
+++ b/Byte_Level_Encoding/byte_encoding_record_cmd.ML
@@ -1,0 +1,249 @@
+(* Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+   SPDX-License-Identifier: MIT *)
+
+(* The `define_byte_record` command.  Given a name and a list of (field,
+   field-type) pairs, it
+     (1) defines the record type via `datatype_record`,
+     (2) builds the field byte-prism by nesting `prod_byte_prism` over the
+         per-field codecs and relabelling the resulting tuple to the named
+         record via `iso_prism`, and
+     (3) proves `<T>_byte_prism_valid` (the round-trip law) automatically.
+   This is the Isabelle analogue of the Verus `define_payload!` macro.
+
+   Currently supports word fields (u16/u32/u64/u128). *)
+
+signature BYTE_ENCODING_RECORD_CMD =
+sig
+  val define_byte_record: binding -> (binding * string) list -> local_theory -> local_theory
+end
+
+structure Byte_Encoding_Record_Cmd : BYTE_ENCODING_RECORD_CMD =
+struct
+
+(* A field's encoding info:
+     hol_ty  - the HOL field type (for datatype_record)
+     codec   - the byte-list codec term, as a string
+     fw_thm  - a PROVED `fixed_width_prism <n> <codec>` theorem (concrete codec).
+   The width <n> is read off `fw_thm`. *)
+type field_enc = { hol_ty : string, codec : string, fw_thm : thm }
+
+(* Instantiate a schematic length type variable 'l in a fixed-width theorem to a
+   concrete numeral type, and simplify (turning LENGTH('l)/w*LENGTH('l) into a
+   literal width).  Optionally discharge a premise with `OF [prem]` first. *)
+fun inst_len ctxt n prems thm =
+  let
+    val thm' = case prems of [] => thm | _ => thm OF prems
+    val inst = Rule_Insts.where_rule ctxt [((("'l", 0), Position.none), string_of_int n)] [] thm'
+  in
+    Simplifier.simplify ctxt inst
+  end
+
+(* The word codec name and width for an integer width W (in bits). *)
+fun word_codec 16  = ("word16_byte_list_prism_le",  2)
+  | word_codec 32  = ("word32_byte_list_prism_le",  4)
+  | word_codec 64  = ("word64_byte_list_prism_le",  8)
+  | word_codec 128 = ("word128_byte_list_prism_le", 16)
+  | word_codec w   = error ("define_byte_record: unsupported word width " ^ string_of_int w)
+
+fun word_fw_thm 16  = @{thm fixed_width_word16_le}
+  | word_fw_thm 32  = @{thm fixed_width_word32_le}
+  | word_fw_thm 64  = @{thm fixed_width_word64_le}
+  | word_fw_thm 128 = @{thm fixed_width_word128_le}
+  | word_fw_thm w   = error ("define_byte_record: unsupported word width " ^ string_of_int w)
+
+(* Parse an array field type `[uW; N]` into (W, N), or NONE. *)
+fun parse_array ty =
+  case Scan.finite Symbol.stopper
+         (Scan.option (Scan.this_string "[u" |--
+            Scan.many1 Symbol.is_ascii_digit -- (Scan.this_string ";" |-- Scan.many Symbol.is_ascii_blank |--
+              Scan.many1 Symbol.is_ascii_digit) --| Scan.this_string "]"))
+         (Symbol.explode (String.translate (fn c => if c = #" " then "" else str c) ty))
+  of (SOME (w, n), _) => SOME (the (Int.fromString (implode w)), the (Int.fromString (implode n)))
+   | _ => NONE
+
+(* Map a field type name to its encoding info.  Supports: word fields (u16/u32/
+   u64/u128), bool, pad [u8; N], word arrays [uW; N], and (by naming convention)
+   enum / nested record types T (codec T_byte_prism, lemma fixed_width_T). *)
+fun field_info _ "u16"  = { hol_ty = "16 word",  codec = "word16_byte_list_prism_le",
+                            fw_thm = @{thm fixed_width_word16_le} }
+  | field_info _ "u32"  = { hol_ty = "32 word",  codec = "word32_byte_list_prism_le",
+                            fw_thm = @{thm fixed_width_word32_le} }
+  | field_info _ "u64"  = { hol_ty = "64 word",  codec = "word64_byte_list_prism_le",
+                            fw_thm = @{thm fixed_width_word64_le} }
+  | field_info _ "u128" = { hol_ty = "128 word", codec = "word128_byte_list_prism_le",
+                            fw_thm = @{thm fixed_width_word128_le} }
+  | field_info _ "u8"   = { hol_ty = "byte",     codec = "byte_byte_list_prism",
+                            fw_thm = @{thm fixed_width_u8} }
+  | field_info _ "bool" = { hol_ty = "bool",     codec = "bool_byte_list_prism",
+                            fw_thm = @{thm fixed_width_bool} }
+  | field_info ctxt ty =
+      (case parse_array ty of
+         SOME (8, n) =>   (* pad: [u8; N] *)
+           { hol_ty = "(byte, " ^ string_of_int n ^ ") array",
+             codec  = "list_fixlen_prism :: (byte list, (byte, " ^ string_of_int n ^ ") array) prism",
+             fw_thm = inst_len ctxt n [] @{thm fixed_width_pad} }
+       | SOME (w, n) =>   (* word array: [uW; N] *)
+           let val (cname, ew) = word_codec w in
+             { hol_ty = "(" ^ string_of_int w ^ " word, " ^ string_of_int n ^ ") array",
+               codec  = "array_byte_prism " ^ string_of_int ew ^ " " ^ cname
+                          ^ " :: (byte list, (" ^ string_of_int w ^ " word, " ^ string_of_int n ^ ") array) prism",
+               fw_thm = inst_len ctxt n [word_fw_thm w] @{thm fixed_width_array} }
+           end
+       | NONE =>          (* enum / nested record, by naming convention.
+             A nested record (define_byte_record) has both T_byte_prism (already
+             a byte-list codec) and fixed_width_T.  An enum (define_byte_enum) has
+             a single-byte T_byte_prism + T_byte_prism_valid only, so we lift it
+             with single_byte_prism and build its fixed width on the spot. *)
+           (case try (Proof_Context.get_thm ctxt) ("fixed_width_" ^ ty) of
+              SOME fw =>     (* nested record *)
+                { hol_ty = ty, codec = ty ^ "_byte_prism", fw_thm = fw }
+            | NONE =>        (* enum *)
+                { hol_ty = ty,
+                  codec  = "single_byte_prism " ^ ty ^ "_byte_prism",
+                  fw_thm = @{thm fixed_width_single_byte}
+                             OF [Proof_Context.get_thm ctxt (ty ^ "_byte_prism_valid")] }))
+
+(* Read the width <n> out of a `fixed_width_prism <n> <codec>` theorem. *)
+fun width_of_fw_thm thm =
+  case HOLogic.dest_Trueprop (Thm.concl_of thm) of
+    \<^Const_>\<open>fixed_width_prism _\<close> $ n $ _ => snd (HOLogic.dest_number n)
+  | _ => error "define_byte_record: malformed fixed_width theorem"
+
+fun define_byte_record typ_binding (fields : (binding * string) list) lthy =
+  let
+    val _ = if length fields < 2
+            then error "define_byte_record: need at least two fields" else ()
+    val typ_name = Binding.name_of typ_binding
+    val field_binds = map fst fields
+    val field_tys = map snd fields
+    val infos = map (field_info lthy) field_tys
+    val hol_tys = map #hol_ty infos
+
+    (* Step 1: define the record type via datatype_record, inside a nested target
+       so its constructor/selectors are committed before we build terms. *)
+    val args = map2 (fn b => fn ty => (b, ty)) field_binds hol_tys
+    val lthy1 = lthy
+      |> Local_Theory.begin_nested |> snd
+      |> Datatype_Records.record_cmd typ_binding Datatype_Records.default_ctr_options_cmd [] args
+      |> Local_Theory.end_nested
+
+    (* Step 2: build the codec prism as a STRING and let type inference resolve it.
+
+       Nested prod_byte_prism (right-associative) over the per-field codecs:
+         prod_byte_prism w0 p0 (prod_byte_prism w1 p1 (... p(n-1)))
+       then relabel the resulting nested tuple to the named record via iso_prism:
+         forward  = \<lambda>(x0, ..., x(n-1)). make_<T> x0 ... x(n-1)
+         backward = \<lambda>r. (f0 r, ..., f(n-1) r)
+       The record constructor is `make_<T>` and the selectors are the field names. *)
+    val codec_names = map #codec infos
+    val widths = map (width_of_fw_thm o #fw_thm) infos
+
+    fun nested_prod [(_, p)] = "(" ^ p ^ ")"
+      | nested_prod ((w, p) :: rest) =
+          "prod_byte_prism " ^ string_of_int w ^ " (" ^ p ^ ") (" ^ nested_prod rest ^ ")"
+      | nested_prod [] = error "unreachable"
+    val tuple_prism_str = nested_prod (widths ~~ codec_names)
+
+    val field_name_strs = map Binding.name_of field_binds
+    val n = length fields
+    val xs = map (fn i => "x" ^ string_of_int i) (0 upto n - 1)
+    val forward_str =
+      "\<lambda>(" ^ space_implode ", " xs ^ "). make_" ^ typ_name ^ " " ^ space_implode " " xs
+    val backward_str =
+      "\<lambda>r. (" ^ space_implode ", " (map (fn f => f ^ " r") field_name_strs) ^ ")"
+
+    val prism_str =
+      "prism_compose (" ^ tuple_prism_str ^ ") (iso_prism (" ^ forward_str ^ ") (" ^ backward_str ^ "))"
+
+    val prism_body = Syntax.read_term lthy1 prism_str
+    val prism_bind = Binding.suffix_name "_byte_prism" typ_binding
+    val ((_, (_, prism_def)), lthy2) = lthy1
+      |> Local_Theory.define ((prism_bind, NoSyn),
+           ((Binding.suffix_name "_def" prism_bind, []), prism_body))
+
+    (* Step 3: prove <T>_byte_prism_valid.
+
+       The codec is `prism_compose <prod-chain> <iso>`.  After prism_compose_valid:
+         goal L: is_valid_prism <prod-chain>
+         goal R: is_valid_prism <iso>
+       For L, the prod-chain is right-nested over fields [f0, ..., f(n-1)].  Each
+       prod_byte_prism_valid needs `fixed_width_prism (f_i)` for the head and
+       `is_valid_prism (rest)` for the tail; the innermost field is closed by
+       `fixed_width_prism_valid OF <its fw_thm>`.  Walking the field fw_thms in
+       order discharges the whole chain. *)
+    val fw_thms = map #fw_thm infos
+    val total_width = fold (fn t => fn acc => acc + width_of_fw_thm t) fw_thms 0
+
+    (* Discharge `is_valid_prism <prod-chain>` by walking the field fw_thms. *)
+    fun prod_valid_tac ctxt [last_fw] =
+          resolve_tac ctxt [@{thm fixed_width_prism_valid} OF [last_fw]] 1
+      | prod_valid_tac ctxt (fw :: rest) =
+          resolve_tac ctxt @{thms prod_byte_prism_valid} 1
+          THEN resolve_tac ctxt [fw] 1
+          THEN prod_valid_tac ctxt rest
+      | prod_valid_tac _ [] = no_tac
+
+    (* Discharge `fixed_width_prism <w> <prod-chain>` by walking the fw_thms. *)
+    fun prod_fw_tac ctxt [last_fw] =
+          resolve_tac ctxt [last_fw] 1
+      | prod_fw_tac ctxt (fw :: rest) =
+          resolve_tac ctxt @{thms prod_byte_prism_fixed_width} 1
+          THEN resolve_tac ctxt [fw] 1
+          THEN prod_fw_tac ctxt rest
+      | prod_fw_tac _ [] = no_tac
+
+    val iso_tac = fn ctxt =>
+      resolve_tac ctxt @{thms iso_prism_valid} 1
+      THEN ALLGOALS (asm_full_simp_tac (fold Splitter.add_split @{thms prod.split} ctxt))
+
+    (* Step 3: prove <T>_byte_prism_valid. *)
+    val valid_prop =
+      Syntax.read_prop lthy2 ("is_valid_prism " ^ Binding.name_of prism_bind)
+    val valid_thm = Goal.prove lthy2 [] [] valid_prop
+      (fn {context = ctxt, ...} =>
+        Local_Defs.unfold_tac ctxt [prism_def]
+        THEN resolve_tac ctxt @{thms prism_compose_valid} 1
+        THEN prod_valid_tac ctxt fw_thms
+        THEN iso_tac ctxt)
+    val valid_bind = Binding.suffix_name "_byte_prism_valid" typ_binding
+    val (_, lthy3) = lthy2
+      |> Local_Theory.note ((valid_bind, []), [valid_thm])
+
+    (* Step 4: prove fixed_width_<T>, so the record can itself be a nested field.
+       State the width as the sum w0 + w1 + ... (NOT pre-summed) so each
+       prod_byte_prism_fixed_width step unifies its nA + nB without arithmetic;
+       then simplify the registered theorem so its width is the literal total. *)
+    (* right-associated sum w0 + (w1 + (... + w(n-1))), matching the right-nested
+       prod chain, so prod_byte_prism_fixed_width unifies nA + nB at each step. *)
+    fun right_sum [w] = string_of_int w
+      | right_sum (w :: rest) = string_of_int w ^ " + (" ^ right_sum rest ^ ")"
+      | right_sum [] = "0"
+    val width_sum = right_sum (map width_of_fw_thm fw_thms)
+    val fw_prop =
+      Syntax.read_prop lthy3
+        ("fixed_width_prism (" ^ width_sum ^ ") " ^ Binding.name_of prism_bind)
+    val fw_thm0 = Goal.prove lthy3 [] [] fw_prop
+      (fn {context = ctxt, ...} =>
+        Local_Defs.unfold_tac ctxt [prism_def]
+        THEN resolve_tac ctxt @{thms fixed_width_compose_iso} 1
+        THEN prod_fw_tac ctxt fw_thms
+        THEN ALLGOALS (asm_full_simp_tac (fold Splitter.add_split @{thms prod.split} ctxt)))
+    val fw_thm = Simplifier.simplify lthy3 fw_thm0
+    val fw_bind = Binding.name ("fixed_width_" ^ typ_name)
+    val (_, lthy4) = lthy3
+      |> Local_Theory.note ((fw_bind, []), [fw_thm])
+    val _ = total_width
+  in
+    lthy4
+  end
+
+end
+
+(* Parser: `define_byte_record <name> = <f0>: <ty0> | <f1>: <ty1> | ...` *)
+val _ =
+  Outer_Syntax.local_theory \<^command_keyword>\<open>define_byte_record\<close>
+    "define a fixed-layout record type together with its byte serialization"
+    (Parse.binding --
+      (Parse.$$$ "=" |--
+        Parse.enum1 "|" (Parse.binding --| Parse.$$$ ":" -- Parse.embedded))
+      >> (fn (b, fields) => Byte_Encoding_Record_Cmd.define_byte_record b fields))

--- a/Byte_Level_Encoding/byte_encoding_record_cmd.ML
+++ b/Byte_Level_Encoding/byte_encoding_record_cmd.ML
@@ -4,12 +4,24 @@
 (* The `define_byte_record` command.  Given a name and a list of (field,
    field-type) pairs, it
      (1) defines the record type via `datatype_record`,
-     (2) builds the field byte-prism by nesting `prod_byte_prism` over the
-         per-field prisms and relabelling the resulting tuple to the named
-         record via `iso_prism`, and
-     (3) proves `<T>_byte_prism_valid` (the round-trip law) automatically.
+     (2) builds the record parser by sequencing the per-field parsers with the
+         `--` combinator and relabelling the resulting nested tuple to the named
+         record via `iso_focus`, and
+     (3) proves `<T>_focus_valid` (the round-trip law) automatically --- for free,
+         since a parser is a validity-carrying focus.
    Field types: u8/u16/u32/u64/u128, bool, pad [u8; N], word array [uW; N],
-   enum, and nested record. *)
+   enum, and nested record.
+
+   Field parsers:
+     word W    -> parse_wordW           (library)
+     u8        -> parse_byte            (library)
+     bool      -> parse_bool            (library)
+     enum T    -> parse_byte >> T_focus (T_focus from define_byte_enum)
+     [uW; N]   -> FocusParser <T>_<f>_focus, where <T>_<f>_focus = array_focus w p
+     nested T  -> T_parser              (from a prior define_byte_record)
+   Array/pad fields need a per-field focus definition plus a [code abstract]
+   equation making it executable; the other field parsers are library constants,
+   already executable. *)
 
 signature BYTE_ENCODING_RECORD_CMD =
 sig
@@ -18,40 +30,6 @@ end
 
 structure Byte_Encoding_Record_Cmd : BYTE_ENCODING_RECORD_CMD =
 struct
-
-(* A field's encoding info:
-     hol_ty  - the HOL field type (for datatype_record)
-     codec   - the byte-list codec term, as a string
-     fw_thm  - a PROVED `fixed_width_prism <n> <codec>` theorem (concrete codec).
-   The width <n> is read off `fw_thm`. *)
-type field_enc = { hol_ty : string, codec : string, fw_thm : thm }
-
-(* Instantiate a schematic length type variable 'l in a fixed-width theorem to a
-   concrete numeral type, and simplify (turning LENGTH('l)/w*LENGTH('l) into a
-   literal width).  Optionally discharge a premise with `OF [prem]` first. *)
-fun inst_len ctxt n prems thm =
-  let
-    val thm' = case prems of [] => thm | _ => thm OF prems
-    val inst = Rule_Insts.where_rule ctxt [((("'l", 0), Position.none), string_of_int n)] [] thm'
-    (* Delete One_nat_def so the width is left as the numeral 1, not Suc 0
-       (otherwise downstream numeral/Suc unification in the validity proof fails). *)
-    val ctxt' = ctxt delsimps @{thms One_nat_def}
-  in
-    Simplifier.simplify ctxt' inst
-  end
-
-(* The word codec name and width for an integer width W (in bits). *)
-fun word_codec 16  = ("word16_byte_list_prism_le",  2)
-  | word_codec 32  = ("word32_byte_list_prism_le",  4)
-  | word_codec 64  = ("word64_byte_list_prism_le",  8)
-  | word_codec 128 = ("word128_byte_list_prism_le", 16)
-  | word_codec w   = error ("define_byte_record: unsupported word width " ^ string_of_int w)
-
-fun word_fw_thm 16  = @{thm fixed_width_word16_le}
-  | word_fw_thm 32  = @{thm fixed_width_word32_le}
-  | word_fw_thm 64  = @{thm fixed_width_word64_le}
-  | word_fw_thm 128 = @{thm fixed_width_word128_le}
-  | word_fw_thm w   = error ("define_byte_record: unsupported word width " ^ string_of_int w)
 
 (* Parse an array field type `[uW; N]` into (W, N), or NONE. *)
 fun parse_array ty =
@@ -63,61 +41,71 @@ fun parse_array ty =
   of (SOME (w, n), _) => SOME (the (Int.fromString (implode w)), the (Int.fromString (implode n)))
    | _ => NONE
 
-(* Map a field type name to its encoding info.  Supports: word fields (u16/u32/
-   u64/u128), bool, pad [u8; N], word arrays [uW; N], and (by naming convention)
-   enum / nested record types T (codec T_byte_prism, lemma fixed_width_T). *)
-fun field_info _ "u16"  = { hol_ty = "16 word",  codec = "word16_byte_list_prism_le",
-                            fw_thm = @{thm fixed_width_word16_le} }
-  | field_info _ "u32"  = { hol_ty = "32 word",  codec = "word32_byte_list_prism_le",
-                            fw_thm = @{thm fixed_width_word32_le} }
-  | field_info _ "i32"  = { hol_ty = "32 word",  codec = "word32_byte_list_prism_le",
-                            fw_thm = @{thm fixed_width_word32_le} }  (* i32: same 4 bytes as u32 *)
-  | field_info _ "u64"  = { hol_ty = "64 word",  codec = "word64_byte_list_prism_le",
-                            fw_thm = @{thm fixed_width_word64_le} }
-  | field_info _ "u128" = { hol_ty = "128 word", codec = "word128_byte_list_prism_le",
-                            fw_thm = @{thm fixed_width_word128_le} }
-  | field_info _ "u8"   = { hol_ty = "byte",     codec = "byte_byte_list_prism",
-                            fw_thm = @{thm fixed_width_u8} }
-  | field_info _ "bool" = { hol_ty = "bool",     codec = "bool_byte_list_prism",
-                            fw_thm = @{thm fixed_width_bool} }
+(* The element byte-width and element prism for a word width W (in bits). *)
+fun word_elem 16  = (2,  "word16_byte_list_prism_le")
+  | word_elem 32  = (4,  "word32_byte_list_prism_le")
+  | word_elem 64  = (8,  "word64_byte_list_prism_le")
+  | word_elem 128 = (16, "word128_byte_list_prism_le")
+  | word_elem w   = error ("define_byte_record: unsupported word width " ^ string_of_int w)
+
+(* The fixed-width fact for a word element prism (used in the array focus's
+   [code abstract] proof). *)
+fun word_elem_fw 16  = @{thm fixed_width_word16_le}
+  | word_elem_fw 32  = @{thm fixed_width_word32_le}
+  | word_elem_fw 64  = @{thm fixed_width_word64_le}
+  | word_elem_fw 128 = @{thm fixed_width_word128_le}
+  | word_elem_fw w   = error ("define_byte_record: unsupported word width " ^ string_of_int w)
+
+(* A field's parser info:
+     hol_ty  - the HOL field type (for datatype_record)
+     parser  - either a library parser term (Direct), or an array/pad field that
+               needs a per-field focus definition (Array).
+   Array carries (element width w, element prism string, element fixed-width thm),
+   from which the command generates <T>_<f>_focus = array_focus w p and its
+   [code abstract] equation, then uses FocusParser <T>_<f>_focus as the parser. *)
+datatype parser_info =
+    Direct of string                       (* a ready library parser term *)
+  | Array of int * string * thm * string   (* (elem width, elem prism, elem fw thm, array hol type) *)
+
+type field_info = { hol_ty : string, parser : parser_info }
+
+(* Map a field type name to its HOL type and parser info. *)
+fun field_info _ "u16"  = { hol_ty = "16 word",  parser = Direct "parse_word16" }
+  | field_info _ "u32"  = { hol_ty = "32 word",  parser = Direct "parse_word32" }
+  | field_info _ "i32"  = { hol_ty = "32 word",  parser = Direct "parse_word32" }  (* i32: same 4 bytes as u32 *)
+  | field_info _ "u64"  = { hol_ty = "64 word",  parser = Direct "parse_word64" }
+  | field_info _ "u128" = { hol_ty = "128 word", parser = Direct "parse_word128" }
+  | field_info _ "u8"   = { hol_ty = "byte",     parser = Direct "parse_byte" }
+  | field_info _ "bool" = { hol_ty = "bool",     parser = Direct "parse_bool" }
   | field_info ctxt ty =
       (case parse_array ty of
-         SOME (8, n) =>   (* pad: [u8; N] *)
-           { hol_ty = "(byte, " ^ string_of_int n ^ ") array",
-             codec  = "list_fixlen_prism :: (byte list, (byte, " ^ string_of_int n ^ ") array) prism",
-             fw_thm = inst_len ctxt n [] @{thm fixed_width_pad} }
-       | SOME (w, n) =>   (* word array: [uW; N] *)
-           let val (cname, ew) = word_codec w in
-             { hol_ty = "(" ^ string_of_int w ^ " word, " ^ string_of_int n ^ ") array",
-               codec  = "array_byte_prism " ^ string_of_int ew ^ " " ^ cname
-                          ^ " :: (byte list, (" ^ string_of_int w ^ " word, " ^ string_of_int n ^ ") array) prism",
-               fw_thm = inst_len ctxt n [word_fw_thm w] @{thm fixed_width_array} }
+         SOME (8, n) =>   (* pad [u8; N]: array of raw bytes *)
+           let val aty = "(byte, " ^ string_of_int n ^ ") array" in
+             { hol_ty = aty, parser = Array (1, "byte_id_prism", @{thm fixed_width_byte_id}, aty) }
            end
-       | NONE =>          (* enum / nested record, by naming convention.
-             A nested record (define_byte_record) has both T_byte_prism (already
-             a byte-list codec) and fixed_width_T.  An enum (define_byte_enum) has
-             a single-byte T_byte_prism + T_byte_prism_valid only, so we lift it
-             with single_byte_prism and build its fixed width on the spot. *)
-           (case try (Proof_Context.get_thm ctxt) ("fixed_width_" ^ ty) of
-              SOME fw =>     (* nested record *)
-                { hol_ty = ty, codec = ty ^ "_byte_prism", fw_thm = fw }
-            | NONE =>        (* enum *)
-                { hol_ty = ty,
-                  codec  = "single_byte_prism " ^ ty ^ "_byte_prism",
-                  fw_thm = @{thm fixed_width_single_byte}
-                             OF [Proof_Context.get_thm ctxt (ty ^ "_byte_prism_valid")] }))
+       | SOME (w, n) =>   (* word array [uW; N] *)
+           let
+             val (ew, cname) = word_elem w
+             val aty = "(" ^ string_of_int w ^ " word, " ^ string_of_int n ^ ") array"
+           in
+             { hol_ty = aty, parser = Array (ew, cname, word_elem_fw w, aty) }
+           end
+       | NONE =>          (* enum or nested record, by naming convention.
+             A nested record (define_byte_record) exposes T_parser directly.
+             An enum (define_byte_enum) exposes a single-byte focus T_focus,
+             composed with parse_byte to read one discriminant byte. *)
+           (case try (Proof_Context.get_thm ctxt) (ty ^ "_parser_def") of
+              SOME _ => { hol_ty = ty, parser = Direct (ty ^ "_parser") }   (* nested record *)
+            | NONE   => { hol_ty = ty,
+                          parser = Direct ("focus_parser_map parse_byte " ^ ty ^ "_focus") }))
 
-(* A nat literal may appear as a numeral, as 0, or as Suc (...) (e.g. simp leaves
-   `Suc 0` for length 1).  Extract its value robustly. *)
-fun dest_nat \<^Const_>\<open>Groups.zero _\<close> = 0
-  | dest_nat \<^Const_>\<open>Suc for m\<close> = dest_nat m + 1
-  | dest_nat t = snd (HOLogic.dest_number t)
-
-(* Read the width <n> out of a `fixed_width_prism <n> <codec>` theorem. *)
-fun width_of_fw_thm thm =
-  case HOLogic.dest_Trueprop (Thm.concl_of thm) of
-    \<^Const_>\<open>fixed_width_prism _\<close> $ n $ _ => dest_nat n
-  | _ => error "define_byte_record: malformed fixed_width theorem"
+(* Define a constant `<bind>` from a term string, returning (def theorem, lthy). *)
+fun define_from_string bind rhs_str lthy =
+  let
+    val rhs = Syntax.read_term lthy rhs_str
+    val ((_, (_, def_thm)), lthy') = lthy
+      |> Local_Theory.define ((bind, NoSyn), ((Binding.suffix_name "_def" bind, []), rhs))
+  in (def_thm, lthy') end
 
 fun define_byte_record typ_binding (fields : (binding * string) list) lthy =
   let
@@ -125,132 +113,114 @@ fun define_byte_record typ_binding (fields : (binding * string) list) lthy =
             then error "define_byte_record: need at least one field" else ()
     val typ_name = Binding.name_of typ_binding
     val field_binds = map fst fields
+    val field_name_strs = map Binding.name_of field_binds
     val field_tys = map snd fields
     val infos = map (field_info lthy) field_tys
-    val hol_tys = map #hol_ty infos
+    val n = length fields
 
-    (* Step 1: define the record type via datatype_record, inside a nested target
-       so its constructor/selectors are committed before we build terms. *)
-    val args = map2 (fn b => fn ty => (b, ty)) field_binds hol_tys
+    (* Step 1: define the record type via datatype_record, in a nested target so
+       its constructor/selectors are committed before we build later terms. *)
+    val args = map2 (fn b => fn i => (b, #hol_ty i)) field_binds infos
     val lthy1 = lthy
       |> Local_Theory.begin_nested |> snd
       |> Datatype_Records.record_cmd typ_binding Datatype_Records.default_ctr_options_cmd [] args
       |> Local_Theory.end_nested
 
-    (* Step 2: build the codec prism as a STRING and let type inference resolve it.
+    (* Step 2: for each array/pad field, define <T>_<f>_focus = array_focus w p
+       and prove its [code abstract] rep equation, so the field parser is
+       executable.  Returns the parser term string for each field. *)
+    fun field_parser (fname, { parser = Direct s, ... } : field_info) lthy_acc = (s, lthy_acc)
+      | field_parser (fname, { parser = Array (ew, elem, elem_fw, aty), ... }) lthy_acc =
+          let
+            val focus_bind = Binding.name (typ_name ^ "_" ^ fname ^ "_focus")
+            val focus_name = Binding.name_of focus_bind
+            (* Annotate with the concrete array type so the length N is pinned,
+               not left schematic. *)
+            val focus_ty = "(byte list, " ^ aty ^ " \<times> byte list) focus"
+            val (_, lthy_a) =
+              define_from_string focus_bind
+                ("array_focus " ^ string_of_int ew ^ " " ^ elem ^ " :: " ^ focus_ty) lthy_acc
+            val focus_def = Proof_Context.get_thm lthy_a (focus_name ^ "_def")
+            val rep_prop =
+              Syntax.read_prop lthy_a
+                ("Rep_focus " ^ focus_name ^ " = prism_to_focus_raw (array_split_prism "
+                   ^ string_of_int ew ^ " " ^ elem ^ " :: (byte list, " ^ aty ^ " \<times> byte list) prism)")
+            val rep_thm = Goal.prove lthy_a [] [] rep_prop
+              (fn {context = ctxt, ...} =>
+                Local_Defs.unfold_tac ctxt [focus_def]
+                THEN EqSubst.eqsubst_tac ctxt [0] @{thms array_focus.rep_eq} 1
+                THEN asm_full_simp_tac (ctxt addsimps [elem_fw] delsimps @{thms One_nat_def}) 1)
+            val lthy_b = lthy_a |> Code.declare_abstract_eqn rep_thm
+          in ("FocusParser " ^ focus_name, lthy_b) end
 
-       Nested prod_byte_prism (right-associative) over the per-field codecs:
-         prod_byte_prism w0 p0 (prod_byte_prism w1 p1 (... p(n-1)))
-       then relabel the resulting nested tuple to the named record via iso_prism:
-         forward  = \<lambda>(x0, ..., x(n-1)). make_<T> x0 ... x(n-1)
-         backward = \<lambda>r. (f0 r, ..., f(n-1) r)
-       The record constructor is `make_<T>` and the selectors are the field names. *)
-    val codec_names = map #codec infos
-    val widths = map (width_of_fw_thm o #fw_thm) infos
+    val (parser_strs, lthy2) =
+      fold_map field_parser (field_name_strs ~~ infos) lthy1
 
-    fun nested_prod [(_, p)] = "(" ^ p ^ ")"
-      | nested_prod ((w, p) :: rest) =
-          "prod_byte_prism " ^ string_of_int w ^ " (" ^ p ^ ") (" ^ nested_prod rest ^ ")"
-      | nested_prod [] = error "unreachable"
-    val tuple_prism_str = nested_prod (widths ~~ codec_names)
+    (* Step 3: sequence the field parsers with focus_parser_sequence (the -- of
+       the parser notation) left-associatively, producing a left-nested tuple
+       ((..((x0,x1),x2)..),x(n-1)).  We use the full constant name rather than the
+       -- notation so the command does not depend on the notation bundle being in
+       scope at the call site. *)
+    val parser_chain =
+      foldl1 (fn (a, b) => "focus_parser_sequence (" ^ a ^ ") (" ^ b ^ ")") parser_strs
 
-    val field_name_strs = map Binding.name_of field_binds
-    val n = length fields
+    (* The left-nested tuple pattern and the constructor application. *)
     val xs = map (fn i => "x" ^ string_of_int i) (0 upto n - 1)
-    (* For a single field the tuple degenerates to a bare value: the iso is
-       (\<lambda>x0. make_T x0) / (\<lambda>r. f0 r); otherwise it pairs the fields. *)
-    val forward_str =
-      if n = 1
-      then "\<lambda>x0. make_" ^ typ_name ^ " x0"
-      else "\<lambda>(" ^ space_implode ", " xs ^ "). make_" ^ typ_name ^ " " ^ space_implode " " xs
-    val backward_str =
-      if n = 1
-      then "\<lambda>r. " ^ hd field_name_strs ^ " r"
-      else "\<lambda>r. (" ^ space_implode ", " (map (fn f => f ^ " r") field_name_strs) ^ ")"
+    fun left_nest [x] = x
+      | left_nest xs' = "(" ^ left_nest (rev (tl (rev xs'))) ^ ", " ^ List.last xs' ^ ")"
+    val tuple_pat = left_nest xs
+    val make_app = "make_" ^ typ_name ^ " " ^ space_implode " " xs
+    val sels_nest = left_nest (map (fn f => f ^ " r") field_name_strs)
 
-    val prism_str =
-      "prism_compose (" ^ tuple_prism_str ^ ") (iso_prism (" ^ forward_str ^ ") (" ^ backward_str ^ "))"
+    val forward_str = "\<lambda>" ^ tuple_pat ^ ". " ^ make_app
+    val backward_str = "\<lambda>r. " ^ sels_nest
 
-    val prism_body = Syntax.read_term lthy1 prism_str
-    val prism_bind = Binding.suffix_name "_byte_prism" typ_binding
-    val ((_, (_, prism_def)), lthy2) = lthy1
-      |> Local_Theory.define ((prism_bind, NoSyn),
-           ((Binding.suffix_name "_def" prism_bind, []), prism_body))
-
-    (* Step 3: prove <T>_byte_prism_valid.
-
-       The codec is `prism_compose <prod-chain> <iso>`.  After prism_compose_valid:
-         goal L: is_valid_prism <prod-chain>
-         goal R: is_valid_prism <iso>
-       For L, the prod-chain is right-nested over fields [f0, ..., f(n-1)].  Each
-       prod_byte_prism_valid needs `fixed_width_prism (f_i)` for the head and
-       `is_valid_prism (rest)` for the tail; the innermost field is closed by
-       `fixed_width_prism_valid OF <its fw_thm>`.  Walking the field fw_thms in
-       order discharges the whole chain. *)
-    val fw_thms = map #fw_thm infos
-    val total_width = fold (fn t => fn acc => acc + width_of_fw_thm t) fw_thms 0
-
-    (* Discharge `is_valid_prism <prod-chain>` by walking the field fw_thms. *)
-    fun prod_valid_tac ctxt [last_fw] =
-          resolve_tac ctxt [@{thm fixed_width_prism_valid} OF [last_fw]] 1
-      | prod_valid_tac ctxt (fw :: rest) =
-          resolve_tac ctxt @{thms prod_byte_prism_valid} 1
-          THEN resolve_tac ctxt [fw] 1
-          THEN prod_valid_tac ctxt rest
-      | prod_valid_tac _ [] = no_tac
-
-    (* Discharge `fixed_width_prism <w> <prod-chain>` by walking the fw_thms. *)
-    fun prod_fw_tac ctxt [last_fw] =
-          resolve_tac ctxt [last_fw] 1
-      | prod_fw_tac ctxt (fw :: rest) =
-          resolve_tac ctxt @{thms prod_byte_prism_fixed_width} 1
-          THEN resolve_tac ctxt [fw] 1
-          THEN prod_fw_tac ctxt rest
-      | prod_fw_tac _ [] = no_tac
-
-    val iso_tac = fn ctxt =>
-      resolve_tac ctxt @{thms iso_prism_valid} 1
-      THEN ALLGOALS (asm_full_simp_tac (fold Splitter.add_split @{thms prod.split} ctxt))
-
-    (* Step 3: prove <T>_byte_prism_valid. *)
-    val valid_prop =
-      Syntax.read_prop lthy2 ("is_valid_prism " ^ Binding.name_of prism_bind)
-    val valid_thm = Goal.prove lthy2 [] [] valid_prop
-      (fn {context = ctxt, ...} =>
-        Local_Defs.unfold_tac ctxt [prism_def]
-        THEN resolve_tac ctxt @{thms prism_compose_valid} 1
-        THEN prod_valid_tac ctxt fw_thms
-        THEN iso_tac ctxt)
-    val valid_bind = Binding.suffix_name "_byte_prism_valid" typ_binding
-    val (_, lthy3) = lthy2
-      |> Local_Theory.note ((valid_bind, []), [valid_thm])
-
-    (* Step 4: prove fixed_width_<T>, so the record can itself be a nested field.
-       State the width as the sum w0 + w1 + ... (NOT pre-summed) so each
-       prod_byte_prism_fixed_width step unifies its nA + nB without arithmetic;
-       then simplify the registered theorem so its width is the literal total. *)
-    (* right-associated sum w0 + (w1 + (... + w(n-1))), matching the right-nested
-       prod chain, so prod_byte_prism_fixed_width unifies nA + nB at each step. *)
-    fun right_sum [w] = string_of_int w
-      | right_sum (w :: rest) = string_of_int w ^ " + (" ^ right_sum rest ^ ")"
-      | right_sum [] = "0"
-    val width_sum = right_sum (map width_of_fw_thm fw_thms)
-    val fw_prop =
+    (* Step 4: define <T>_tuple_focus = iso_focus <forward> <backward> and prove
+       its [code abstract] rep equation (the iso laws hold by the record simps). *)
+    val tuple_bind = Binding.name (typ_name ^ "_tuple_focus")
+    val tuple_name = Binding.name_of tuple_bind
+    val (_, lthy3) =
+      define_from_string tuple_bind
+        ("iso_focus (" ^ forward_str ^ ") (" ^ backward_str ^ ")") lthy2
+    val tuple_def = Proof_Context.get_thm lthy3 (tuple_name ^ "_def")
+    val tuple_rep_prop =
       Syntax.read_prop lthy3
-        ("fixed_width_prism (" ^ width_sum ^ ") " ^ Binding.name_of prism_bind)
-    val fw_thm0 = Goal.prove lthy3 [] [] fw_prop
+        ("Rep_focus " ^ tuple_name ^ " = iso\<^sub>\<integral> (" ^ forward_str ^ ") (" ^ backward_str ^ ")")
+    val tuple_rep_thm = Goal.prove lthy3 [] [] tuple_rep_prop
       (fn {context = ctxt, ...} =>
-        Local_Defs.unfold_tac ctxt [prism_def]
-        THEN resolve_tac ctxt @{thms fixed_width_compose_iso} 1
-        THEN prod_fw_tac ctxt fw_thms
-        THEN ALLGOALS (asm_full_simp_tac (fold Splitter.add_split @{thms prod.split} ctxt)))
-    val fw_thm = Simplifier.simplify lthy3 fw_thm0
-    val fw_bind = Binding.name ("fixed_width_" ^ typ_name)
-    val (_, lthy4) = lthy3
-      |> Local_Theory.note ((fw_bind, []), [fw_thm])
-    val _ = total_width
+        Local_Defs.unfold_tac ctxt [tuple_def]
+        THEN EqSubst.eqsubst_tac ctxt [0] @{thms iso_focus.rep_eq} 1
+        THEN asm_full_simp_tac (fold Splitter.add_split @{thms prod.split} ctxt) 1)
+    val lthy4 = lthy3 |> Code.declare_abstract_eqn tuple_rep_thm
+
+    (* Step 5: <T>_parser = (parser chain) >> <T>_tuple_focus.  Declare its
+       defining equation as a code equation so the parser is executable (the
+       field parsers and focus reps are already executable). *)
+    val parser_bind = Binding.suffix_name "_parser" typ_binding
+    val (parser_def, lthy5) =
+      define_from_string parser_bind
+        ("focus_parser_map (" ^ parser_chain ^ ") " ^ tuple_name) lthy4
+    val lthy5 = lthy5 |> Code.declare_default_eqns [(parser_def, true)]
+
+    (* Step 6: <T>_focus = run_parser_all <T>_parser, and its validity --- for
+       free, since a focus is validity-carrying (Rep_focus lands in the typedef). *)
+    val focus_bind = Binding.suffix_name "_focus" typ_binding
+    val (_, lthy6) =
+      define_from_string focus_bind
+        ("run_parser_all " ^ Binding.name_of parser_bind) lthy5
+    val focus_def = Proof_Context.get_thm lthy6 (Binding.name_of focus_bind ^ "_def")
+    val valid_prop =
+      Syntax.read_prop lthy6
+        ("is_valid_focus (Rep_focus " ^ Binding.name_of focus_bind ^ ")")
+    val valid_thm = Goal.prove lthy6 [] [] valid_prop
+      (fn {context = ctxt, ...} =>
+        Local_Defs.unfold_tac ctxt [focus_def]
+        THEN resolve_tac ctxt @{thms Rep_focus[simplified]} 1)
+    val valid_bind = Binding.suffix_name "_focus_valid" typ_binding
+    val (_, lthy7) = lthy6
+      |> Local_Theory.note ((valid_bind, []), [valid_thm])
   in
-    lthy4
+    lthy7
   end
 
 end
@@ -258,7 +228,7 @@ end
 (* Parser: `define_byte_record <name> = <f0>: <ty0> | <f1>: <ty1> | ...` *)
 val _ =
   Outer_Syntax.local_theory \<^command_keyword>\<open>define_byte_record\<close>
-    "define a fixed-layout record type together with its byte serialization"
+    "define a fixed-layout record type together with its byte-parser serialization"
     (Parse.binding --
       (Parse.$$$ "=" |--
         Parse.enum1 "|" (Parse.binding --| Parse.$$$ ":" -- Parse.embedded))

--- a/Byte_Level_Encoding/byte_encoding_record_cmd.ML
+++ b/Byte_Level_Encoding/byte_encoding_record_cmd.ML
@@ -5,12 +5,11 @@
    field-type) pairs, it
      (1) defines the record type via `datatype_record`,
      (2) builds the field byte-prism by nesting `prod_byte_prism` over the
-         per-field codecs and relabelling the resulting tuple to the named
+         per-field prisms and relabelling the resulting tuple to the named
          record via `iso_prism`, and
      (3) proves `<T>_byte_prism_valid` (the round-trip law) automatically.
-   This is the Isabelle analogue of the Verus `define_payload!` macro.
-
-   Currently supports word fields (u16/u32/u64/u128). *)
+   Field types: u8/u16/u32/u64/u128, bool, pad [u8; N], word array [uW; N],
+   enum, and nested record. *)
 
 signature BYTE_ENCODING_RECORD_CMD =
 sig
@@ -34,8 +33,11 @@ fun inst_len ctxt n prems thm =
   let
     val thm' = case prems of [] => thm | _ => thm OF prems
     val inst = Rule_Insts.where_rule ctxt [((("'l", 0), Position.none), string_of_int n)] [] thm'
+    (* Delete One_nat_def so the width is left as the numeral 1, not Suc 0
+       (otherwise downstream numeral/Suc unification in the validity proof fails). *)
+    val ctxt' = ctxt delsimps @{thms One_nat_def}
   in
-    Simplifier.simplify ctxt inst
+    Simplifier.simplify ctxt' inst
   end
 
 (* The word codec name and width for an integer width W (in bits). *)
@@ -68,6 +70,8 @@ fun field_info _ "u16"  = { hol_ty = "16 word",  codec = "word16_byte_list_prism
                             fw_thm = @{thm fixed_width_word16_le} }
   | field_info _ "u32"  = { hol_ty = "32 word",  codec = "word32_byte_list_prism_le",
                             fw_thm = @{thm fixed_width_word32_le} }
+  | field_info _ "i32"  = { hol_ty = "32 word",  codec = "word32_byte_list_prism_le",
+                            fw_thm = @{thm fixed_width_word32_le} }  (* i32: same 4 bytes as u32 *)
   | field_info _ "u64"  = { hol_ty = "64 word",  codec = "word64_byte_list_prism_le",
                             fw_thm = @{thm fixed_width_word64_le} }
   | field_info _ "u128" = { hol_ty = "128 word", codec = "word128_byte_list_prism_le",
@@ -103,16 +107,22 @@ fun field_info _ "u16"  = { hol_ty = "16 word",  codec = "word16_byte_list_prism
                   fw_thm = @{thm fixed_width_single_byte}
                              OF [Proof_Context.get_thm ctxt (ty ^ "_byte_prism_valid")] }))
 
+(* A nat literal may appear as a numeral, as 0, or as Suc (...) (e.g. simp leaves
+   `Suc 0` for length 1).  Extract its value robustly. *)
+fun dest_nat \<^Const_>\<open>Groups.zero _\<close> = 0
+  | dest_nat \<^Const_>\<open>Suc for m\<close> = dest_nat m + 1
+  | dest_nat t = snd (HOLogic.dest_number t)
+
 (* Read the width <n> out of a `fixed_width_prism <n> <codec>` theorem. *)
 fun width_of_fw_thm thm =
   case HOLogic.dest_Trueprop (Thm.concl_of thm) of
-    \<^Const_>\<open>fixed_width_prism _\<close> $ n $ _ => snd (HOLogic.dest_number n)
+    \<^Const_>\<open>fixed_width_prism _\<close> $ n $ _ => dest_nat n
   | _ => error "define_byte_record: malformed fixed_width theorem"
 
 fun define_byte_record typ_binding (fields : (binding * string) list) lthy =
   let
-    val _ = if length fields < 2
-            then error "define_byte_record: need at least two fields" else ()
+    val _ = if null fields
+            then error "define_byte_record: need at least one field" else ()
     val typ_name = Binding.name_of typ_binding
     val field_binds = map fst fields
     val field_tys = map snd fields
@@ -147,10 +157,16 @@ fun define_byte_record typ_binding (fields : (binding * string) list) lthy =
     val field_name_strs = map Binding.name_of field_binds
     val n = length fields
     val xs = map (fn i => "x" ^ string_of_int i) (0 upto n - 1)
+    (* For a single field the tuple degenerates to a bare value: the iso is
+       (\<lambda>x0. make_T x0) / (\<lambda>r. f0 r); otherwise it pairs the fields. *)
     val forward_str =
-      "\<lambda>(" ^ space_implode ", " xs ^ "). make_" ^ typ_name ^ " " ^ space_implode " " xs
+      if n = 1
+      then "\<lambda>x0. make_" ^ typ_name ^ " x0"
+      else "\<lambda>(" ^ space_implode ", " xs ^ "). make_" ^ typ_name ^ " " ^ space_implode " " xs
     val backward_str =
-      "\<lambda>r. (" ^ space_implode ", " (map (fn f => f ^ " r") field_name_strs) ^ ")"
+      if n = 1
+      then "\<lambda>r. " ^ hd field_name_strs ^ " r"
+      else "\<lambda>r. (" ^ space_implode ", " (map (fn f => f ^ " r") field_name_strs) ^ ")"
 
     val prism_str =
       "prism_compose (" ^ tuple_prism_str ^ ") (iso_prism (" ^ forward_str ^ ") (" ^ backward_str ^ "))"


### PR DESCRIPTION
## Byte_Level_Encoding: bool/array/enum encodings + define_byte_enum/define_byte_record

### Motivation

Building serializers for real fixed-layout binary formats on top of `Byte_Level_Encoding` runs into two gaps.

**1. Missing leaf types.** The `Byte_Level_Encoding` library currently provides byte encodings for `u16`/`u32`/`u64`/`u128` (`Byte_Encoding_Word_Nat.thy`) and for `Option<NonNull>` (`Niche_Encoding_Option_NonNull.thy`). It has no encoding for the other primitive field types a fixed-layout struct uses: `bool`, `u8`, fixed-length arrays `[T; N]`, and enumerations `enum`.

**2. No automation.** Even with the leaf types, each struct is serialized by hand: declare the record type, build its byte encoding field by field, and prove the round-trip law. For a struct such as
```rust
struct Header { tag: u32, flag: bool, len: u8, pad: [u8; 6] }
```
that is ~30 lines, repeated for every struct in a format.

### Solution

In this PR, we provide support for:

**1. Single-byte leaf types: `bool`, `u8`, enums.** `Byte_Encoding_Bool.thy` provides `bool_byte_prism`; `Byte_Encoding_Enum.thy` provides `enum_byte_prism`, turning a discriminant assignment into a one-byte enum prism. Both are trivial: one byte, no endianness, no length.

**2. Array leaf type: `[T; N]`.** `Byte_Encoding_Array.thy` provides `array_byte_prism w p`, a prism `(byte list, ('e, 'l) array)` built from an element prism `p` of width `w`:

```isabelle
array_byte_prism :: nat ⇒ (byte list, 'e) prism ⇒ (byte list, ('e, 'l::len) array) prism
```

Its round-trip law is proved by induction on the array length. 

**3. Automated Declaration.** A fixed-layout format is built from two kinds of declaration — enumerations and records — so we add one command for each. Both take a one-line declaration and generate, automatically, the type definition, its field-by-field encoding, and the round-trip (prism validity) proof.

`define_byte_enum T = C0: d0 | C1: d1 | ...` (`Byte_Encoding_Enum.thy`) defines an enum `T` with one constructor per `Ci` and discriminant byte `di`, and provides:

- the enum type `T`;
- the discriminant functions `T_to_byte` / `T_from_byte`;
- the prism `T_byte_prism`;
- its validity `T_byte_prism_valid`.

`define_byte_record T = f0: ty0 | f1: ty1 | ...` (`Byte_Encoding_Record.thy`) defines a record `T` with one field `fi` of type `tyi` per entry, laid out in order, and provides:

- the `datatype_record` type `T`;
- the prism `T_byte_prism`;
- its validity `T_byte_prism_valid`;

A field type may be `u8/16/32/64/128`, `bool`, a pad `[u8; N]`, a word array `[uW; N]`, an enum, or a nested record.


### Note: why not built on the combinators?

**This PR** provides an `array_byte_prism`, a universal prism for a word array `[uW:N](uW:u8/16/.../128)`, and proves its validity once by induction on `N`, as the lemma `array_byte_prism_valid`. The benefit is that when declaring an array field `[uW,N]`, it can directly get its validity (round-trip) proof by instantiating this single lemma. The proof size is O(1), shared across all `uW` and all possible `N`. 

**The alternative** leverages the `focus_parser` combinators, as we discussed. However, the combinator encodes `N` in the type as `uW x ... x uW`, so no single validity proof can cover arbitrary `uW` and `N`. Instead, since each declared array `[uW:N_i]` has a concrete length `N_i`, we need to provide a concrete `N_i`-length composed proof per declaration, whose size grows with `N_i`. 

We chose the former: one induction proof, reused by every array field as an O(1) instantiation. I am also happy to discuss this further if you would prefer `define_byte_record` built on the existing combinators.


### Future Work

- Support `Option<NonNull>` (niche) as a field type.
- Support user-specified prisms as field types.
- Runtime performance profiling of the exported code.



