### PR TITLE
ic2: server status shows cwd, start time, last activity; sort by last

### DIFF
--- a/ic2/src/client.scala
+++ b/ic2/src/client.scala
@@ -935,6 +935,7 @@ Usage: isabelle ic2 server status [OPTIONS]
       case Some(st) =>
         Output.writeln(format_status(name, st))
         Output.writeln(format_options(st))
+        Output.writeln(format_where(st))
         Output.writeln(format_ir(st))
         if (full) print_full_nodes(name, st)
         sys.exit(0)
@@ -1040,21 +1041,32 @@ Usage: isabelle ic2 server status [OPTIONS]
     }
   }
 
-  /** Every server with a socket node: ping each (summary line + I/R line).
-   *  Informational — always exits 0, even with stale nodes present. */
+  /** Every server with a socket node: ping each (summary line + where line +
+   *  I/R line). Live servers are ordered by most-recent activity first (so a
+   *  stale server sinks to the bottom of the list, where its `last=…` age is
+   *  the reason it's there); stale-socket entries come after them, in name
+   *  order. Informational — always exits 0. */
   private def status_all(): Unit = {
     val names = Endpoint.list_names()
-    if (names.isEmpty)
+    if (names.isEmpty) {
       Output.writeln("no ic2 servers (looked in " + Endpoint.dir.expand.implode + ")")
-    else
-      for (n <- names) {
-        Daemon.ping_status(n) match {
-          case Some(st) =>
-            Output.writeln(format_status(n, st))
-            Output.writeln(format_ir(st))
-          case None => Output.writeln(n + ": stale socket (no server listening)")
-        }
-      }
+      sys.exit(0)
+    }
+    val pinged = names.map(n => n -> Daemon.ping_status(n))
+    val live: List[(String, JSON.T)] =
+      pinged.collect { case (n, Some(st)) => (n, st) }
+    val stale: List[String] = pinged.collect { case (n, None) => n }
+    // Most-recently-active first; ties (and servers that never reported the
+    // field) fall back to name order so the display is stable.
+    val ordered = live.sortBy { case (n, st) =>
+      (-JSON.long(st, "last_activity_ms").getOrElse(0L), n)
+    }
+    for ((n, st) <- ordered) {
+      Output.writeln(format_status(n, st))
+      Output.writeln(format_where(st))
+      Output.writeln(format_ir(st))
+    }
+    for (n <- stale) Output.writeln(n + ": stale socket (no server listening)")
     sys.exit(0)
   }
 
@@ -1112,6 +1124,41 @@ Usage: isabelle ic2 server status [OPTIONS]
       (if (no_build) List("no_build") else Nil) :::
       (if (no_iq) List("no_iq") else Nil)
     "    started with: " + parts.mkString("  ")
