### PR TITLE
Make ic2 checks submit-only

### DIFF
--- a/ic2/README.md
+++ b/ic2/README.md
@@ -10,8 +10,8 @@ serves work against it, avoiding repeated per-invocation session/heap loads.
 run side by side, with no host/port/token to configure):
 
   * **`ic2 server`** — start/stop/inspect the resident session.
-  * **`ic2 check FILE...`** — type-check `.thy` files, with live progress and a
-    scriptable exit code.
+  * **`ic2 check FILE...`** — submit `.thy` files for checking, then poll with
+    `check status`.
   * **`ic2 query SUBTOOL FILE`** — read-only diagnostics over the session.
   * **`ic2 repl-create FILE:LINE NAME`** — fork an interactive I/R REPL at a
     source location.
@@ -44,7 +44,8 @@ isabelle ic2 server start --daemon -l AutoCorrode -d AutoCorrode
 
 # Wait until the session is ready, then check a file:
 isabelle ic2 server status                  # state: building → loading → ready
-isabelle ic2 check /abs/path/to/Foo.thy     # exit 0 = ok, 1 = first error
+isabelle ic2 check /abs/path/to/Foo.thy     # submit
+isabelle ic2 check status                   # poll result
 
 # Stop:
 isabelle ic2 server stop
@@ -64,40 +65,39 @@ watch a cold build to completion).
 
 ## `ic2 check`
 
-Type-checks `.thy` files (absolute paths) against the running server, showing one
-live progress bar per theory and stopping at the first error.
+Submits `.thy` files (absolute paths) to be type-checked by the running server
+and returns immediately. Poll with `check status`; cancel with `check cancel`.
 
 ```bash
-isabelle ic2 check Foo.thy Bar.thy      # check both, stop at first error
-isabelle ic2 check Foo.thy --line 87    # partial: only up to line 87
-isabelle ic2 check Foo.thy -P           # plain output (no ANSI bars)
+isabelle ic2 check Foo.thy Bar.thy      # submit both
+isabelle ic2 check status               # state + per-theory status
+isabelle ic2 check Foo.thy --line 87    # submit partial check up to line 87
+isabelle ic2 check cancel               # abort the in-flight check
 ```
 
 `--line N` evaluates only the prefix up to line `N`, leaving the rest
 unprocessed and re-checkable — handy for iterating on the line you're editing.
-On Ctrl-C the check is cancelled and interrupted promptly; the server stays up.
 
 Exit codes drop into scripts and editor integrations:
 
 | code | meaning |
 |---|---|
-| 0 | all checks passed |
-| 1 | a check failed (a proof error was found, or the run was stopped) — **also** a bad FILE argument (not `.thy`, or does not exist) |
+| 0 | check submitted |
+| 1 | submission failed, or a bad FILE argument (not `.thy`, or does not exist) |
 | 2 | bad usage (no FILE, or `--line` with ≠1 file) |
-| 3 | server unreachable, not ready, or connection dropped mid-check |
+| 3 | server unreachable or not ready |
 
-Note the code-1 overlap: a missing or non-`.thy` path exits 1, the same as a
-real proof error. If a script must distinguish them, validate the path before
-calling `check`.
+Proof success or failure is reported by `check status`, not by the submit
+command's exit code.
 
