### PR TITLE
Preserve IC2 state across theory edits

### DIFF
--- a/THIRD_PARTY
+++ b/THIRD_PARTY
@@ -1,15 +1,16 @@
 
 The files `crush/mepo_prem.ML`, `Misc/Data_Structures/BraunTrees.thy`,
-`iq/Isar_Explore.thy`, and `iq/src/Extended_Query_Operation.scala`
-contain derivatives of Isabelle source files. These files are licensed
-under the terms of the Isabelle Copyright Notice, reproduced below.
+`ic2/src/ic2_use_theories.scala`, `iq/Isar_Explore.thy`, and
+`iq/src/Extended_Query_Operation.scala` contain derivatives of Isabelle source
+files. These files are licensed under the terms of the Isabelle Copyright
+Notice, reproduced below.
 
 License notice for Isabelle
 ------------------------------------------------------------------------
 
 ISABELLE COPYRIGHT NOTICE, LICENCE AND DISCLAIMER.
 
-Copyright (c) 1986-2025,
+Copyright (c) 1986-2026,
   University of Cambridge,
   Technische Universitaet Muenchen,
   and contributors.

--- a/ic2/README.md
+++ b/ic2/README.md
@@ -13,8 +13,6 @@ run side by side, with no host/port/token to configure):
   * **`ic2 check FILE...`** — type-check `.thy` files, with live progress and a
     scriptable exit code.
   * **`ic2 query SUBTOOL FILE`** — read-only diagnostics over the session.
-  * **`ic2 load-files FILE...`** — parse theories into the graph without
-    evaluating, so structural queries work at near-zero cost.
   * **`ic2 repl-create FILE:LINE NAME`** — fork an interactive I/R REPL at a
     source location.
 
@@ -143,19 +141,7 @@ $ isabelle ic2 query diagnostics Foo.thy --json | jq .      # raw payload
 The selection tools take one of `--offset N` / `--line N` / `--pattern P` to
 point at a command; `--line N` resolves to the command ending on or before that
 line (as jEdit does). The FILE must be a loaded session node — check it
-(`ic2 check`) or parse it (`ic2 load-files`) first.
-
-## `ic2 load-files`
-
-Parses `.thy` files into the document graph **without evaluating any commands** —
-no ML runs, no proof state. The structural `query` subtools then work on the
-loaded nodes at near-zero cost, and a later `ic2 check` pays only the evaluation
-cost, not the parse cost.
-
-```bash
-isabelle ic2 load-files Foo.thy Bar.thy
-isabelle ic2 load-files Foo.thy --print   # also dump each node's parsed spans
-```
+(`ic2 check`) first.
 
 ## `ic2 repl-create`
 
@@ -231,7 +217,7 @@ With `--mcp` (opt-in, off by default), the server also stands up a generic
     I/Q exposes;
   * **session diagnostic tools** — `list_files`, `get_diagnostics`,
     `get_sorry_positions`, `get_entities`, `get_proof_blocks`,
-    `get_command_info`, `get_state_at`, `load_files`, `status`, etc. These read
+    `get_command_info`, `get_state_at`, `status`, etc. These read
     only the document snapshot (base PIDE, no jEdit), so the identical code
     serves ic2's headless session and I/Q's live PIDE session — the `query` CLI
     routes through the same dispatch;
@@ -328,7 +314,7 @@ src/ic2.scala       — the `isabelle ic2` front door (subcommand dispatch)
 src/daemon.scala    — `ic2 server start`: daemon, --daemon launch, status op
 src/iq.scala        — I/R + MCP bring-up (IRLauncher, McpServer + tools) and the
                       single-slot Check model (Job, cancel/reset, --line worker)
-src/client.scala    — check / query / load-files / server / repl-create + UIs
+src/client.scala    — check / query / server / repl-create + UIs
 src/endpoint.scala  — socket-path discovery + the 0700 directory
 src/json_io.scala   — newline-delimited JSON over a socket channel
 src/test_tool.scala — `isabelle ic2_test` runner

--- a/ic2/etc/build.props
+++ b/ic2/etc/build.props
@@ -13,6 +13,7 @@ sources = \
   src/SessionClient.scala \
   src/json_io.scala \
   src/endpoint.scala \
+  src/ic2_use_theories.scala \
   src/iq.scala \
   src/daemon.scala \
   src/client.scala \

--- a/ic2/src/client.scala
+++ b/ic2/src/client.scala
@@ -490,106 +490,6 @@ Usage: isabelle ic2 $cmd [-n NAME] [-c N]
     }
 
 