+  }
+
+  /** Third status line: where + when the server was started, and when it last
+   *  saw a real (non-status/shutdown) client op. Two absolute timestamps plus
+   *  a relative age on `last` so a stale server is easy to spot at a glance.
+   *  Older servers may not report the three fields — each falls back to a "?"
+   *  or is elided so nothing crashes on a mixed-version fleet. */
+  private def format_where(st: JSON.T): String = {
+    val cwd = JSON.string(st, "cwd").getOrElse("?")
+    val started = JSON.long(st, "started_ms").map(format_wall).getOrElse("?")
+    val last_at = JSON.long(st, "last_activity_ms").map(format_wall).getOrElse("?")
+    val last_ago =
+      JSON.long(st, "last_activity_ms")
+        .map(t => " (" + format_age(System.currentTimeMillis() - t) + " ago)")
+        .getOrElse("")
+    "    cwd=" + cwd + "  started=" + started + "  last=" + last_at + last_ago
+  }
+
+  /** Render an epoch-ms as `YYYY-MM-DD HH:mm:ss` in the local timezone, so the
+   *  timestamp reads at a glance without a mental math round-trip through UTC. */
+  private def format_wall(ms: Long): String = {
+    val zdt = java.time.Instant.ofEpochMilli(ms)
+      .atZone(java.time.ZoneId.systemDefault)
+    zdt.format(java.time.format.DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss"))
+  }
+
+  /** A short human age for a millisecond delta: `5s` / `3m12s` / `2h05m` /
+   *  `4d03h`, sized to the largest unit that keeps two significant components.
+   *  Negative / zero deltas render as `0s`. */
+  private def format_age(delta_ms: Long): String = {
+    val s = (delta_ms.max(0L)) / 1000
+    if (s < 60) s + "s"
+    else if (s < 3600) f"${s / 60}%dm${s % 60}%02ds"
+    else if (s < 86400) f"${s / 3600}%dh${(s % 3600) / 60}%02dm"
+    else f"${s / 86400}%dd${(s % 86400) / 3600}%02dh"
   }
 
   /** I/R status lines, if I/R was brought up: the client-facing repl.py port/token

--- a/ic2/src/daemon.scala
+++ b/ic2/src/daemon.scala
@@ -399,7 +399,26 @@ Usage: isabelle ic2 server start [OPTIONS]
     val opts: Start_Options, val pid: Long, val build: Build_Status
   ) {
     private val start_ms: Long = System.currentTimeMillis()
+    /** Working directory of the server process at start — reported by `status`
+     *  so a user staring at several servers can tell which is which. Captured
+     *  eagerly so it reflects the launch environment even if `user.dir` mutates
+     *  later. */
+    private val cwd: String =
+      try new java.io.File(".").getCanonicalPath
+      catch { case _: Throwable =>
+        val ud = System.getProperty("user.dir"); if (ud == null) "?" else ud
+      }
+    /** Wall-clock of the last real client interaction (any op other than
+     *  status/shutdown probes). Used by `ic2 server status` to spot stale
+     *  servers. Initialised to start_ms so a freshly-started server that has
+     *  never been touched still reads as "recent" until the first status poll. */
+    private val last_activity_ms = new AtomicLong(start_ms)
     val active_connections = new AtomicLong(0L)
+
+    /** Note that the server was just interfaced with (called for every non-poll
+     *  op). status/shutdown are deliberately NOT counted so that a monitor
+     *  polling `status` doesn't mask an otherwise idle server. */
+    def note_activity(): Unit = last_activity_ms.set(System.currentTimeMillis())
 
     // Filled in when the bring-up worker completes each stage. Volatile: written
     // by the worker thread, read by connection-handler threads.
@@ -435,6 +454,13 @@ Usage: isabelle ic2 server start [OPTIONS]
         "state" -> build.phase_token,
         "pid" -> pid,
         "uptime_s" -> uptime_s,
+        // Absolute wall-clock (ms since the epoch) of server start and of the
+        // last real client interaction, plus the server's CWD at launch. Reported
+        // as ms rather than pre-formatted strings so the client controls locale
+        // / timezone / relative rendering.
+        "started_ms" -> start_ms,
+        "last_activity_ms" -> last_activity_ms.get,
+        "cwd" -> cwd,
         "busy" -> Check.busy,
         "checks_in_flight" -> (if (Check.busy) 1 else 0),
         // Active connections include the one issuing this status query.
@@ -767,6 +793,7 @@ Usage: isabelle ic2 server start [OPTIONS]
             case Some(t) =>
               JSON.string(t, "op") match {
                 case Some("check") =>
+                  state.note_activity()
                   val files = JSON.strings(t, "files").getOrElse(Nil)
                   val detach = JSON.bool(t, "detach").getOrElse(false)
                   val line = JSON.int(t, "line")
@@ -783,29 +810,38 @@ Usage: isabelle ic2 server start [OPTIONS]
                     case None => fail_check(io, not_ready_msg)
                   }
                 case Some("check_status") =>
+                  state.note_activity()
                   vlog("op=check_status")
                   io.write(check_status_reply())
                 case Some("check_attach") =>
+                  state.note_activity()
                   vlog("op=check_attach")
                   check_attach(io)
                 case Some("check_cancel") =>
+                  state.note_activity()
                   vlog("op=check_cancel")
                   io.write(check_cancel_reply())
                 case Some("query") =>
+                  state.note_activity()
                   vlog("op=query tool=" + JSON.string(t, "tool").getOrElse("<missing>"))
                   with_session(io) { (session, _) => io.write(query_reply(session, t)) }
                 case Some("repl") =>
+                  state.note_activity()
                   vlog("op=repl")
                   with_session(io) { (session, _) => io.write(repl_reply(session, t)) }
                 case Some("load-files") =>
+                  state.note_activity()
                   val files = JSON.strings(t, "files").getOrElse(Nil)
                   vlog("op=load-files: " + files.length + " file(s): " + files.mkString(", "))
                   with_session(io) { (session, resources) =>
                     io.write(load_files_reply(session, resources, files)) }
                 case Some("status") =>
+                  // Deliberately NOT counted as activity: a monitor polling
+                  // `status` shouldn't hide an otherwise idle server.
                   vlog("op=status")
                   io.write(state.status_json)
                 case Some("shutdown") =>
+                  // Also not counted: shutdown is the end of activity, not a use.
                   vlog("op=shutdown")
                   io.write(JSON.Object("event" -> "shutting_down"))
                   done = true


### PR DESCRIPTION
Adds three fields to the status wire reply (cwd, started_ms, last_activity_ms), and a third `cwd=... started=... last=... (Ns ago)` line to the `ic2 server status` output. `last_activity_ms` bumps on every real client op; the status and shutdown ops are deliberately excluded so a polling monitor doesn't mask an idle server. `server status` without -n now orders live servers by most-recent activity first, so a stale one sinks to the bottom next to its `last=…` age.