-**Detached checks.** `--detach` submits and returns immediately; the check keeps
-running server-side after the command exits. Track it without `-n` ambiguity:
+`check attach` is the only live output path. It is intended for a human watching
+an interactive terminal with normal terminal capabilities; it rejects non-TTY,
+`TERM=dumb`, and common non-interactive/agent environments with a pointer to
+`check status` for automation or agentic workflows.
 
 ```bash
-isabelle ic2 check --detach Foo.thy     # "submitted (...)"
-isabelle ic2 check status               # state + per-theory status
-isabelle ic2 check attach               # stream to completion
-isabelle ic2 check cancel               # abort the in-flight check
+isabelle ic2 check attach                    # live terminal UI for human users
+isabelle ic2 check attach --long-running 10  # list commands running >=10s
 ```
 
 **At most one check runs at a time, server-wide** (`use_theories` is not safe to

--- a/ic2/src/client.scala
+++ b/ic2/src/client.scala
@@ -4,15 +4,15 @@
 /*  Title:      ic2/src/client.scala
 
 Client subcommands for `isabelle ic2`: `check FILE...`, `status`, `stop`.
-`check` renders one ANSI progress bar per active theory; it falls back to
-plain-text event lines on a non-TTY (or with -P).
+`check` submits work to the server and returns immediately. Live progress is
+only available through `check attach`, which is intended for human TTY use.
 
 Connects to the daemon's Unix-domain socket (discovered by name). There is no
 auth handshake — the 0700 socket directory is the access boundary.
 
-On exit (normal exit, exception, JVM shutdown) during a check, the channel
-closes and the server's cancel-on-disconnect path interrupts the in-flight
-check. There is no explicit cancel op: dropping the connection is the cancel.
+Foreground wire-protocol checks still use cancel-on-disconnect internally; the
+CLI `check` path uses detached checks instead, so automation cannot accidentally
+stream progress into a transcript.
 */
 
 package isabelle.ic2
@@ -31,7 +31,7 @@ object Client {
   private val MAX_ACTIVE_BARS: Int = 20
 
   /** Default threshold (seconds) for the long-running-command list under each
-   *  bar. Overridable per-invocation with `check --long-running SECS`. */
+   *  bar. */
   private val DEFAULT_LONG_RUNNING_SECS: Double = 5.0
 
   /** True if args request help. We intercept `help`/`--help`/`-h` in the
@@ -40,6 +40,21 @@ object Client {
    *  work uniformly across every `ic2` command. */
   private def wants_help(args: List[String]): Boolean =
     args.exists(a => a == "help" || a == "--help" || a == "-h")
+
+  private val NONINTERACTIVE_ATTACH_ENV: List[String] =
+    List("NONINTERACTIVE", "CI", "CODEX_CI", "CLAUDECODE")
+
+  private def env_marker_is_set(name: String): Boolean = {
+    val value = Isabelle_System.getenv(name).trim
+    value.nonEmpty && value != "0" && value.toLowerCase != "false"
+  }
+
+  private def noninteractive_attach_marker: Option[String] =
+    NONINTERACTIVE_ATTACH_ENV.find(env_marker_is_set).orElse {
+      val term = Isabelle_System.getenv("TERM").trim
+      if (term.isEmpty || term == "dumb") Some("TERM=" + (if (term.isEmpty) "<empty>" else term))
+      else None
+    }
 
 
   /* ---- discovery + connection ---- */
@@ -121,26 +136,23 @@ Usage: isabelle ic2 check [OPTIONS] FILE...
 
   Options are:
     -n NAME             server name (default: the sole running server)
-    -P                  plain mode (disable ANSI progress bars)
-    --detach            submit the check and return immediately, without
-                        waiting; track it with `ic2 check status`
     --line N            check only the prefix of the (single) FILE up to
                         and including the command that ends on or before
                         source line N (1-based). Fast partial check for
-                        iterative development. Same UI + cancel semantics
-                        as a full check; commands after line N are left
+                        iterative development. Commands after line N are left
                         UNPROCESSED. Requires exactly one FILE.
-    --long-running SECS commands running longer than SECS are listed under
-                        their theory's progress bar (default 5; 0 disables)
 
-  Type-check the given .thy files against the running server; the first error
-  stops the check (exit 1). Ctrl-C closes the connection, which cancels it.
-  With --detach the check keeps running after the command returns.
+  Submit a type-check of the given .thy files to the running server and return
+  immediately. Track progress with `isabelle ic2 check status`; abort the
+  in-flight check with `isabelle ic2 check cancel`.
+
+  Live output is only available via `isabelle ic2 check attach`, which requires
+  an interactive terminal with normal terminal capabilities and is intended for
+  human users.
 
   Examples:
-    isabelle ic2 check src/MyThy.thy               # full check
-    isabelle ic2 check src/MyThy.thy --line 42     # up to line 42 only
-    isabelle ic2 check src/MyThy.thy --detach      # background it
+    isabelle ic2 check src/MyThy.thy               # submit full check
+    isabelle ic2 check src/MyThy.thy --line 42     # submit up to line 42
 
   Subcommands (in place of FILE...): status | attach | cancel — see
   `isabelle ic2 --help`.
@@ -149,22 +161,13 @@ Usage: isabelle ic2 check [OPTIONS] FILE...
   def check(args: List[String]): Unit = {
     if (wants_help(args)) { Output.writeln(check_usage_text, stdout = true); sys.exit(2) }
     var name: Option[String] = None
-    var plain: Boolean = false
-    // `--detach`, `--long-running`, and `--line` are long options, which
-    // Isabelle's single-letter Getopts can't express; strip them ourselves
-    // first (same trick as `ic2 server start --daemon`).
-    val detach = args.contains("--detach")
-    var long_running_secs: Double = DEFAULT_LONG_RUNNING_SECS
-    val (long_running_stripped, afterLR) = extract_long_running(args) match {
-      case Some((secs, rest)) => long_running_secs = secs; (true, rest)
-      case None => (false, args)
-    }
-    val _ = long_running_stripped
-    val (line_opt, afterLine) = extract_line(afterLR)
-    val rest_args = afterLine.filterNot(_ == "--detach")
+    reject_removed_check_options(args)
+    // `--line` is a long option, which Isabelle's single-letter Getopts can't
+    // express; strip it ourselves first (same trick as `ic2 server start
+    // --daemon`).
+    val (line_opt, rest_args) = extract_line(args)
     val getopts = Getopts(check_usage_text,
-      "n:" -> (a => name = Some(a)),
-      "P"  -> (_ => plain = true))
+      "n:" -> (a => name = Some(a)))
 
     val files = getopts(rest_args)
     if (files.isEmpty) {
@@ -175,9 +178,16 @@ Usage: isabelle ic2 check [OPTIONS] FILE...
       sys.exit(2)
     }
     val server = resolve_name(name)
-    if (detach) do_check_detach(server, files, line_opt)
-    else do_check(server, plain, files, long_running_secs, line_opt)
+    do_check_detach(server, files, line_opt)
   }
+
+  private def reject_removed_check_options(args: List[String]): Unit =
+    args.find(a => a == "-P" || a == "--detach" || a == "--long-running").foreach { opt =>
+      Output.error_message("check: option " + opt + " was removed; " +
+        "check always submits and returns. Use `isabelle ic2 check status` " +
+        "for polling or `isabelle ic2 check attach` for human live output.")
+      sys.exit(2)
+    }
 
   /** Pull an optional `--line N` from the args: returns (parsed line-or-None,
    *  args with the flag+value removed). Exits(2) if N isn't a positive integer,
@@ -197,82 +207,9 @@ Usage: isabelle ic2 check [OPTIONS] FILE...
     }
   }
 
-  /** Pull an optional `--long-running SECS` from the args, returning the
-   *  parsed threshold + the args with both tokens removed; None if absent. */
-  private def extract_long_running(args: List[String]): Option[(Double, List[String])] = {
-    val i = args.indexOf("--long-running")
-    if (i < 0 || i + 1 >= args.length) None
-    else {
-      val v = args(i + 1)
-      v.toDoubleOption match {
-        case Some(secs) if secs >= 0 =>
-          Some((secs, args.take(i) ::: args.drop(i + 2)))
-        case _ =>
-          Output.error_message("check: --long-running SECS expects a non-negative number, got " + v)
-          sys.exit(2)
-      }
-    }
-  }
-
-  private def do_check(name: String, plain: Boolean, files: List[String],
-                       long_running_secs: Double = DEFAULT_LONG_RUNNING_SECS,
-                       line: Option[Int] = None): Unit = {
-    // Validate locally first — fail fast with the user's CWD context, before
-    // any round-trip. The server re-checks too (defence in depth).
-    val abs_files = files.map { f =>
-      if (!f.endsWith(".thy")) {
-        Output.error_message("not a .thy file: " + f); sys.exit(1)
-      }
-      val jfile = Path.explode(f).expand.absolute_file
-      if (!jfile.isFile) {
-        Output.error_message("file not found: " + f); sys.exit(1)
-      }
-      File.standard_path(jfile)
-    }
-
-    val io = open_connection(resolve_socket(name))
-
-    /* Cancel on JVM shutdown (Ctrl-C, etc.): closing the channel is the
-     * cancel — the server interrupts the in-flight check on disconnect. */
-    val sig_handler = new Thread(new Runnable {
-      def run(): Unit = try { io.close() } catch { case _: Throwable => }
-    }, "ic2-sigint")
-    Runtime.getRuntime.addShutdownHook(sig_handler)
-
-    io.write(JSON.Object("op" -> "check", "files" -> abs_files) ++
-      line.map(l => JSON.Object("line" -> l)).getOrElse(JSON.Object()))
-
-    val use_tui = !plain && System.console() != null
-    val ui: Progress_UI =
-      if (use_tui) new ANSI_UI(MAX_ACTIVE_BARS, long_running_secs = long_running_secs)
-      else new Plain_UI(long_running_secs = long_running_secs)
-
-    var ok: Option[Boolean] = None
-    var reason: String = ""
-
-    try {
-      stream_check_events(io, ui, b => ok = Some(b), r => reason = r)
-    } finally {
-      ui.close()
-      try { Runtime.getRuntime.removeShutdownHook(sig_handler) }
-      catch { case _: IllegalStateException => /* shutdown in progress */ }
-      try { io.close() } catch { case _: Throwable => }
-    }
-
-    ok match {
-      case Some(true) => sys.exit(0)
-      case Some(false) =>
-        if (reason.nonEmpty) Output.error_message("check failed: " + reason)
-        sys.exit(1)
-      case None =>
-        Output.error_message("check: connection lost before completion")
-        sys.exit(3)
-    }
-  }
-
   /** Read the check event stream from `io`, rendering started/progress/error to
-   *  `ui` and reporting the terminal `finished` via setOk/setReason. Shared by
-   *  the foreground `check` and `check-attach`. Returns when `finished` or EOF. */
+   *  `ui` and reporting the terminal `finished` via setOk/setReason. Used by
+   *  `check attach`. Returns when `finished` or EOF. */
   private def stream_check_events(
     io: JSON_IO, ui: Progress_UI, setOk: Boolean => Unit, setReason: String => Unit
   ): Unit = {
@@ -292,8 +229,10 @@ Usage: isabelle ic2 check [OPTIONS] FILE...
                 JSON.int(t, "line").getOrElse(0),
                 JSON.string(t, "message").getOrElse(""))
             case Some("finished") =>
-              setOk(JSON.bool(t, "ok").getOrElse(false))
-              setReason(JSON.string(t, "reason").getOrElse(""))
+              val ok = JSON.bool(t, "ok").getOrElse(false)
+              val reason = JSON.string(t, "reason").getOrElse("")
+              setOk(ok)
+              setReason(reason)
               done = true
             case Some("server_error") => ui.server_error(JSON.string(t, "message").getOrElse(""))
             case Some("shutting_down") => ui.note("server shutting down")
@@ -322,7 +261,7 @@ Usage: isabelle ic2 check [OPTIONS] FILE...
           "track with: isabelle ic2 check status -n " + name)
         sys.exit(0)
       case _ =>
