### PR TITLE
IC2: Show most recently updated theories during status check

### DIFF
--- a/ic2/src/client.scala
+++ b/ic2/src/client.scala
@@ -28,7 +28,7 @@ import java.nio.file.Paths
 object Client {
 
   /** How many active progress bars the ANSI UI shows at once. */
-  private val MAX_ACTIVE_BARS: Int = 8
+  private val MAX_ACTIVE_BARS: Int = 20
 
   /** Default threshold (seconds) for the long-running-command list under each
    *  bar. Overridable per-invocation with `check --long-running SECS`. */
@@ -484,6 +484,8 @@ Usage: isabelle ic2 $cmd [-n NAME] [-c N]
         warned = JSON.int(t, "warned").getOrElse(0),
         failed = JSON.int(t, "failed").getOrElse(0),
         consolidated = JSON.bool(t, "consolidated").getOrElse(false),
+        updated = JSON.long(t, "update_seq")
+          .orElse(JSON.int(t, "update_seq").map(_.toLong)).getOrElse(0L),
         long_running = long_running)
     }
 
@@ -1361,6 +1363,10 @@ Usage: isabelle ic2 server attach [OPTIONS]
     warned: Int,
     failed: Int,
     consolidated: Boolean,
+    /** Server-side monotonic "last updated" stamp (0 if the server didn't
+      * report one). The display sorts shown theories by this so it tracks
+      * where the check is actively working. */
+    updated: Long = 0L,
     long_running: List[Running_Command] = Nil
   ) {
     /** "Done" for display purposes: every command has completed, so the
@@ -1434,8 +1440,11 @@ Usage: isabelle ic2 server attach [OPTIONS]
       f"  $finished%d/$total%d done   running=$total_running%d   unprocessed=$total_unproc%d" +
       (if (total_failed > 0) f"   FAILED=$total_failed%d" else "")
 
-    // In-flight theories first (most complete first), bounded to max_rows.
-    val active = nodes.filter(n => !n.done).sortBy(n => -n.percentage)
+    // In-flight theories, most-recently-updated first (alphabetical tiebreak
+    // among same-tick updates), bounded to max_rows. This is a one-shot frame
+    // with no cross-tick state, so it can't do the live UI's sticky ordering —
+    // it just shows the current last-updated bucket.
+    val active = nodes.filter(n => !n.done).sortBy(n => (-n.updated, n.theory))
     val shown = active.take(max_rows)
     val name_w = (term_width - 50).max(20).min(60)
     val rows = shown.flatMap { n =>
@@ -1455,14 +1464,15 @@ Usage: isabelle ic2 server attach [OPTIONS]
    *  running longer than `long_running_secs` are printed indented under the
    *  progress line for their theory. */
   class Plain_UI(
-    max_active: Int = 3,
+    max_active: Int = 20,
     long_running_secs: Double = DEFAULT_LONG_RUNNING_SECS
   ) extends Progress_UI {
     def started(theories: List[String]): Unit =
       Output.writeln("checking " + theories.length + " theory/theories: " +
         theories.mkString(", "))
     def progress(nodes: List[Theory_Status]): Unit = {
-      val active = nodes.filter(n => !n.done).sortBy(n => -n.percentage)
+      // Most-recently-updated first, alphabetical tiebreak among same-tick.
+      val active = nodes.filter(n => !n.done).sortBy(n => (-n.updated, n.theory))
       val (done, total) = (nodes.count(_.done), nodes.length)
       val shown = active.take(max_active)
       Output.writeln(s"[$done/$total done] " + shown.map(n =>
@@ -1478,11 +1488,17 @@ Usage: isabelle ic2 server attach [OPTIONS]
     def close(): Unit = ()
   }
 
-  /** ANSI live UI: shows the N in-flight theories with the highest processing
-   *  percentage, repainted in place. Consolidated theories drop off the list
-   *  but are still counted in the header. Under each theory's bar, commands
-   *  running longer than `long_running_secs` are listed indented, longest
-   *  elapsed first. */
+  /** ANSI live UI: shows the N in-flight theories the check most recently
+   *  worked on, repainted in place. Consolidated theories drop off the list but
+   *  are still counted in the header. Under each theory's bar, commands running
+   *  longer than `long_running_secs` are listed indented, longest elapsed first.
+   *
+   *  The shown set is kept STABLE across ticks to avoid flicker: the bucket of
+   *  the N most-recently-updated in-flight theories is computed each tick, but
+   *  their on-screen order is preserved — survivors keep their previous slots,
+   *  theories that fell out of the bucket are removed, and freshly-entering
+   *  theories are added at the top. So a run touching a steady set of <N
+   *  theories does not reshuffle them every tick (see `stable_order`). */
   class ANSI_UI(
     max_active: Int,
     out: PrintStream = System.out,
@@ -1496,6 +1512,11 @@ Usage: isabelle ic2 server attach [OPTIONS]
     /** for each theory we've ever seen: last known status. */
     private val last_state =
       scala.collection.mutable.Map.empty[String, Theory_Status]
+
+    /** Theory names currently on screen, in display order — carried across
+      * ticks so the shown set only changes at the edges (drop-outs removed,
+      * newcomers prepended) rather than being re-sorted every repaint. */
+    private var displayed: List[String] = Nil
 
     private val width: Int = term_width
 
@@ -1536,12 +1557,20 @@ Usage: isabelle ic2 server attach [OPTIONS]
       out.println(header)
       lines_drawn = 1
 
-      val active =
-        last_state.values.iterator
-          .filter(!_.done)
-          .toList
-          .sortBy(-_.percentage)
-          .take(max_active)
+      // The bucket: the N in-flight theories the check most recently touched
+      // (highest update stamp; alphabetical tiebreak among same-tick updates).
+      val inflight = last_state.values.iterator.filter(!_.done).toList
+      val bucket =
+        inflight.sortBy(n => (-n.updated, n.theory)).take(max_active).map(_.theory)
+      // Keep the display STABLE: survivors stay in their old relative order,
+      // drop-outs are removed, and theories new to the bucket are prepended
+      // (most-recently-updated first). This is (a)+(b)+(c) from the spec.
+      val bucketSet = bucket.toSet
+      val survivors = displayed.filter(bucketSet.contains)
+      val survivorSet = survivors.toSet
+      val newcomers = bucket.filterNot(survivorSet.contains)
+      displayed = newcomers ::: survivors
+      val active = displayed.flatMap(last_state.get)
 
       val name_w = (width - 50).max(20).min(60)
       for (n <- active) {

--- a/ic2/src/daemon.scala
+++ b/ic2/src/daemon.scala
@@ -866,10 +866,10 @@ Usage: isabelle ic2 server start [OPTIONS]
     private def wireEvent(io: JSON_IO)(e: Check.Event): Unit = e match {
       case Check.Event.Started(theories) =>
         io.write(JSON.Object("event" -> "started", "theories" -> theories))
-      case Check.Event.Progress(nodes, runningCommands) =>
+      case Check.Event.Progress(nodes, runningCommands, updateSeqs) =>
         io.write(JSON.Object("event" -> "progress",
           "nodes" -> nodes.map { case (n, st) =>
-            Check.nodeStatusJson(n, st, runningCommands.getOrElse(n, Nil)) }))
+            Check.nodeStatusJson(n, st, runningCommands.getOrElse(n, Nil), updateSeqs.getOrElse(n, 0L)) }))
       case Check.Event.Error(theory, file, line, message) =>
         io.write(JSON.Object("event" -> "error", "theory" -> theory) ++
           file.map(f => JSON.Object("file" -> f)).getOrElse(JSON.Object()) ++

--- a/ic2/src/iq.scala
+++ b/ic2/src/iq.scala
@@ -196,7 +196,8 @@ object Check {
   def nodeStatusJson(
     name: Document.Node.Name,
     st: Document_Status.Node_Status,
-    runningCommands: List[RunningCommand] = Nil
+    runningCommands: List[RunningCommand] = Nil,
+    updateSeq: Long = 0L
   ): JSON.Object.T = {
     val base = JSON.Object(
       "theory" -> name.theory,
@@ -208,6 +209,9 @@ object Check {
       "finished" -> st.finished,
       "warned" -> st.warned,
       "failed" -> st.failed,
+      // Monotonic "last updated" stamp (0 if unknown); the client sorts the
+      // shown theories by this so the display tracks recent activity.
+      "update_seq" -> updateSeq,
       "consolidated" -> st.consolidated)
     if (runningCommands.isEmpty) base
     else base ++ JSON.Object("long_running" -> runningCommands.map { rc =>
@@ -246,7 +250,8 @@ object Check {
       * running commands (with elapsed time), for indented rendering under bars. */
     final case class Progress(
       nodes: List[(Document.Node.Name, Document_Status.Node_Status)],
-      runningCommands: Map[Document.Node.Name, List[RunningCommand]] = Map.empty
+      runningCommands: Map[Document.Node.Name, List[RunningCommand]] = Map.empty,
+      updateSeqs: Map[Document.Node.Name, Long] = Map.empty
     ) extends Event
     final case class Error(theory: String, file: Option[String], line: Option[Int], message: String) extends Event
     final case class Finished(ok: Boolean, reason: String) extends Event
@@ -269,6 +274,15 @@ object Check {
   private final class Job_Progress(job: Job, session: Headless.Session) extends Progress {
     private val per_theory =
       Synchronized(Map.empty[Document.Node.Name, Document_Status.Node_Status])
+    // Per-node "last updated" stamp: a monotonic sequence bumped each time a
+    // node's status actually changes, so the client can show the theories the
+    // check most recently touched (where work is happening) rather than the
+    // most-progressed ones. Not wall-clock — a sequence keeps it deterministic
+    // and cheap, and only relative order matters to the display.
+    private val update_seq =
+      Synchronized(Map.empty[Document.Node.Name, Long])
+    private val seq_counter = new java.util.concurrent.atomic.AtomicLong(0L)
+    def updateSeqOf(name: Document.Node.Name): Long = update_seq.value.getOrElse(name, 0L)
     private val error_latch = Synchronized(false)
     private val last_emit = Synchronized[Option[Long]](None)
     private val emit_interval_ms: Long = 200
@@ -315,7 +329,7 @@ object Check {
               if (cur.nonEmpty) {
                 val running = snapshotRunning(cur)
                 if (running.nonEmpty)
-                  job.fan(Event.Progress(cur.toList.sortBy(_._1.theory), running))
+                  job.fan(Event.Progress(cur.toList.sortBy(_._1.theory), running, update_seq.value))
               }
             } catch { case _: Throwable => }
             try Thread.sleep(tick_interval_ms) catch { case _: InterruptedException => return }
@@ -351,7 +365,16 @@ object Check {
       check_partial_reached()
       val updated = per_theory.change_result { cache =>
         var c = cache
-        for (name <- ns.domain) { val st = ns(name); if (!st.is_empty) c = c + (name -> st) }
+        for (name <- ns.domain) {
+          val st = ns(name)
+          // Bump the node's update stamp only when its status actually changed,
+          // so an unchanged node re-reported on a quiet tick keeps its place
+          // rather than churning to the top of the last-updated list.
+          if (!st.is_empty && !cache.get(name).contains(st)) {
+            c = c + (name -> st)
+            update_seq.change(_ + (name -> seq_counter.incrementAndGet()))
+          }
+        }
         (c, c)
       }
       updated.find { case (_, st) => st.failed > 0 } match {
@@ -369,7 +392,7 @@ object Check {
             case _ => (true, Some(now))
           }
           if (emit)
-            job.fan(Event.Progress(updated.toList.sortBy(_._1.theory), snapshotRunning(updated)))
+            job.fan(Event.Progress(updated.toList.sortBy(_._1.theory), snapshotRunning(updated), update_seq.value))
       }
     }
 
@@ -377,7 +400,7 @@ object Check {
       * remain here (the run has settled), so `runningCommands` is empty. */
     def flush_final(): Unit = {
       val cur = per_theory.value
-      if (cur.nonEmpty) job.fan(Event.Progress(cur.toList.sortBy(_._1.theory)))
+      if (cur.nonEmpty) job.fan(Event.Progress(cur.toList.sortBy(_._1.theory), Map.empty, update_seq.value))
     }
 
     /** Post-result fallback: result is failure but the live callback never saw
@@ -703,7 +726,7 @@ object Check {
         "theories" -> theories,
         "elapsed_ms" -> elapsedMs,
         "nodes" -> progress.snapshot_status.toList.sortBy(_._1.theory)
-          .map { case (n, s) => nodeStatusJson(n, s) }) ++
+          .map { case (n, s) => nodeStatusJson(n, s, Nil, progress.updateSeqOf(n)) }) ++
       (st match { case Outcome.Failed(r) if r.nonEmpty => JSON.Object("reason" -> r); case _ => JSON.Object() })
     }
   }
@@ -1069,7 +1092,7 @@ object IQ {
     def processed(nodes: List[(Document.Node.Name, Document_Status.Node_Status)]): Int =
       math.min(nodes.count { case (n, st) => job.nodeNames.contains(n) && st.consolidated }, total)
     job.subscribe {
-      case Check.Event.Progress(nodes, _) => sink(progressDict(processed(nodes), total))
+      case Check.Event.Progress(nodes, _, _) => sink(progressDict(processed(nodes), total))
       case Check.Event.Finished(ok, _) => sink(progressDict(if (ok) total else 0, total))
       case _ =>
     }

--- a/ic2/src/test_tool.scala
+++ b/ic2/src/test_tool.scala
@@ -1684,19 +1684,21 @@ Usage: isabelle ic2_test [OPTIONS] MODE [DIR]
      *  the transition/fork offset collision. */
     private def e2e_progress_display_changes(server_name: String, fixtures: Path): Unit = {
       // (a) rendered order: three in-flight theories in a MIXED input order —
-      // the rendered frame must list them by descending percentage.
+      // the rendered frame must list them by descending last-updated stamp
+      // (not by percentage), so the display tracks where the check is
+      // actively working.
       val nodes = List(
-        Client.Theory_Status("A", 10, 5, 1, 0, 0, 0, false),
-        Client.Theory_Status("B", 60, 0, 2, 8, 0, 0, false),
-        Client.Theory_Status("C", 40, 3, 1, 4, 0, 0, false))
+        Client.Theory_Status("A", 10, 5, 1, 0, 0, 0, false, updated = 3),
+        Client.Theory_Status("B", 60, 0, 2, 8, 0, 0, false, updated = 1),
+        Client.Theory_Status("C", 40, 3, 1, 4, 0, 0, false, updated = 2))
       val frame = Client.render_progress_frame(nodes, 8)
       // First distinct theory-name letters seen after the header, in order.
       val order = frame.tail.flatMap { line =>
         List("A", "B", "C").find(t => line.contains(t + " ") || line.contains(" " + t))
       }.distinct
-      if (order.take(3) != List("B", "C", "A"))
+      if (order.take(3) != List("A", "C", "B"))
         error("render_progress_frame should sort in-flight theories by " +
-          "descending percentage; expected [B, C, A], got " +
+          "descending last-updated stamp; expected [A, C, B], got " +
           order.take(3).mkString(", ") + " in frame:\n" + frame.mkString("\n"))
 
       // (b) end-to-end: at least one `by` command from SpinTactic.thy should

--- a/ir/ir.ML
+++ b/ir/ir.ML
@@ -746,7 +746,7 @@ fun claims () =
       case entry of
         Claimed ci =>
           let val elapsed = Time.toReal (Time.- (now, #claimed_at ci))
-          in out (id ^ " [" ^ claim_op_str (#operation ci) ^ "] " ^
+          in out ("id=" ^ id ^ " [" ^ claim_op_str (#operation ci) ^ "] " ^
                   Real.fmt (StringCvt.FIX (SOME 1)) elapsed ^ "s")
           end
       | Repl _ => ()) tab ()

--- a/ir/repl_srv.py
+++ b/ir/repl_srv.py
@@ -1615,7 +1615,7 @@ class Server:
                             claims_block = (
                                 "\n\nList of current REPLs claimed by a "
                                 "communication channel:\n"
-                                + "\n".join(f"  {ln}"
+                                + "\n".join(f"  * {ln}"
                                             for ln in claims_txt.splitlines())
                                 + "\nUse `interrupt <repl_id>` to interrupt "
                                   "and potentially free a channel.")


### PR DESCRIPTION
```
The check progress display sorted shown theories by highest processing
percentage. Reorder by a server-stamped "last updated" sequence so the
display tracks where the check is actively working, raise the default
bar count 8 -> 20, and keep the live ANSI set stable across ticks
(drop-outs removed keeping relative order, newcomers prepended) so a
steady set of theories no longer reshuffles every repaint.
```