### PR TITLE
ic2: server status — prominent readiness state; ready == activity

### DIFF
--- a/ic2/src/client.scala
+++ b/ic2/src/client.scala
@@ -1082,13 +1082,15 @@ Usage: isabelle ic2 server status [OPTIONS]
     // A server that isn't yet "ready" is still coming up (heap build / session
     // load) or failed: report the phase + a one-line build readout instead of
     // the idle/busy activity, so a client polling during a cold build sees it.
+    // The phase is emitted as `state=…` first thing after the name, so a
+    // reader scanning for readiness never has to hunt for it.
     val state = JSON.string(st, "state").getOrElse("ready")
     val activity =
-      if (state != "ready") state + format_build(st)
+      if (state != "ready") "STARTING UP" + format_build(st)
       else if (busy) "busy(" + cif + " check" + (if (cif == 1) "" else "s") + ")"
       else "idle"
-    name + ": session=" + session + " pid=" + pid + " up=" + up + "s " +
-      activity + " conns=" + conns
+    name + ": state=" + state + " session=" + session + " pid=" + pid +
+      " up=" + up + "s " + activity + " conns=" + conns
   }
 
   /** The compact build readout appended while a server is not yet ready: the

--- a/ic2/src/daemon.scala
+++ b/ic2/src/daemon.scala
@@ -675,7 +675,15 @@ Usage: isabelle ic2 server start [OPTIONS]
                   case None => state.bind_ir(None, None)
                 }
               }
-              if (live) { build_status.set_phase(Phase.Ready); progress.echo("Ready.") }
+              if (live) {
+                build_status.set_phase(Phase.Ready)
+                // Count reaching Ready as an activity so `last=` doesn't
+                // display the whole heap-build wall-clock as "inactivity" the
+                // moment the server first becomes usable — until a real op
+                // arrives, "last" is the readiness transition, not launch.
+                state.note_activity()
+                progress.echo("Ready.")
+              }
             }
           }
         }


### PR DESCRIPTION
Two related tweaks to `ic2 server status`:

  1. Emit `state=<phase>` as the first field on the summary line, and render the activity slot as `STARTING UP(...)` (in caps) whenever the server isn't yet Ready. Previously the phase was tucked into the activity slot and easy to miss, so a still-building server looked much like an idle one.

  2. When the bring-up worker sets Phase.Ready, bump the last-activity stamp. Otherwise a server that spent an hour building a heap and then sat unused for a minute would report `last=<launch> (1h1m ago)`, misrepresenting the whole heap build as inactivity. Now "last" points at the readiness transition until a real op arrives.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