-  /* ========================== load-files =========================== */
-
-  private val load_files_usage_text: String = """
-Usage: isabelle ic2 load-files [OPTIONS] FILE...
-
-  Options are:
-    -n NAME             server name (default: the sole running server)
-    --print             after loading, print the parsed command spans of
-                        each loaded node (line, offset range, keyword,
-                        source) — same output as `ic2 query spans FILE`
-    --include-ignored   with --print, include inter-command whitespace/
-                        comment spans too (Ignored_Span)
-
-  Parse the given .thy files into the running server's document graph
-  WITHOUT evaluating any commands: the Scala side splits each theory into
-  its commands (fixing spans, IDs, offsets, line positions), but no ML
-  process runs and no proof state is produced. After loading:
-
-    - `ic2 query list-files` lists the newly-loaded nodes.
-    - `ic2 query entities|sorry|spans|proof-blocks|command-info|state-at`
-      work on the loaded nodes (with proof/status fields empty).
-
-  A subsequent `ic2 check` on the same files will pay only the evaluation
-  cost, not the parse cost. Header imports are checked (they must be
-  locatable in the session), but their bodies aren't evaluated either.
-
-  Exit codes: 0 (loaded); 1 (bad FILE: not .thy, or does not exist); 2 (usage:
-  no FILE, or --include-ignored without --print); 3 (server-side error, e.g.
-  header parse failed).
-"""
-
-  /** `ic2 load-files FILE...` — parse the given .thy files into the session's
-   *  document graph, without evaluating them. Same file-resolution shape as
-   *  `ic2 check`. With `--print`, follows up with a `list_spans` query for
-   *  every loaded node so the raw parse output is visible without a second
-   *  invocation. */
-  def load_files(args: List[String]): Unit = {
-    if (wants_help(args)) { Output.writeln(load_files_usage_text, stdout = true); sys.exit(2) }
-    var name: Option[String] = None
-    // `--print` and `--include-ignored` are long options (Getopts is single-
-    // letter only); strip them ourselves first.
-    val print_spans = args.contains("--print")
-    val include_ignored = args.contains("--include-ignored")
-    if (include_ignored && !print_spans) {
-      Output.error_message("load-files: --include-ignored requires --print")
-      sys.exit(2)
-    }
-    val rest_args = args.filterNot(a => a == "--print" || a == "--include-ignored")
-    val getopts = Getopts(load_files_usage_text,
-      "n:" -> (a => name = Some(a)))
-    val files = getopts(rest_args)
-    if (files.isEmpty) {
-      Output.error_message("load-files: at least one FILE required"); sys.exit(2)
-    }
-    // Same local validation as `check`: absolute .thy, exists.
-    val abs_files = files.map { f =>
-      if (!f.endsWith(".thy")) { Output.error_message("not a .thy file: " + f); sys.exit(1) }
-      val jfile = Path.explode(f).expand.absolute_file
-      if (!jfile.isFile) { Output.error_message("file not found: " + f); sys.exit(1) }
-      File.standard_path(jfile)
-    }
-    val server = resolve_name(name)
-    val reply = request(server, JSON.Object("op" -> "load-files", "files" -> abs_files))
-    JSON.string(reply, "event") match {
-      case Some("load-files") =>
-        val loaded = JSON.strings(reply, "loaded").getOrElse(Nil)
-        Output.writeln("loaded " + loaded.length + " theory node(s):")
-        for (n <- loaded) Output.writeln("  " + n, stdout = true)
-        if (print_spans) print_loaded_spans(server, loaded, include_ignored)
-        sys.exit(0)
-      case _ =>
-        Output.error_message(JSON.string(reply, "message").getOrElse("load-files failed: " + JSON.Format(reply)))
-        sys.exit(3)
-    }
-  }
-
-  /** After `load-files --print`: fetch and render the `list_spans` result for
-   *  each loaded node. Uses the SAME query pipeline `ic2 query spans` does —
-   *  the wire tool, param map, and human renderer — so its output stays
-   *  byte-identical between the two entry points. */
-  private def print_loaded_spans(
-    server: String, nodes: List[String], include_ignored: Boolean
-  ): Unit = {
-    for (node <- nodes) {
-      qout("")
-      val params: List[(String, JSON.T)] =
-        ("path" -> (node: JSON.T)) ::
-        (if (include_ignored) List(("include_ignored" -> (true: JSON.T))) else Nil)
-      val reply = request(server, JSON.Object(
-        (("op" -> "query") :: ("tool" -> "list_spans") :: params): _*))
-      JSON.value(reply, "result") match {
-        case Some(result) => render_query("spans", result)
-        case None =>
-          Output.error_message("load-files --print: " +
-            JSON.string(reply, "message").getOrElse("no result for " + node))
-      }
-    }
-  }
-
-
   /* ============================ query ============================= */
 
   private val QUERY_TOOLS: List[(String, String)] = List(
@@ -972,8 +872,8 @@ Usage: isabelle ic2 server status [OPTIONS]
 
     // Column-aligned node table: name, bar, %, and finished/failed/warned
     // tallies. `unprocessed` is carried too (as tuple position 8) so the
-    // heap-node filter below can distinguish a parse-only node (has commands
-    // to process) from a fully heap-resident node (nothing tracked).
+    // heap-node filter below can distinguish active document nodes from fully
+    // heap-resident nodes (nothing tracked).
     val allRows = files.map { f =>
       (JSON.string(f, "theory").orElse(JSON.string(f, "node")).getOrElse("?"),
        JSON.int(f, "percentage").getOrElse(0),
@@ -987,10 +887,6 @@ Usage: isabelle ic2 server status [OPTIONS]
     // Omit heap/library nodes: those already resident in the prebuilt heap
     // show up in the document graph but have no PIDE commands tracked in this
     // session — every counter is zero AND `unprocessed == 0` (nothing to do).
-    // A parse-only node loaded via `ic2 load-files` has the same zeros for
-    // finished/failed/warned/consolidated but `unprocessed > 0` (every command
-    // is tracked, none evaluated), so it survives the filter and shows up as
-    // a real (0%) row rather than being folded into the "heap omitted" count.
     val rows = allRows.filterNot { case (_, pct, fin, failed, warned, cons, _, unproc) =>
       pct == 0 && fin == 0 && failed == 0 && warned == 0 && !cons && unproc == 0
     }

--- a/ic2/src/daemon.scala
+++ b/ic2/src/daemon.scala
@@ -837,12 +837,6 @@ Usage: isabelle ic2 server start [OPTIONS]
                   state.note_activity()
                   vlog("op=repl")
                   with_session(io) { (session, _) => io.write(repl_reply(session, t)) }
-                case Some("load-files") =>
-                  state.note_activity()
-                  val files = JSON.strings(t, "files").getOrElse(Nil)
-                  vlog("op=load-files: " + files.length + " file(s): " + files.mkString(", "))
-                  with_session(io) { (session, resources) =>
-                    io.write(load_files_reply(session, resources, files)) }
                 case Some("status") =>
                   // Deliberately NOT counted as activity: a monitor polling
                   // `status` shouldn't hide an otherwise idle server.
@@ -1039,21 +1033,6 @@ Usage: isabelle ic2 server start [OPTIONS]
       if (running) Check.current.foreach(_.cancel("cancelled"))
       JSON.Object("event" -> "check_cancel", "cancelled" -> running)
     }
-
-    /** Parse-only load: parse the given .thy files into the session's
-     *  document graph WITHOUT evaluating any commands. Delegates to the
-     *  shared `SessionTools.parseFiles`. On success returns the list of
-     *  loaded node paths; on failure returns a server_error. */
-    private def load_files_reply(
-      session: Headless.Session, resources: Headless.Resources, files: List[String]
-    ): JSON.Object.T =
-      SessionTools.parseFiles(session, resources, files) match {
-        case Right(names) =>
-          JSON.Object("event" -> "load-files",
-            "loaded" -> names.map(_.node),
-            "count" -> names.length)
-        case Left(msg) => server_error("load-files: " + msg)
-      }
 
     /** One-shot read-only diagnostic query — the wire counterpart of the MCP
      *  diagnostic tools. Routes `{op:query, tool, ...}` through the SAME

--- a/ic2/src/ic2.scala
+++ b/ic2/src/ic2.scala
@@ -7,8 +7,6 @@ The single `isabelle ic2` tool. Dispatches to command groups:
 
   ic2 server start|stop|status     manage the headless PIDE daemon
   ic2 check [FILE...|status|attach|cancel]   run / inspect / control a check
-  ic2 load-files FILE...           parse .thy files into the session graph
-                                   without evaluating them
   ic2 query SUBTOOL ...             read-only diagnostics over the session
   ic2 repl-create FILE:LINE NAME    create an interactive I/R REPL
 
@@ -104,11 +102,6 @@ Usage: isabelle ic2 COMMAND [ARGS...]
                                diagnostics, command-info, ...).
                                `query help` for the full catalogue.
 
-    load-files FILE...         Parse .thy files into the session's document
-                               graph WITHOUT evaluating them. After loading,
-                               `query` sees the theory shape (list-files,
-                               entities, command-info, ...) at zero ML cost.
-
   ============================== Concrete flow ============================
 
     isabelle ic2 server start --daemon -l HOL
@@ -175,7 +168,6 @@ Usage: isabelle ic2 server SUBCOMMAND [ARGS...]
     args match {
       case "server" :: rest => server(rest)
       case "check" :: rest => check(rest)
-      case "load-files" :: rest => Client.load_files(rest)
       case "query" :: rest => Client.query(rest)
       case "repl-create" :: rest => Client.repl_create(rest)
       case ("help" | "-h" | "--help") :: _ | Nil => usage()

--- a/ic2/src/ic2_use_theories.scala
+++ b/ic2/src/ic2_use_theories.scala
@@ -1,0 +1,559 @@
+/*  Title:      ic2/src/ic2_use_theories.scala
+
+IC2-local copy of the relevant `Headless.Session.use_theories` /
+`Headless.Resources.load_theories` machinery from Isabelle2025-2
+`Pure/PIDE/headless.scala`.
+
+ISABELLE COPYRIGHT NOTICE, LICENCE AND DISCLAIMER.
+
+Copyright (c) 1986-2026,
+  University of Cambridge,
+  Technische Universitaet Muenchen,
+  and contributors.
+
+  All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are
+met:
+
+* Redistributions of source code must retain the above copyright
+notice, this list of conditions and the following disclaimer.
+
+* Redistributions in binary form must reproduce the above copyright
+notice, this list of conditions and the following disclaimer in the
+documentation and/or other materials provided with the distribution.
+
+* Neither the name of the University of Cambridge or the Technische
+Universitaet Muenchen nor the names of their contributors may be used
+to endorse or promote products derived from this software without
+specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED
+TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+The copy is intentionally narrow: IC2 does not use upstream's `commit` callback
+path, so this keeps only the no-commit checking path. The key IC2 modification
+is in `Theory.node_edits`: upstream uses a whole-file `Text.Edit.replace(0, old,
+new)` for changed files; IC2 computes a common-prefix/common-suffix replacement
+so PIDE can preserve unchanged command identities across repeated CLI checks.
+*/
+
+package isabelle.ic2
+
+import isabelle._
+
+import scala.annotation.tailrec
+
+
+object IC2_Use_Theories {
+  private def stable_snapshot(
+    state: Document.State,
+    version: Document.Version,
+    name: Document.Node.Name
+  ): Document.Snapshot = {
+    val snapshot = state.snapshot(name)
+    assert(version.id == snapshot.version.id)
+    snapshot
+  }
+
+  final class Result private[IC2_Use_Theories](
+    val state: Document.State,
+    val version: Document.Version,
+    val nodes: List[(Document.Node.Name, Document_Status.Node_Status)]
+  ) {
+    def snapshot(name: Document.Node.Name): Document.Snapshot =
+      stable_snapshot(state, version, name)
+
+    def ok: Boolean = nodes.iterator.forall({ case (_, st) => st.ok })
+  }
+
+
+  /* loader state: copied from Headless.Resources.State, with IC2 edits */
+
+  private object Loader {
+    private val states =
+      new java.util.WeakHashMap[Headless.Session, Synchronized[State]]
+
+    private def state_for(session: Headless.Session): Synchronized[State] =
+      states.synchronized {
+        var state = states.get(session)
+        if (state == null) {
+          state = Synchronized(State())
+          states.put(session, state)
+        }
+        state
+      }
+
+    private final case class Theory(
+      node_name: Document.Node.Name,
+      node_header: Document.Node.Header,
+      text: String,
+      node_required: Boolean
+    ) {
+      def node_perspective: Document.Node.Perspective_Text.T =
+        Document.Node.Perspective(node_required, Text.Perspective.empty, Document.Node.Overlays.empty)
+
+      def make_edits(text_edits: List[Text.Edit]): List[Document.Edit_Text] =
+        List(
+          node_name -> Document.Node.Deps(node_header),
+          node_name -> Document.Node.Edits(text_edits),
+          node_name -> node_perspective)
+
+      def node_edits(session: Headless.Session, old: Option[Theory]): List[Document.Edit_Text] = {
+        val old_text =
+          old match {
+            case Some(t) => t.text
+            case None => SessionTools.nodeText(session, node_name)
+          }
+        val old_required = old.map(_.node_required).getOrElse(false)
+        val text_edits =
+          if (old.isEmpty && old_text.isEmpty) Text.Edit.inserts(0, text)
+          else Theory.minimal_replace(old_text, text)
+
+        if (text_edits.isEmpty && node_required == old_required) Nil
+        else make_edits(text_edits)
+      }
+
+      def set_required(required: Boolean): Theory =
+        if (required == node_required) this
+        else copy(node_required = required)
+    }
+
+    private object Theory {
+      /* IC2 deviation from Headless.Resources.Theory.node_edits:
+       * upstream uses Text.Edit.replace(0, old, new), which expands to a
+       * whole-file remove+insert. That removes unchanged prefix Command objects
+       * before Thy_Syntax.reparse_spans can preserve them, so a tiny edit near
+       * EOF can re-run an expensive command near BOF. This common-prefix /
+       * common-suffix edit preserves unchanged command identities and lets PIDE
+       * invalidate only the affected command range. */
+      private def minimal_replace(old_text: String, new_text: String): List[Text.Edit] = {
+        if (old_text == new_text) Nil
+        else {
+          val old_len = old_text.length
+          val new_len = new_text.length
+          var start = 0
+          while (start < old_len && start < new_len &&
+                 old_text.charAt(start) == new_text.charAt(start)) {
+            start += 1
+          }
+
+          var old_stop = old_len
+          var new_stop = new_len
+          while (old_stop > start && new_stop > start &&
+                 old_text.charAt(old_stop - 1) == new_text.charAt(new_stop - 1)) {
+            old_stop -= 1
+            new_stop -= 1
+          }
+
+          Text.Edit.removes(start, old_text.substring(start, old_stop)) :::
+            Text.Edit.inserts(start, new_text.substring(start, new_stop))
+        }
+      }
+    }
+
+    private final case class State(
+      blobs: Map[Document.Node.Name, Document.Blobs.Item] = Map.empty,
+      theories: Map[Document.Node.Name, Theory] = Map.empty,
+      required: Multi_Map[Document.Node.Name, UUID.T] = Multi_Map.empty
+    ) {
+      def doc_blobs: Document.Blobs = Document.Blobs(blobs)
+
+      def update_blobs(names: List[Document.Node.Name]): (Document.Blobs, State) = {
+        val new_blobs =
+          names.flatMap { name =>
+            val bytes = Bytes.read(name.path)
+            blobs.get(name) match {
+              case Some(blob) if blob.bytes == bytes => None
+              case _ =>
+                val text = bytes.text
+                val blob = Document.Blobs.Item(bytes, text, Symbol.Text_Chunk(text), changed = true)
+                Some(name -> blob)
+            }
+          }
+        val blobs1 = new_blobs.foldLeft(blobs)(_ + _)
+        val blobs2 = new_blobs.foldLeft(blobs) { case (map, (a, b)) => map + (a -> b.unchanged) }
+        (Document.Blobs(blobs1), copy(blobs = blobs2))
+      }
+
+      def blob_edits(
+        name: Document.Node.Name,
+        old_blob: Option[Document.Blobs.Item]
+      ): List[Document.Edit_Text] = {
+        val blob = blobs.getOrElse(name, error("Missing blob " + quote(name.toString)))
+        val text_edits =
+          old_blob match {
+            case None => List(Text.Edit.insert(0, blob.source))
+            case Some(blob0) => Text.Edit.replace(0, blob0.source, blob.source)
+          }
+        if (text_edits.isEmpty) Nil
+        else List(name -> Document.Node.Blob(blob), name -> Document.Node.Edits(text_edits))
+      }
+
+      def is_required(name: Document.Node.Name): Boolean = required.isDefinedAt(name)
+
+      def insert_required(id: UUID.T, names: List[Document.Node.Name]): State =
+        copy(required = names.foldLeft(required)(_.insert(_, id)))
+
+      def remove_required(id: UUID.T, names: List[Document.Node.Name]): State =
+        copy(required = names.foldLeft(required)(_.remove(_, id)))
+
+      def update_theories(update: List[Theory]): State =
+        copy(theories =
+          update.foldLeft(theories) {
+            case (thys, thy) =>
+              thys.get(thy.node_name) match {
+                case Some(thy1) if thy1 == thy => thys
+                case _ => thys + (thy.node_name -> thy)
+              }
+          })
+
+      def unload_theories(
+        session: Headless.Session,
+        id: UUID.T,
+        names: List[Document.Node.Name]
+      ): (List[Document.Edit_Text], State) = {
+        val st1 = remove_required(id, names)
+        val theory_edits =
+          for {
+            node_name <- names
+            theory <- st1.theories.get(node_name)
+          }
+          yield {
+            val theory1 = theory.set_required(st1.is_required(node_name))
+            val edits = theory1.node_edits(session, Some(theory))
+            (theory1, edits)
+          }
+        (theory_edits.flatMap(_._2), st1.update_theories(theory_edits.map(_._1)))
+      }
+    }
+
+    def load_theories(
+      session: Headless.Session,
+      resources: Headless.Resources,
+      id: UUID.T,
+      theories: List[Document.Node.Name],
+      files: List[Document.Node.Name],
+      unicode_symbols: Boolean,
+      progress: Progress
+    ): Unit = {
+      val loaded_theories =
+        for (node_name <- theories)
+        yield {
+          val path = node_name.path
+          if (!node_name.is_theory) error("Not a theory file: " + path)
+
+          progress.expose_interrupt()
+          val text = Symbol.output(unicode_symbols, File.read(path))
+          val node_header = resources.check_thy(node_name, Scan.char_reader(text))
+          Theory(node_name, node_header, text, true)
+        }
+
+      val loaded = loaded_theories.length
+      if (loaded > 1) progress.echo("Loading " + loaded + " theories ...")
+
+      state_for(session).change { st =>
+        val (doc_blobs1, st1) = st.insert_required(id, theories).update_blobs(files)
+        val theory_edits =
+          for (theory <- loaded_theories)
+          yield {
+            val node_name = theory.node_name
+            val old_theory = st.theories.get(node_name)
+            val theory1 = theory.set_required(st1.is_required(node_name))
+            val edits = theory1.node_edits(session, old_theory)
+            (theory1, edits)
+          }
+        val file_edits =
+          for { node_name <- files if doc_blobs1.changed(node_name) }
+          yield st1.blob_edits(node_name, st.blobs.get(node_name))
+
+        session.update(doc_blobs1, theory_edits.flatMap(_._2) ::: file_edits.flatten)
+        st1.update_theories(theory_edits.map(_._1))
+      }
+    }
+
+    def unload_theories(
+      session: Headless.Session,
+      id: UUID.T,
+      theories: List[Document.Node.Name]
+    ): Unit = {
+      state_for(session).change { st =>
+        val (edits, st1) = st.unload_theories(session, id, theories)
+        session.update(st.doc_blobs, edits)
+        st1
+      }
+    }
+  }
+
+
+  /* use_theories copy, no upstream commit callback path */
+
+  private object Load_State {
+    def finished: Load_State = Load_State(Nil, Nil, Space.zero)
+
+    def count_file(resources: Headless.Resources)(name: Document.Node.Name): Long =
+      if (resources.loaded_theory(name)) 0 else File.size(name.path)
+  }
+
+  private final case class Load_State(
+    pending: List[Document.Node.Name],
+    rest: List[Document.Node.Name],
+    load_limit: Space
+  ) {
+    def next(
+      resources: Headless.Resources,
+      dep_graph: Document.Node.Name.Graph[Unit],
+      consolidated: Document.Node.Name => Boolean
+    ): (List[Document.Node.Name], Load_State) = {
+      def load_requirements(
+        pending1: List[Document.Node.Name],
+        rest1: List[Document.Node.Name]
+      ): (List[Document.Node.Name], Load_State) = {
+        val load_theories = dep_graph.all_preds_rev(pending1)
+        (load_theories, Load_State(pending1, rest1, load_limit))
+      }
+
+      if (!pending.forall(consolidated)) (Nil, this)
+      else if (rest.isEmpty) (Nil, Load_State.finished)
+      else if (!load_limit.is_proper) load_requirements(rest, Nil)
+      else {
+        val reachable =
+          dep_graph.reachable_limit(
+            load_limit.bytes, Load_State.count_file(resources), dep_graph.imm_preds, rest)
+        val (pending1, rest1) = rest.partition(reachable)
+        load_requirements(pending1, rest1)
+      }
+    }
+  }
+
+  private final case class Use_Theories_State(
+    resources: Headless.Resources,
+    dep_graph: Document.Node.Name.Graph[Unit],
+    load_state: Load_State,
+    watchdog_timeout: Time,
+    last_update: Date = Date.now(),
+    nodes_status: Document_Status.Nodes_Status = Document_Status.Nodes_Status.empty,
+    changed_nodes: Set[Document.Node.Name] = Set.empty,
+    changed_assignment: Boolean = false,
+    result: Option[Exn.Result[Result]] = None
+  ) {
+    def nodes_status_update(
+      state: Document.State,
+      version: Document.Version,
+      domain: Option[Set[Document.Node.Name]] = None,
+      trim: Boolean = false
+    ): (Boolean, Use_Theories_State) = {
+      val now = Date.now()
+      val nodes_status1 =
+        nodes_status.update_nodes(now, resources, state, version, domain = domain, trim = trim)
+      val st1 = copy(last_update = now, nodes_status = nodes_status1)
+      (nodes_status1 != nodes_status, st1)
+    }
+
+    def changed(
+      nodes: IterableOnce[Document.Node.Name],
+      assignment: Boolean
+    ): Use_Theories_State =
+      copy(
+        changed_nodes = changed_nodes ++ nodes,
+        changed_assignment = changed_assignment || assignment)
+
+    def reset_changed: Use_Theories_State =
+      if (changed_nodes.isEmpty && !changed_assignment) this
+      else copy(changed_nodes = Set.empty, changed_assignment = false)
+
+    def watchdog: Boolean =
+      watchdog_timeout > Time.zero && Date.now() - last_update > watchdog_timeout
+
+    def finished_result: Boolean = result.isDefined
+
+    def join_result: Option[(Exn.Result[Result], Use_Theories_State)] =
+      if (finished_result) Some((result.get, this)) else None
+
+    def cancel_result: Use_Theories_State =
+      if (finished_result) this else copy(result = Some(Exn.Exn(Exn.Interrupt())))
+
+    private def consolidated(
+      state: Document.State,
+      version: Document.Version,
+      name: Document.Node.Name
+    ): Boolean =
+      resources.loaded_theory(name) ||
+        nodes_status.quasi_consolidated(name) ||
+        state.node_consolidated(version, name)
+
+    def check(
+      state: Document.State,
+      version: Document.Version,
+      beyond_limit: Boolean
+    ): (List[Document.Node.Name], Use_Theories_State) = {
+      val (load_theories0, load_state1) =
+        load_state.next(resources, dep_graph, consolidated(state, version, _))
+      val load_theories = load_theories0.filterNot(resources.loaded_theory)
+
+      val result1 = {
+        val stopped = beyond_limit || watchdog
+        if (!finished_result && load_theories.isEmpty &&
+            (stopped || dep_graph.keys_iterator.forall(consolidated(state, version, _)))) {
+          val now = Date.now()
+
+          @tailrec def make_nodes(
+            input: List[Document.Node.Name],
+            output: List[(Document.Node.Name, Document_Status.Node_Status)]
+          ): Option[List[(Document.Node.Name, Document_Status.Node_Status)]] = {
+            input match {
+              case name :: rest =>
+                if (resources.loaded_theory(name)) make_nodes(rest, output)
+                else {
+                  val status = Document_Status.Node_Status.make(now, state, version, name)
+                  if (stopped || status.consolidated) make_nodes(rest, (name -> status) :: output)
+                  else None
+                }
+              case Nil => Some(output)
+            }
+          }
+
+          for (nodes <- make_nodes(dep_graph.topological_order.reverse, Nil))
+            yield Exn.Res(new Result(state, version, nodes))
+        }
+        else result
+      }
+
+      (load_theories, copy(result = result1, load_state = load_state1))
+    }
+  }
+
+  def use_theories(
+    session: Headless.Session,
+    resources: Headless.Resources,
+    theories: List[String],
+    qualifier: String = Sessions.DRAFT,
+    master_dir: String = "",
+    unicode_symbols: Boolean = false,
+    check_delay: Time,
+    check_limit: Int,
+    watchdog_timeout: Time,
+    nodes_status_delay: Time,
+    id: UUID.T = UUID.random(),
+    progress: Progress = new Progress
+  ): Result = {
+    val dependencies = {
+      val import_names =
+        theories.map(thy =>
+          resources.import_name(qualifier, session.master_directory(master_dir), thy) -> Position.none)
+      resources.dependencies(import_names, progress = progress).check_errors
+    }
+    val dep_theories = dependencies.theories
+    val dep_theories_set = dep_theories.toSet
+    val dep_files = dependencies.loaded_files
+
+    val use_theories_state = {
+      val dep_graph = dependencies.theory_graph
+      val maximals = dep_graph.maximals
+      val rest =
+        if (maximals.isEmpty || maximals.tail.isEmpty) maximals
+        else {
+          val depth = dep_graph.node_depth(Load_State.count_file(resources))
+          maximals.sortBy(node => - depth(node))
+        }
+      Synchronized(
+        Use_Theories_State(
+          resources, dep_graph, Load_State(Nil, rest, Space.zero), watchdog_timeout))
+    }
+
+    def check_state(
+      beyond_limit: Boolean = false,
+      state: Document.State = session.get_state()
+    ): Unit = {
+      for {
+        version <- state.stable_tip_version
+        load_theories = use_theories_state.change_result(_.check(state, version, beyond_limit))
+        if load_theories.nonEmpty
+      } Loader.load_theories(session, resources, id, load_theories, dep_files, unicode_symbols, progress)
+    }
+
+    lazy val check_progress = {
+      var check_count = 0
+      Event_Timer.request(Time.now(), repeat = Some(check_delay)) {
+        if (progress.stopped) use_theories_state.change(_.cancel_result)
+        else {
+          check_count += 1
+          check_state(check_limit > 0 && check_count > check_limit)
+        }
+      }
+    }
+
+    val consumer = {
+      val delay_nodes_status =
+        Delay.first(nodes_status_delay max Time.zero) {
+          val st = use_theories_state.value
+          val now = progress.now()
+          progress.nodes_status(
+            Progress.Nodes_Status(now, st.dep_graph.topological_order, st.nodes_status))
+        }
+
+      isabelle.Session.Consumer[isabelle.Session.Commands_Changed](getClass.getName) { changed =>
+        val state = session.get_state()
+
+        def apply_changed(st: Use_Theories_State): Use_Theories_State =
+          st.changed(changed.nodes.iterator.filter(dep_theories_set), changed.assignment)
+
+        state.stable_tip_version match {
+          case None => use_theories_state.change(apply_changed)
+          case Some(version) =>
+            val theory_progress =
+              use_theories_state.change_result { st =>
+                val changed_st = apply_changed(st)
+                val domain =
+                  if (st.nodes_status.is_empty) dep_theories_set
+                  else changed_st.changed_nodes
+
+                val (nodes_status_changed, st1) =
+                  st.reset_changed.nodes_status_update(
+                    state, version, domain = Some(domain), trim = changed_st.changed_assignment)
+
+                if (nodes_status_delay >= Time.zero && nodes_status_changed)
+                  delay_nodes_status.invoke()
+
+                val theory_progress =
+                  (for {
+                    name <- st1.dep_graph.topological_order.iterator
+                    node_status = st1.nodes_status(name)
+                    if !node_status.is_empty && changed_st.changed_nodes(name)
+                    p1 = node_status.percentage
+                    if p1 > 0 && !st.nodes_status.get(name).map(_.percentage).contains(p1)
+                  } yield Progress.Theory(name.theory, percentage = Some(p1))).toList
+
+                (theory_progress, st1)
+              }
+
+            theory_progress.foreach(progress.theory)
+            check_state(state = state)
+        }
+      }
+    }
+
+    try {
+      session.commands_changed += consumer
+      check_progress
+      use_theories_state.guarded_access(_.join_result)
+      check_progress.cancel()
+    }
+    finally {
+      session.commands_changed -= consumer
+      Loader.unload_theories(session, id, dep_theories)
+    }
+
+    Exn.release(use_theories_state.guarded_access(_.join_result))
+  }
+}

--- a/ic2/src/iq.scala
+++ b/ic2/src/iq.scala
@@ -73,9 +73,8 @@ object Check {
    *   (b) cancelViaEdit() — reclaims a still-running forked proof after stop().
    */
 
-  /** Delegates to `SessionTools.resolveFileTargets`, which is the shared
-    * file→(Node.Name, theory-string) resolver used by both this check
-    * pipeline and the parse-only loader (`SessionTools.parseFiles`). */
+  /** Delegates to `SessionTools.resolveFileTargets`, the shared
+    * file→(Node.Name, theory-string) resolver used by the check pipeline. */
   def resolveTargets(
     resources: Headless.Resources, files: List[String]
   ): Either[String, List[(Document.Node.Name, String)]] =
@@ -405,7 +404,7 @@ object Check {
 
     /** Post-result fallback: result is failure but the live callback never saw
       * it (consolidation on the final tick). Emit the first error, once. */
-    def emit_post_result_error(result: Headless.Use_Theories_Result): Unit =
+    def emit_post_result_error(result: IC2_Use_Theories.Result): Unit =
       result.nodes.find { case (_, st) => st.failed > 0 } match {
         case Some((name, _)) => if (claim_error()) emit_error_from(name, Some(result.snapshot(name)))
         case None =>
@@ -532,20 +531,22 @@ object Check {
       t.start()
     }
 
-    /** The Full-mode worker: run `use_theories` and classify the outcome from
+    /** The Full-mode worker: run IC2's copied `use_theories` and classify the outcome from
       * its result + the observed cancel/first-error flags. */
     private def full_body(theoryStrings: List[String]): Runnable = new Runnable {
       def run(): Unit = {
         val result =
-          try Exn.Res(session.use_theories(theoryStrings,
+          try Exn.Res(IC2_Use_Theories.use_theories(session,
+            resources.getOrElse(error("check job missing Headless.Resources")), theoryStrings,
             qualifier = Sessions.DRAFT, master_dir = "",
-            check_delay = Time.seconds(0.2), watchdog_timeout = Time.seconds(0),
+            check_delay = Time.seconds(0.2), check_limit = session.default_check_limit,
+            watchdog_timeout = Time.seconds(0),
             nodes_status_delay = Time.seconds(0.2), progress = progress))
           catch { case e: Throwable => Exn.Exn(e) }
           finally {
             progress.stop_ticker()   // does NOT set progress.stopped
             progress.flush_final()
-            // use_theories has returned (its finally ran unload_theories, so
+            // IC2_Use_Theories has returned (its finally ran unload_theories, so
             // the node is no longer required) — reclaim any still-running fork
             // now via a text-changing tail edit. No-op unless something is
             // still executing (i.e. this check was cancelled mid-flight).
@@ -583,7 +584,7 @@ object Check {
 
     /** The Partial-mode worker for `check FILE --line N`.
       *
-      * Runs a normal `use_theories([target])` — which loads and evaluates the
+      * Runs a normal IC2 copied `use_theories([target])` — which loads and evaluates the
       * target's whole dependency closure exactly like a full check, so the
       * prefix type-checks and Headless.Resources' bookkeeping stays
       * consistent (no direct session.update, so no double-load desync with a
@@ -618,10 +619,12 @@ object Check {
         val out =
           try {
             arm_target_resolver(p)
-            val result: Exn.Result[Headless.Use_Theories_Result] =
-              try Exn.Res(session.use_theories(List(p.targetTheory),
+            val result: Exn.Result[IC2_Use_Theories.Result] =
+              try Exn.Res(IC2_Use_Theories.use_theories(session,
+                resources.getOrElse(error("partial check job missing Headless.Resources")), List(p.targetTheory),
                 qualifier = Sessions.DRAFT, master_dir = "",
-                check_delay = Time.seconds(0.2), watchdog_timeout = Time.seconds(0),
+                check_delay = Time.seconds(0.2), check_limit = session.default_check_limit,
+                watchdog_timeout = Time.seconds(0),
                 nodes_status_delay = Time.seconds(0.2), progress = progress))
               catch { case e: Throwable => Exn.Exn(e) }
             classify_partial(result)
@@ -678,7 +681,7 @@ object Check {
       * SUCCESS — the target was reached, the tail was intentionally
       * abandoned. Everything else (first-error stop, other cancel reasons,
       * genuine interrupts) surfaces as failure, matching Full mode. */
-    private def classify_partial(result: Exn.Result[Headless.Use_Theories_Result]): Outcome =
+    private def classify_partial(result: Exn.Result[IC2_Use_Theories.Result]): Outcome =
       result match {
         case Exn.Res(r) =>
           if (progress.error_emitted) Outcome.Failed("first-error stop")
@@ -755,7 +758,8 @@ object Check {
     if (busy) Left("a check is already in flight; cancel it before submitting another")
     else if (files.isEmpty) Left("empty files list")
     else resolveTargets(resources, files).map { resolved =>
-      val job = new Job(resolved.map(_._1.theory), resolved.map(_._1), session)
+      val job = new Job(resolved.map(_._1.theory), resolved.map(_._1), session,
+        resources = Some(resources))
       slot.set(Some(job))
       job.start(resolved.map(_._2))
       job
@@ -1055,7 +1059,6 @@ object IQ {
           .flatMap(_ => server.register(checkAsyncTool(session, resources, progress)))
           .flatMap(_ => server.register(checkStatusTool))
           .flatMap(_ => server.register(checkCancelTool))
-          .flatMap(_ => server.register(loadFilesTool(session, resources, progress)))
           .flatMap(_ => new SessionClient(session, server).register())
           .flatMap(_ => new IRTools(server, conn).register())
       registration match {
@@ -1229,41 +1232,6 @@ object IQ {
           "cancelled" -> running,
           "message" -> (if (running) "cancellation requested" else "no check running"))))
       })
-
-  /** MCP `load_files`: parse the given .thy files into the session's document
-    * graph without evaluating them. Wraps `SessionTools.parseFiles`. On
-    * success returns `{loaded: [<node paths>], count: N}`; on failure the
-    * tool returns an isError result carrying the resolution/header-parse
-    * message. */
-  private def loadFilesTool(
-    session: Headless.Session, resources: Headless.Resources, log: Progress
-  ): McpTool =
-    McpTool(
-      name = "load_files",
-      description = "Parse .thy files into the session's document graph " +
-        "WITHOUT evaluating any commands. The Scala side splits each theory " +
-        "into commands (fixing spans/IDs/offsets), so `list_files`, " +
-        "`get_entities`, `get_command_info`, and friends can then see the " +
-        "theory shape — but no proof state is produced, no ML work runs. Use " +
-        "for cheap structural exploration; call `check` afterwards to " +
-        "actually evaluate. Files must be absolute .thy paths. Header " +
-        "imports must be locatable in the session.",
-      inputSchema = Map(
-        "type" -> "object",
-        "properties" -> Map(
-          "files" -> Map("type" -> "array", "items" -> Map("type" -> "string"),
-            "description" -> "Absolute paths of .thy files to parse-load")),
-        "required" -> List("files"),
-        "additionalProperties" -> false),
-      handler = params =>
-        SessionTools.parseFiles(session, resources, checkFiles(params)) match {
-          case Left(msg) => Left("load_files: " + msg)
-          case Right(names) =>
-            log.echo("[mcp] load-files: " + names.length + " theory node(s)")
-            Right(McpToolResult.fromMap(Map(
-              "loaded" -> names.map(_.node),
-              "count" -> names.length)))
-        })
 
   /* ---- check param helpers (shared by check / check_async) ---- */
 

--- a/ic2/src/test_tool.scala
+++ b/ic2/src/test_tool.scala
@@ -158,6 +158,37 @@ Usage: isabelle ic2_test [OPTIONS] MODE [DIR]
       file.toAbsolutePath.toString
     }
 
+    /** Write a fresh theory whose expensive command is BEFORE a cheap marker
+     *  command that tests can rewrite. Used to pin incremental re-checks: after
+     *  a successful baseline check, changing only the marker must not re-run
+     *  the earlier sleep. */
+    private def fresh_incremental_recheck_theory(secs: Double = 4.0): String = {
+      val name = "Incremental_" + short_id()
+      val dir = Files.createTempDirectory("ic2_incremental")
+      val file = dir.resolve(name + ".thy")
+      val body =
+        "theory " + name + "\n" +
+        "  imports Main\n" +
+        "begin\n\n" +
+        "ML_command ‹\n" +
+        "  writeln \"IC2_INCREMENTAL_SLEEP_BEGIN\";\n" +
+        "  OS.Process.sleep (Time.fromReal " + secs + ");\n" +
+        "  writeln \"IC2_INCREMENTAL_SLEEP_END\"\n" +
+        "›\n\n" +
+        "ML_command ‹writeln \"IC2_INCREMENTAL_MARKER_0\"›\n\n" +
+        "end\n"
+      Files.write(file, body.getBytes("UTF-8"))
+      file.toAbsolutePath.toString
+    }
+
+    private def rewrite_marker(path: String, from: String, to: String): Unit = {
+      val p = Paths.get(path)
+      val oldText = new String(Files.readAllBytes(p), "UTF-8")
+      if (!oldText.contains(from))
+        error("rewrite_marker: marker not found in " + path + ": " + from)
+      Files.write(p, oldText.replace(from, to).getBytes("UTF-8"))
+    }
+
     /** Run `isabelle ic2 <args>` as a subprocess and return its result. Used by
      *  the tests that exercise the CLI front door (exit codes, printed output)
      *  rather than the wire protocol directly. */
@@ -433,6 +464,7 @@ Usage: isabelle ic2_test [OPTIONS] MODE [DIR]
         etest("check_ok") { e2e_check_ok(server_name, fixtures) }
         etest("check_fail") { e2e_check_fail(server_name, fixtures) }
         etest("check_cli_exit_codes") { e2e_check_cli(server_name, fixtures) }
+        etest("recheck_after_edit_skips_unchanged_prefix") { e2e_recheck_after_edit_skips_prefix(server_name) }
         etest("multi_file_first_error") { e2e_multi_file(server_name, fixtures) }
         etest("concurrent_clients") { e2e_concurrent_clients(server_name, fixtures) }
         etest("second_check_rejected") { e2e_second_check_rejected(server_name, fixtures) }
@@ -466,8 +498,6 @@ Usage: isabelle ic2_test [OPTIONS] MODE [DIR]
         test("no_iq_skips_ir") { e2e_no_iq(fixtures) }
         // MCP is opt-in: a server without --mcp has I/R but no MCP endpoint.
         test("mcp_off_by_default") { e2e_mcp_off_by_default(fixtures) }
-        // Parse-only loading: own -N server so the fixture starts UNloaded.
-        test("load_files_parse_only") { e2e_load_files_parse_only(fixtures) }
         // Partial check (`check --line N`): own -N server so we can observe
         // the post-check state (only the prefix evaluated, tail unprocessed).
         test("check_line_partial") { e2e_check_line_partial(fixtures) }
@@ -1319,6 +1349,34 @@ Usage: isabelle ic2_test [OPTIONS] MODE [DIR]
       if (r1.rc != 1) error("check Fail should exit 1, got " + r1.rc)
       val r2 = ic2("check -P -n " + n)
       if (r2.rc != 2) error("check with no FILE should exit 2, got " + r2.rc)
+    }
+
+    /** Re-checking a changed theory should preserve the unchanged processed
+     *  prefix. The baseline check evaluates an expensive ML command, then the
+     *  test rewrites only a later marker command. A correct incremental check
+     *  should finish the second run without re-running the earlier sleep. */
+    private def e2e_recheck_after_edit_skips_prefix(server_name: String): Unit = {
+      val file = fresh_incremental_recheck_theory(secs = 5.0)
+
+      val (_, firstFinished) = run_check(server_name, List(file), deadline_secs = 30)
+      if (firstFinished.flatMap(JSON.bool(_, "ok")) != Some(true))
+        error("baseline incremental check should pass, got " + firstFinished)
+
+      rewrite_marker(file, "IC2_INCREMENTAL_MARKER_0", "IC2_INCREMENTAL_MARKER_1")
+
+      val start = System.currentTimeMillis()
+      val (events, secondFinished) = run_check(server_name, List(file), deadline_secs = 4)
+      val elapsed = System.currentTimeMillis() - start
+      val replayedSleep = events.exists(t =>
+        JSON.array(t, "nodes").getOrElse(Nil).exists(n =>
+          JSON.array(n, "long_running").getOrElse(Nil).exists(rc =>
+            JSON.string(rc, "preview").exists(_.contains("IC2_INCREMENTAL_SLEEP_BEGIN")))))
+      if (secondFinished.flatMap(JSON.bool(_, "ok")) != Some(true))
+        error("post-edit re-check should finish within 4s by reusing the unchanged prefix; " +
+          "got finished=" + secondFinished + ", events=" + events.length +
+          ", elapsed_ms=" + elapsed + ", replayed_sleep=" + replayedSleep)
+      if (replayedSleep)
+        error("post-edit re-check reported the pre-edit sleep as running")
     }
 
     /** Submit OK + Fail together; first-error stop must blame Fail, never OK. */
@@ -2489,147 +2547,6 @@ Usage: isabelle ic2_test [OPTIONS] MODE [DIR]
             if (JSON.value(ir, "mcp_port").isDefined || JSON.value(ir, "mcp_token").isDefined)
               error("without --mcp, status must not expose an MCP endpoint, got " + JSON.Format(ir))
         }
-      } finally {
-        try { proc.terminate() } catch { case _: Throwable => }
-        cleanup_server(name)
-      }
-    }
-
-    /** `ic2 load-files`: parse a .thy file into the session's document graph
-     *  WITHOUT evaluating it, then confirm that structural queries see the
-     *  theory shape and that no evaluation happened.
-     *
-     *  Uses its own -N server so we can start from a state where the fixture
-     *  is guaranteed NOT loaded (the main server's earlier tests will have
-     *  checked it). The test pins:
-     *   (a) load-files reply reports the correct count + node path;
-     *   (b) list-files then includes the node with percentage=0, unconsolidated;
-     *   (c) entities finds the expected declarations by line;
-     *   (d) command-info at a definition reports status=unprocessed (not
-     *       finished/failed — proof of no evaluation);
-     *   (e) context-info at a lemma reports has_goal=false (no STATE msgs);
-     *   (f) load-files is idempotent — a second call on the same file
-     *       succeeds (session.update sees no text change and no-ops the
-     *       edits, but the wire reply still reports it "loaded"). */
-    private def e2e_load_files_parse_only(fixtures: Path): Unit = {
-      val name = "t_lf_" + short_id()
-      val proc = start_server(name, extra_args = List("-N", "--no-iq"))
-      try {
-        wait_for_server(name, timeout = 60)
-        val file = (fixtures + Path.basic("CommandLookup.thy")).expand.implode
-
-        // Precondition: the node is not yet in the session.
-        val lfBefore = request_op(name, JSON.Object("op" -> "query", "tool" -> "list_files"))
-        val before = JSON.value(lfBefore, "result").flatMap(r => JSON.array(r, "files")).getOrElse(Nil)
-        if (before.exists(f => JSON.string(f, "node").exists(_.endsWith("CommandLookup.thy"))))
-          error("precondition: CommandLookup.thy should NOT be loaded on the fresh server yet")
-
-        // (a) load-files reply.
-        val loaded = request_op(name, JSON.Object("op" -> "load-files", "files" -> List(file)))
-        if (JSON.string(loaded, "event") != Some("load-files"))
-          error("load-files: unexpected event: " + JSON.Format(loaded))
-        if (JSON.int(loaded, "count") != Some(1))
-          error("load-files: expected count=1, got " + JSON.Format(loaded))
-        val loadedNodes = JSON.strings(loaded, "loaded").getOrElse(Nil)
-        if (!loadedNodes.exists(_.endsWith("CommandLookup.thy")))
-          error("load-files: reply 'loaded' should include CommandLookup.thy, got " + loadedNodes)
-
-        // (b) list-files now includes the node, unconsolidated at 0%.
-        //     The Scala change_parser runs asynchronously; poll briefly.
-        var found: Option[JSON.T] = None
-        val deadline = System.currentTimeMillis() + 5000
-        while (found.isEmpty && System.currentTimeMillis() < deadline) {
-          val lf = request_op(name, JSON.Object("op" -> "query", "tool" -> "list_files"))
-          found = JSON.value(lf, "result").flatMap(r => JSON.array(r, "files")).getOrElse(Nil)
-            .find(f => JSON.string(f, "node").exists(_.endsWith("CommandLookup.thy")))
-          if (found.isEmpty) Thread.sleep(150)
-        }
-        val entry = found.getOrElse(error("list-files after load: CommandLookup.thy not present within 5s"))
-        if (JSON.int(entry, "percentage").getOrElse(-1) != 0)
-          error("list-files: parse-only node should be at 0% (no eval), got " + JSON.int(entry, "percentage"))
-        if (JSON.bool(entry, "consolidated") != Some(false))
-          error("list-files: parse-only node should be unconsolidated, got " + JSON.Format(entry))
-
-        // (c) entities finds the expected declarations.
-        val ents = request_op(name, JSON.Object("op" -> "query", "tool" -> "get_entities",
-          "path" -> "CommandLookup.thy"))
-        val entities = JSON.value(ents, "result").flatMap(r => JSON.array(r, "entities")).getOrElse(Nil)
-        val entKeys = entities.flatMap(e =>
-          for (kw <- JSON.string(e, "keyword"); nm <- JSON.string(e, "name")) yield (kw, nm))
-        for (expected <- List(("definition", "foo"), ("definition", "bar"),
-                              ("definition", "p"), ("definition", "q"),
-                              ("lemma", "apply_style"), ("lemma", "structured"))) {
-          if (!entKeys.contains(expected))
-            error("entities: parse-only node should expose " + expected + ", got " + entKeys)
-        }
-
-        // (d) command-info at a definition line reports status=unprocessed —
-        //     the definitive signal that no evaluation happened. `finished`/
-        //     `failed` would indicate the prover ran the command.
-        val ci = request_op(name, JSON.Object("op" -> "query", "tool" -> "get_command_info",
-          "path" -> "CommandLookup.thy", "line" -> 5))
-        val ciR = JSON.value(ci, "result").getOrElse(JSON.Object())
-        val status = JSON.value(ciR, "status").flatMap(st => JSON.string(st, "summary")).getOrElse("?")
-        if (status != "unprocessed")
-          error(s"command-info --line 5: expected status=unprocessed on a parse-only node, got '$status' (full reply: ${JSON.Format(ciR)})")
-        val src = JSON.string(ciR, "source").getOrElse("")
-        if (!src.contains("foo = 0"))
-          error("command-info --line 5: source should be the definition body, got: " + src)
-
-        // (e) context-info reports has_goal=false — parse-only has no STATE msgs.
-        val ctx = request_op(name, JSON.Object("op" -> "query", "tool" -> "get_context_info",
-          "path" -> "CommandLookup.thy", "line" -> 12))
-        val ctxR = JSON.value(ctx, "result").getOrElse(JSON.Object())
-        if (JSON.bool(ctxR, "has_goal") != Some(false))
-          error(s"context-info: parse-only lemma should have has_goal=false, got ${JSON.Format(ctxR)}")
-
-        // (f) Idempotent: a second load-files on the same file still succeeds.
-        val loaded2 = request_op(name, JSON.Object("op" -> "load-files", "files" -> List(file)))
-        if (JSON.string(loaded2, "event") != Some("load-files"))
-          error("load-files (2nd call): expected event=load-files, got " + JSON.Format(loaded2))
-        if (JSON.int(loaded2, "count") != Some(1))
-          error("load-files (2nd call): expected count=1, got " + JSON.Format(loaded2))
-
-        // (g) `server status --full` displays parse-only nodes with a `parsed`
-        //     flag. The heap-node filter requires `unprocessed==0` to exclude
-        //     them: TRUE for heap nodes (no PIDE commands tracked), FALSE for
-        //     parse-only nodes (every command is unprocessed) — so they are not
-        //     mistaken for heap-resident library nodes despite the same all-zero
-        //     percentage/finished/failed/warned shape.
-        val fullOut = ic2("server status --full -n " + Bash.string(name))
-        if (fullOut.rc != 0)
-          error("server status --full: expected rc=0, got " + fullOut.rc + " err=" + fullOut.err)
-        val fullText = fullOut.out + fullOut.err
-        if (!fullText.contains("Draft.CommandLookup"))
-          error("server status --full should now list the parse-only node, got:\n" + fullText)
-        if (!fullText.contains("parsed"))
-          error("server status --full should tag parse-only nodes with 'parsed', got:\n" + fullText)
-        if (!fullText.contains("0%"))
-          error("server status --full: parse-only node should be at 0%, got:\n" + fullText)
-
-        // (h) `list-files` now emits `unprocessed` and `running` fields (added
-        //     to distinguish parse-only from heap-resident). Pin the parse-
-        //     only shape: unprocessed>0, running=0.
-        val lfNow = request_op(name, JSON.Object("op" -> "query", "tool" -> "list_files"))
-        val loadedEntry = JSON.value(lfNow, "result").flatMap(r => JSON.array(r, "files")).getOrElse(Nil)
-          .find(f => JSON.string(f, "node").exists(_.endsWith("CommandLookup.thy")))
-          .getOrElse(error("list-files: CommandLookup.thy missing"))
-        if (JSON.int(loadedEntry, "unprocessed").getOrElse(0) <= 0)
-          error("list-files: parse-only node should have unprocessed>0, got " + JSON.Format(loadedEntry))
-        if (JSON.int(loadedEntry, "running") != Some(0))
-          error("list-files: parse-only node should have running=0, got " + JSON.Format(loadedEntry))
-
-        // (i) CLI-side: load-files exit codes.
-        //   - Missing FILE -> exit 2 (usage).
-        //   - Unknown/non-existent file -> exit 1 (local pre-check).
-        //   - Not a .thy file -> exit 1.
-        val n = Bash.string(name)
-        if (ic2("load-files -n " + n).rc != 2)
-          error("load-files with no FILE should exit 2")
-        if (ic2("load-files -n " + n + " /no/such/path/Foo.thy").rc != 1)
-          error("load-files on non-existent file should exit 1")
-        if (ic2("load-files -n " + n + " " + Bash.string(file.replace(".thy", ""))).rc != 1)
-          error("load-files on non-.thy path should exit 1")
       } finally {
         try { proc.terminate() } catch { case _: Throwable => }
         cleanup_server(name)

--- a/iq/src/SessionClient.scala
+++ b/iq/src/SessionClient.scala
@@ -101,8 +101,8 @@ final class SessionClient(session: Session, server: McpServer) {
 
     McpTool("list_spans",
       "Flat list of every parsed command span in a theory, with line, offset " +
-        "range, keyword, and source. Useful after `load_files` to inspect the " +
-        "raw parse output. `include_ignored` (default false) toggles inter-" +
+        "range, keyword, and source. Useful for inspecting the raw parse " +
+        "output. `include_ignored` (default false) toggles inter-" +
         "command whitespace/comment spans.",
       schema(Map(pathParam,
         "include_ignored" -> bool("Include Ignored_Span (whitespace/comments); default false")),

--- a/iq/src/SessionTools.scala
+++ b/iq/src/SessionTools.scala
@@ -246,8 +246,7 @@ object SessionTools {
   /** Resolve absolute .thy paths to (Document.Node.Name, theory-string) pairs
     * against a Headless.Resources. `find_theory` matches a session-known file
     * by canonical identity; otherwise the file is qualified as DRAFT. Used by
-    * both the check pipeline (Check.resolveTargets, which delegates here) and
-    * the parse-only loader (parseFiles). */
+    * the check pipeline (Check.resolveTargets, which delegates here). */
   def resolveFileTargets(
     resources: Headless.Resources, files: List[String]
   ): Either[String, List[(Document.Node.Name, String)]] =
@@ -268,119 +267,6 @@ object SessionTools {
       })
     } catch { case ERROR(msg) => Left(msg) }
 
-
-  /* ---- parse-only loading (empty-perspective session.update) ---- */
-
-  /** Load theories into the session as PARSED-BUT-UNEVALUATED nodes.
-    *
-    * Given absolute .thy paths, resolves each to a Node.Name, reads its text,
-    * parses the header (via resources.check_thy, which validates imports
-    * exist), then issues a session.update with a perspective that is
-    * deliberately empty (required=false, visible=empty, overlays=empty). The
-    * Scala-side change_parser runs `Thy_Syntax.parse_change` on the edits and
-    * fills in `Document.Version.nodes[name].commands` — every command in the
-    * theory gets a stable id, span, and start offset — so every
-    * SessionTools query (list_files, entities, sorry_positions, proof_blocks,
-    * command_info, context_info, commandAt/resolveCommand, ...) becomes
-    * usable on the newly-loaded nodes.
-    *
-    * The prover does NOT evaluate anything (see document.ML:864-870's
-    * `still_visible orelse node_required` gate — both false here, so
-    * iterate_entries_after is elided and no `new_exec` fires). No ML work
-    * runs; command_status will report `unprocessed`, `has_goal` will be
-    * false everywhere, `results_text` will be empty. If a subsequent
-    * `ic2 check` targets these same paths, use_theories' load_theories will
-    * see they haven't changed text-wise and won't re-emit edits, so the
-    * incremental cost is limited to actual evaluation.
-    *
-    * Bypasses Headless.Resources' private required-set (deliberately — we
-    * don't want these nodes to count toward any check's consolidation
-    * requirements). A concurrent `ic2 check` on the same node still works;
-    * Headless.Resources' internal state is separate from Session's document
-    * graph, which is what we're touching via session.update. */
-  /** A theory resolved for loading: its node name, current source text, and
-    * parsed header. Intermediate for parseFiles' dependency-closure loading. */
-  private final case class LoadTheory(
-    name: Document.Node.Name, text: String, header: Document.Node.Header)
-
-  /** Resolve the transitive .thy dependency closure of `files` (requested
-    * nodes + every source import, minus session-heap-resident theories) and
-    * read each one's text + header. `check_thy` validates that every import
-    * is locatable. Returns the requested node names paired with the full
-    * dep-ordered LoadTheory list. */
-  private def resolveLoadClosure(
-    resources: Headless.Resources, files: List[String]
-  ): Either[String, (List[Document.Node.Name], List[LoadTheory])] =
-    resolveFileTargets(resources, files).flatMap { targets =>
-      try {
-        val requested = targets.map(_._1)
-        val deps = resources.dependencies(requested.map(_ -> Position.none)).check_errors
-        val transitive = deps.theories.filterNot(resources.loaded_theory)
-        val theories =
-          for (name <- transitive) yield {
-            val path = name.path
-            if (!name.is_theory) error("not a theory file: " + path)
-            val text = File.read(path.file)
-            val header = resources.check_thy(name, Scan.char_reader(text))
-            LoadTheory(name, text, header)
-          }
-        Right((requested, theories))
-      } catch { case ERROR(msg) => Left(msg) }
-    }
-
-  /** The Deps + (incremental) Edits + Perspective triple for one node — the
-    * same shape Headless.Resources.Theory.make_edits produces. `textEdits`
-    * are computed against whatever the node currently holds (unchanged text
-    * -> Nil, so a re-load is a no-op rather than stacking a second copy). */
-  private def nodeEdits(
-    session: Session, t: LoadTheory, perspective: Document.Node.Perspective_Text.T
-  ): List[Document.Edit_Text] = {
-    val existing = nodeText(session, t.name)   // "" if not loaded yet
-    val textEdits =
-      if (existing == t.text) Nil
-      else if (existing.isEmpty) Text.Edit.inserts(0, t.text)
-      else Text.Edit.replace(0, existing, t.text)
-    (t.name -> Document.Node.Deps(t.header)) ::
-    (if (textEdits.isEmpty) Nil else List(t.name -> Document.Node.Edits(textEdits))) :::
-    List(t.name -> perspective)
-  }
-
-  /** Wait (bounded) for the async change_parser to populate `name`'s commands
-    * after a session.update, so a caller that immediately queries the node
-    * doesn't race the parser. Returns true once commands are present. */
-  private def awaitParsed(
-    session: Session, name: Document.Node.Name, timeout_ms: Long = 5000
-  ): Boolean = {
-    val deadline = System.currentTimeMillis() + timeout_ms
-    var ready = false
-    while (!ready && System.currentTimeMillis() < deadline) {
-      val nd = session.snapshot(node_name = name).get_node(name)
-      if (nd != null && nd.commands.nonEmpty) ready = true else Thread.sleep(25)
-    }
-    ready
-  }
-
-  private def emptyPerspective: Document.Node.Perspective_Text.T =
-    Document.Node.Perspective(false, Text.Perspective.empty, Document.Node.Overlays.empty)
-
-  def parseFiles(
-    session: Headless.Session,
-    resources: Headless.Resources,
-    files: List[String]
-  ): Either[String, List[Document.Node.Name]] =
-    resolveLoadClosure(resources, files).flatMap { case (requested, theories) =>
-      try {
-        // Parse-only: every node gets an empty perspective (required=false,
-        // no visible ranges), so the Scala change_parser fills in command
-        // spans but the prover evaluates nothing.
-        val edits = theories.flatMap(t => nodeEdits(session, t, emptyPerspective))
-        session.update(Document.Blobs.empty, edits)
-        for (t <- theories) awaitParsed(session, t.name)
-        // Return only the explicitly-requested nodes (transitive deps are an
-        // implementation detail; the caller cares about what it asked for).
-        Right(requested)
-      } catch { case ERROR(msg) => Left(msg) }
-    }
 
   /* ---- command resolution (file + offset|pattern -> Command) ---- */
 
@@ -693,10 +579,9 @@ object SessionTools {
   }
 
   /** list_spans: every command span in the node (a flat view of the parse
-    * output), each carrying line, offset range, keyword, and source. Handy
-    * after `load-files` to inspect what the parser produced — no evaluation
-    * required. `includeIgnored` toggles whether inter-command whitespace/
-    * comment spans (Ignored_Span) appear too. */
+    * output), each carrying line, offset range, keyword, and source.
+    * `includeIgnored` toggles whether inter-command whitespace/comment spans
+    * (Ignored_Span) appear too. */
   def listSpans(
     session: Session, name: Document.Node.Name, includeIgnored: Boolean
   ): Map[String, Any] = {


### PR DESCRIPTION
Previous, re-checking a theory after an edit would reprocess the entire theory contents, rather than the suffix from the point of modification onwards. This commit fixes that.

Under the hood, IC2 used to just call `use_theories`, but unfortunately this use a full-theory update even if only a small change to the file was made.

To remedy, we copy the relevant bits of the Isabelle distribution and modify as needed. The THIRD_PARTY file is amended appropriately, flagging the 3rd party source code and modification.

At the same time, we also remove the unnecessary `load-files` API from IC2 (CLI and MCP).