-        Output.error_message("check --detach failed: " +
+        Output.error_message("check submit failed: " +
           JSON.string(reply, "message").getOrElse(JSON.Format(reply)))
         sys.exit(1)
     }
@@ -381,6 +320,50 @@ Usage: isabelle ic2 $cmd [-n NAME] [-c N]
     (resolve_name(name), if (bars <= 0) Int.MaxValue else bars)
   }
 
+  /** Like `name_and_bars_opt`, with attach-only long-running-command display
+   *  threshold. `--long-running 0` disables the under-bar command list. */
+  private def name_bars_long_running_opt(
+    cmd: String, desc: String, args: List[String]
+  ): (String, Int, Double) = {
+    val usage = s"""
+Usage: isabelle ic2 $cmd [-n NAME] [-c N] [--long-running SECS]
+
+  $desc
+
+  -n NAME              server name (default: the sole running server)
+  -c N                 max per-theory progress bars to show (default $DEFAULT_BARS; 0 = all)
+  --long-running SECS  list commands running longer than SECS under their
+                       theory's progress bar (default $DEFAULT_LONG_RUNNING_SECS; 0 disables)
+"""
+    if (wants_help(args)) { Output.writeln(usage, stdout = true); sys.exit(2) }
+    val (long_running_secs, rest_args) = extract_long_running_for_attach(args)
+    var name: Option[String] = None
+    var bars: Int = DEFAULT_BARS
+    val getopts = Getopts(usage,
+      "n:" -> (a => name = Some(a)),
+      "c:" -> (a => bars = Value.Int.parse(a)))
+    val rest = getopts(rest_args)
+    if (rest.nonEmpty) getopts.usage()
+    (resolve_name(name), if (bars <= 0) Int.MaxValue else bars, long_running_secs)
+  }
+
+  private def extract_long_running_for_attach(args: List[String]): (Double, List[String]) = {
+    val i = args.indexOf("--long-running")
+    if (i < 0) (DEFAULT_LONG_RUNNING_SECS, args)
+    else if (i + 1 >= args.length) {
+      Output.error_message("check attach: --long-running requires a non-negative number of seconds")
+      sys.exit(2)
+    }
+    else args(i + 1).toDoubleOption match {
+      case Some(secs) if secs >= 0 =>
+        (secs, args.take(i) ::: args.drop(i + 2))
+      case _ =>
+        Output.error_message("check attach: --long-running SECS expects a non-negative number, got " +
+          args(i + 1))
+        sys.exit(2)
+    }
+  }
+
   /** `ic2 check status`: print one static frame of the current/last check —
    *  the same "checking N theory/theories" + per-theory bar view that
    *  `check attach` streams, but rendered once and returned. Because it shows
@@ -427,17 +410,26 @@ Usage: isabelle ic2 $cmd [-n NAME] [-c N]
     }
   }
 
-  /** `ic2 check attach`: stream the in-flight (typically detached) check's
-   *  progress to completion, like a foreground check. Does not cancel on
-   *  disconnect. */
+  /** `ic2 check attach`: stream the in-flight check's progress to completion
+   *  for a human using an interactive terminal. Does not cancel on disconnect. */
   def check_attach(args: List[String]): Unit = {
-    val (name, bars) = name_and_bars_opt("check attach",
-      "Stream the in-flight check's progress to completion, like a foreground\n" +
-      "  check. Does NOT cancel the check on disconnect.", args)
+    val (name, bars, long_running_secs) = name_bars_long_running_opt("check attach",
+      "Stream the in-flight check's progress to completion for a human user.\n" +
+      "  Requires an interactive terminal with normal terminal capabilities;\n" +
+      "  use check status in automation or agentic workflows.", args)
+    noninteractive_attach_marker.foreach { marker =>
+      Output.error_message("check attach is disabled in non-interactive/agent environments (" +
+        marker + " is set); use `isabelle ic2 check status -n " + name + "` for polling")
+      sys.exit(2)
+    }
+    if (System.console() == null) {
+      Output.error_message("check attach requires an interactive terminal; use " +
+        "`isabelle ic2 check status -n " + name + "` for non-interactive polling")
+      sys.exit(2)
+    }
     val io = open_connection(resolve_socket(name))
     io.write(JSON.Object("op" -> "check_attach"))
-    val use_tui = System.console() != null
-    val ui: Progress_UI = if (use_tui) new ANSI_UI(bars) else new Plain_UI(bars)
+    val ui: Progress_UI = new ANSI_UI(bars, long_running_secs = long_running_secs)
     var ok: Option[Boolean] = None; var reason = ""
     try { stream_check_events(io, ui, b => ok = Some(b), r => reason = r) }
     finally { ui.close(); try { io.close() } catch { case _: Throwable => } }
@@ -1292,7 +1284,7 @@ Usage: isabelle ic2 server attach [OPTIONS]
 
   /** A single running command reported alongside its theory in a progress
     *  event. Rendered indented under that theory's bar when its `elapsed_s`
-    *  clears the client's --long-running threshold. `preview` is a single-line
+    *  clears the live UI threshold. `preview` is a single-line
     *  trimmed excerpt of the command source (empty when the daemon couldn't
     *  produce one, e.g. batch/pro-forma theory nodes), used to disambiguate
     *  otherwise-identical entries (two `by (…)` proofs on different lines). */
@@ -1402,35 +1394,6 @@ Usage: isabelle ic2 server attach [OPTIONS]
     }
     val more = if (active.size > shown.size) List(s"  ... +${active.size - shown.size} more in flight") else Nil
     header :: rows ::: more
-  }
-
-  /** No fancy UI: one event per line. `max_active` bounds how many in-flight
-   *  theories appear in each progress line (Int.MaxValue = all). Commands
-   *  running longer than `long_running_secs` are printed indented under the
-   *  progress line for their theory. */
-  class Plain_UI(
-    max_active: Int = 20,
-    long_running_secs: Double = DEFAULT_LONG_RUNNING_SECS
-  ) extends Progress_UI {
-    def started(theories: List[String]): Unit =
-      Output.writeln("checking " + theories.length + " theory/theories: " +
-        theories.mkString(", "))
-    def progress(nodes: List[Theory_Status]): Unit = {
-      // Most-recently-updated first, alphabetical tiebreak among same-tick.
-      val active = nodes.filter(n => !n.done).sortBy(n => (-n.updated, n.theory))
-      val (done, total) = (nodes.count(_.done), nodes.length)
-      val shown = active.take(max_active)
-      Output.writeln(s"[$done/$total done] " + shown.map(n =>
-        s"${n.theory} ${n.percentage}%").mkString("; "))
-      // Under each shown theory, indent its long-running commands.
-      for (n <- shown; ln <- render_long_running(n.long_running, long_running_secs))
-        Output.writeln("  [" + n.theory + "]" + ln.stripPrefix("     "))
-    }
-    def error(theory: String, file: String, line: Int, msg: String): Unit =
-      Output.error_message(s"ERROR in $theory at $file:$line\n$msg")
-    def server_error(msg: String): Unit = Output.error_message("server: " + msg)
-    def note(msg: String): Unit = Output.writeln(msg)
-    def close(): Unit = ()
   }
 
   /** ANSI live UI: shows the N in-flight theories the check most recently

--- a/ic2/src/ic2.scala
+++ b/ic2/src/ic2.scala
@@ -60,18 +60,17 @@ Usage: isabelle ic2 COMMAND [ARGS...]
         server status          report a server (-n NAME), or survey all
         server attach          stream a backgrounded server's console log
 
-    check [FILE...]            Type-check .thy files against the running
-                               server; first-error stop; exit 0 on success.
+    check [FILE...]            Submit .thy files to be type-checked by the
+                               running server; returns after submission.
       Variants (in place of FILE...):
         check status           report the current/last check's state
-        check attach           stream the in-flight check to completion
+        check attach           stream the in-flight check to completion;
+                               requires an interactive terminal context
         check cancel           cancel the in-flight check
       Options:
         --line N               check only the prefix of the (single) FILE
                                up to the command ending on or before source
                                line N; commands after N are left UNPROCESSED
-        --detach               submit and return immediately (poll via
-                               `check status` / `check attach`)
 
     query state-at FILE ...    Query document / proof state at a target
                                location. Location is FILE plus one of:
@@ -105,7 +104,8 @@ Usage: isabelle ic2 COMMAND [ARGS...]
   ============================== Concrete flow ============================
 
     isabelle ic2 server start --daemon -l HOL
-    isabelle ic2 check src/MyThy.thy                       # exit 0 = ok
+    isabelle ic2 check src/MyThy.thy                       # submit check
+    isabelle ic2 check status                              # poll result
     isabelle ic2 check src/MyThy.thy --line 87             # only up to 87
     isabelle ic2 query state-at src/MyThy.thy --line 87    # inspect goal
     isabelle ic2 server stop
@@ -161,7 +161,7 @@ Usage: isabelle ic2 server SUBCOMMAND [ARGS...]
       case "status" :: rest => Client.check_status(rest)
       case "attach" :: rest => Client.check_attach(rest)
       case "cancel" :: rest => Client.check_cancel(rest)
-      case _ => Client.check(args)   // FILE... [+ --detach/-n/-P], or its own --help/usage
+      case _ => Client.check(args)   // FILE... [+ --line/-n], or its own --help/usage
     }
 
   private def run_tool(args: List[String]): Unit =

--- a/ic2/src/iq.scala
+++ b/ic2/src/iq.scala
@@ -231,8 +231,8 @@ object Check {
 
   /** Currently long-running commands in `name`, via the session's bound
     * `Timing_Tracker` (see it for why that stream is the right signal).
-    * Returns Nil when no tracker is bound. The threshold is applied by the
-    * CLIENT (`--long-running`), so this reports every live command. */
+    * Returns Nil when no tracker is bound. Display thresholds are applied by
+    * clients, so this reports every live command. */
   def runningCommandsFor(
     session: Session, name: Document.Node.Name
   ): List[RunningCommand] =

--- a/ic2/src/test_tool.scala
+++ b/ic2/src/test_tool.scala
@@ -634,6 +634,22 @@ Usage: isabelle ic2_test [OPTIONS] MODE [DIR]
       } finally io.close()
     }
 
+    private def wait_check_state(name: String, states: Set[String], deadline_secs: Int = 30): JSON.T = {
+      val deadline = System.currentTimeMillis() + deadline_secs * 1000L
+      var st = request_op(name, JSON.Object("op" -> "check_status"))
+      while (!states.contains(JSON.string(st, "state").getOrElse("")) &&
+             System.currentTimeMillis() < deadline) {
+        Thread.sleep(200)
+        st = request_op(name, JSON.Object("op" -> "check_status"))
+      }
+      if (JSON.string(st, "event") != Some("check_status"))
+        error("check_status should reply check_status, got " + JSON.Format(st))
+      if (!states.contains(JSON.string(st, "state").getOrElse("")))
+        error("check_status did not reach " + states.mkString("/") +
+          " within " + deadline_secs + "s, got " + JSON.Format(st))
+      st
+    }
+
     /** Theory names are session-qualified on the wire (e.g. "Draft.Trivial_OK");
      *  tests compare against the unqualified basename. */
     private def base_name(theory: String): String = {
@@ -1336,19 +1352,43 @@ Usage: isabelle ic2_test [OPTIONS] MODE [DIR]
       }
     }
 
-    /** The `ic2 check` CLI front door: exit 0 on success, 1 on a check failure,
-     *  2 on a usage error (no FILE). -P forces the plain UI for determinism. */
+    /** The `ic2 check` CLI front door submits and returns. Completion state is
+     *  observed with `check_status`; live `check attach` is TTY-only. */
     private def e2e_check_cli(server_name: String, fixtures: Path): Unit = {
       val ok = (fixtures + Path.basic("Trivial_OK.thy")).expand.implode
       val bad = (fixtures + Path.basic("Trivial_Fail.thy")).expand.implode
       val n = Bash.string(server_name)
 
-      val r0 = ic2("check -P -n " + n + " " + Bash.string(ok))
-      if (r0.rc != 0) error("check OK should exit 0, got " + r0.rc + " err=" + r0.err.mkString)
-      val r1 = ic2("check -P -n " + n + " " + Bash.string(bad))
-      if (r1.rc != 1) error("check Fail should exit 1, got " + r1.rc)
-      val r2 = ic2("check -P -n " + n)
+      val r0 = ic2("check -n " + n + " " + Bash.string(ok))
+      if (r0.rc != 0) error("check OK should submit with exit 0, got " + r0.rc + " err=" + r0.err.mkString)
+      val r0_text = r0.out.mkString + r0.err.mkString
+      if (!r0_text.contains("submitted"))
+        error("check OK should print submitted ack, got output=" + r0_text)
+      val s0 = wait_check_state(server_name, Set("ok"))
+      if (JSON.bool(s0, "ok") != Some(true))
+        error("submitted OK check should finish ok, got " + JSON.Format(s0))
+
+      val r1 = ic2("check -n " + n + " " + Bash.string(bad))
+      if (r1.rc != 0) error("check Fail should submit with exit 0, got " + r1.rc)
+      val s1 = wait_check_state(server_name, Set("failed"))
+      if (JSON.bool(s1, "ok") != Some(false))
+        error("submitted failing check should finish failed/ok=false, got " + JSON.Format(s1))
+
+      val r2 = ic2("check -n " + n)
       if (r2.rc != 2) error("check with no FILE should exit 2, got " + r2.rc)
+      val r3 = ic2("check -P -n " + n + " " + Bash.string(ok))
+      if (r3.rc != 2) error("check -P should be rejected as bad usage, got " + r3.rc)
+      val r4 = ic2("check --detach -n " + n + " " + Bash.string(ok))
+      if (r4.rc != 2) error("check --detach should be rejected as bad usage, got " + r4.rc)
+      val r5 = ic2("check attach -n " + n)
+      if (r5.rc != 2) error("check attach without TTY should exit 2, got " + r5.rc)
+      if (!r5.err.mkString.contains("check status"))
+        error("check attach without TTY should point to check status, got err=" + r5.err.mkString)
+      val r6 = ic2("check attach --long-running 1 -n " + n)
+      if (r6.rc != 2) error("check attach --long-running without TTY should exit 2, got " + r6.rc)
+      if (!r6.err.mkString.contains("check status"))
+        error("check attach --long-running should be accepted before the TTY guard, got err=" +
+          r6.err.mkString)
     }
 
     /** Re-checking a changed theory should preserve the unchanged processed
@@ -2654,20 +2694,23 @@ Usage: isabelle ic2_test [OPTIONS] MODE [DIR]
         // (d) CLI `ic2 check --line N` (on the same Slow.thy that (a) used,
         //     so it's already loaded; this arm tests the CLI wrapper's exit codes).
         val n = Bash.string(name)
-        val cliOk = ic2("check -P -n " + n + " " + Bash.string(file) + " --line 13")
+        val cliOk = ic2("check -n " + n + " " + Bash.string(file) + " --line 13")
         if (cliOk.rc != 0)
           error("ic2 check --line 13 should exit 0, got rc=" + cliOk.rc + " err=" + cliOk.err)
+        val cliSt = wait_check_state(name, Set("ok"))
+        if (JSON.bool(cliSt, "ok") != Some(true))
+          error("ic2 check --line 13 should finish ok, got " + JSON.Format(cliSt))
 
         // (e) Usage errors.
         //     - `--line` with no value.
-        val e1 = ic2("check -P -n " + n + " " + Bash.string(file) + " --line")
+        val e1 = ic2("check -n " + n + " " + Bash.string(file) + " --line")
         if (e1.rc != 2) error("check --line with no value: expected rc=2, got " + e1.rc)
         //     - `--line` with two FILEs.
         val other = (fixtures + Path.basic("Trivial_OK.thy")).expand.implode
-        val e2 = ic2("check -P -n " + n + " " + Bash.string(file) + " " + Bash.string(other) + " --line 3")
+        val e2 = ic2("check -n " + n + " " + Bash.string(file) + " " + Bash.string(other) + " --line 3")
         if (e2.rc != 2) error("check --line with 2 FILEs: expected rc=2, got " + e2.rc)
         //     - `--line 0`.
-        val e3 = ic2("check -P -n " + n + " " + Bash.string(file) + " --line 0")
+        val e3 = ic2("check -n " + n + " " + Bash.string(file) + " --line 0")
         if (e3.rc != 2) error("check --line 0: expected rc=2, got " + e3.rc)
 
         // (f) LINE BOUNDING — `--line N` stops evaluation at the target line.


### PR DESCRIPTION
Change the check CLI to submit work and return, with completion observed through check status. Keep live progress behind `check attach`, reject non-interactive or agent contexts, and let human attach users tune long-running command display with --long-running.

This avoids accidental ANSI/progress floods in automation while preserving an explicit terminal-only live UI for interactive use.