### PR TITLE
I/R: support native Windows

### DIFF
--- a/ir/heap_info.py
+++ b/ir/heap_info.py
@@ -11,6 +11,8 @@ import re
 import sqlite3
 import subprocess
 
+from win_compat import isabelle_argv, from_cygwin_path
+
 try:
     import zstandard
     HAS_ZSTD = True
@@ -39,12 +41,12 @@ def isabelle_getenv(var, isabelle_bin=None):
         if not val:
             try:
                 r = subprocess.run(
-                    [isabelle_bin, "getenv", "-b", var],
+                    isabelle_argv(isabelle_bin, ["getenv", "-b", var]),
                     capture_output=True, text=True, timeout=5)
                 val = r.stdout.strip()
             except Exception:
                 val = ""
-        _isabelle_env_cache[key] = val
+        _isabelle_env_cache[key] = from_cygwin_path(val)
     return _isabelle_env_cache[key]
 
 
@@ -92,7 +94,7 @@ def file_lines(path):
     """
     if path not in _file_content_cache:
         try:
-            content = open(path, "r", errors="replace").read()
+            content = open(path, "r", encoding="utf-8", errors="replace").read()
             line_starts = [0]  # symbol offset at start of each line
             sym = 0
             i = 0
@@ -279,17 +281,17 @@ class HeapInfo:
         if not heaps_dir:
             try:
                 r = subprocess.run(
-                    [isabelle_bin, "getenv", "-b", "ISABELLE_HEAPS"],
+                    isabelle_argv(isabelle_bin, ["getenv", "-b", "ISABELLE_HEAPS"]),
                     capture_output=True, text=True, timeout=10)
-                heaps_dir = r.stdout.strip()
+                heaps_dir = from_cygwin_path(r.stdout.strip())
             except Exception:
                 pass
         if not heaps_dir:
             try:
                 r = subprocess.run(
-                    [isabelle_bin, "getenv", "-b", "ISABELLE_HOME_USER"],
+                    isabelle_argv(isabelle_bin, ["getenv", "-b", "ISABELLE_HOME_USER"]),
                     capture_output=True, text=True, timeout=10)
-                home_user = r.stdout.strip()
+                home_user = from_cygwin_path(r.stdout.strip())
                 if home_user:
                     heaps_dir = os.path.join(home_user, "heaps")
             except Exception:

--- a/ir/mcp_server.py
+++ b/ir/mcp_server.py
@@ -160,14 +160,16 @@ _ASCII_TO_UNICODE = {}  # populated by _load_symbols below
 def _load_mcp_symbols():
     """Load symbol table for MCP server."""
     import os, subprocess
+    from win_compat import isabelle_argv, from_cygwin_path
     isabelle = os.environ.get("ISABELLE",
-        os.path.expanduser("~/Isabelle2025-2-experimental.app/bin/isabelle"))
+        os.path.expanduser("~/Isabelle2025-2/bin/isabelle" if os.name == "nt"
+                           else "~/Isabelle2025-2-experimental.app/bin/isabelle"))
     try:
-        isabelle_home = subprocess.check_output(
-            [isabelle, "getenv", "-b", "ISABELLE_HOME"],
-            text=True, timeout=10).strip()
+        isabelle_home = from_cygwin_path(subprocess.check_output(
+            isabelle_argv(isabelle, ["getenv", "-b", "ISABELLE_HOME"]),
+            text=True, timeout=10).strip())
         symbols_path = os.path.join(isabelle_home, "etc", "symbols")
-        with open(symbols_path) as f:
+        with open(symbols_path, encoding="utf-8") as f:
             for line in f:
                 line = line.strip()
                 if not line or line.startswith("#"):
@@ -516,6 +518,11 @@ async def raw_ml(ml_code: str, ctx: Context = None) -> str:
 # ---------------------------------------------------------------------------
 
 def main():
+    # Spawned as its own process, so it needs the same cp1252 guard repl.py
+    # applies -- otherwise a "●" in a log line kills the MCP server on Windows.
+    from win_compat import force_utf8_stdio
+    force_utf8_stdio()
+
     import argparse
     p = argparse.ArgumentParser(description="I/R MCP server")
     p.add_argument("--transport", choices=["stdio", "sse", "streamable-http"],

--- a/ir/repl.py
+++ b/ir/repl.py
@@ -32,7 +32,32 @@ Usage:
 import sys
 
 
+def _force_utf8_stdio():
+    """Make stdout/stderr UTF-8 on Windows, whatever the console codepage is.
+
+    Native Windows Python encodes stdout with the locale codepage (e.g.
+    cp1252), which cannot encode the "●" in our status lines -- that raises
+    UnicodeEncodeError and kills the process mid-startup.  PYTHONUTF8=1 avoids
+    it, but the I/Q jEdit plugin spawns `python3 repl.py` with no flags and its
+    own environment, so we cannot depend on that being set.
+
+    Deliberately inlined rather than imported from win_compat: this runs on the
+    `cli` path too, and importing win_compat (subprocess, shutil) costs ~19ms
+    on a ~16ms interpreter start -- see the module docstring on keeping `cli`
+    near the startup floor.  Mirrors win_compat.force_utf8_stdio().
+    """
+    if sys.platform != "win32":
+        return
+    for stream in (sys.stdout, sys.stderr):
+        try:
+            stream.reconfigure(encoding="utf-8", errors="replace")
+        except (AttributeError, ValueError, OSError):
+            pass
+
+
 def main():
+    _force_utf8_stdio()
+
     if len(sys.argv) >= 2 and sys.argv[1] == "cli":
         import repl_cli
         repl_cli.main(sys.argv[2:])   # always exits

--- a/ir/repl_srv.py
+++ b/ir/repl_srv.py
@@ -82,6 +82,10 @@ if hasattr(sys.stderr, "reconfigure"):
     sys.stderr.reconfigure(line_buffering=True)
 import time
 
+from win_compat import (
+    IS_WINDOWS, isabelle_argv, SPAWN_KW, terminate_tree, from_cygwin_path,
+    restrict_file_to_user)
+
 try:
     from prompt_toolkit import PromptSession
     from prompt_toolkit.completion import Completer, Completion
@@ -349,12 +353,12 @@ def _extract_repl_id(command):
 
 def _load_symbols(isabelle_bin):
     """Load unicode-to-Isabelle-ASCII mapping from $ISABELLE_HOME/etc/symbols."""
-    isabelle_home = subprocess.check_output(
-        [isabelle_bin, "getenv", "-b", "ISABELLE_HOME"],
-        text=True, timeout=10).strip()
+    isabelle_home = from_cygwin_path(subprocess.check_output(
+        isabelle_argv(isabelle_bin, ["getenv", "-b", "ISABELLE_HOME"]),
+        text=True, timeout=10).strip())
     symbols_path = os.path.join(isabelle_home, "etc", "symbols")
     unicode_to_ascii = {}
-    with open(symbols_path, "r") as f:
+    with open(symbols_path, "r", encoding="utf-8") as f:
         for line in f:
             line = line.strip()
             if not line or line.startswith("#"):
@@ -574,15 +578,15 @@ class BashServer:
     """Starts an Isabelle Bash.Server for external tool support (e.g. Sledgehammer)."""
 
     def __init__(self, isabelle, quiet=False):
-        cmd = [isabelle, "scala", "-e",
+        cmd = isabelle_argv(isabelle, ["scala", "-e",
                '{ val server = isabelle.Bash.Server.start(debugging = false); '
                'println("BASH_SERVER_ADDRESS=" + server.address); '
                'println("BASH_SERVER_PASSWORD=" + server.password); '
-               'Thread.sleep(Long.MaxValue) }']
+               'Thread.sleep(Long.MaxValue) }'])
         self.proc = subprocess.Popen(
             cmd, stdin=subprocess.DEVNULL,
             stdout=subprocess.PIPE, stderr=subprocess.PIPE,
-            start_new_session=True)
+            **SPAWN_KW)
         self.address = None
         self.password = None
         if quiet:
@@ -607,11 +611,14 @@ class BashServer:
 
     def close(self):
         if self.proc.poll() is None:
-            os.killpg(self.proc.pid, signal.SIGTERM)
+            terminate_tree(self.proc)
             try:
                 self.proc.wait(timeout=5)
             except subprocess.TimeoutExpired:
-                os.killpg(self.proc.pid, signal.SIGKILL)
+                if IS_WINDOWS:
+                    terminate_tree(self.proc)   # taskkill /F already forceful
+                else:
+                    os.killpg(self.proc.pid, signal.SIGKILL)
 
 
 def spinner(label, done_event):
@@ -639,13 +646,23 @@ class PolyMLProcess:
         self.cmd = self._build_cmd(isabelle, session, directory, ml_dir, port,
                                    bash_server=bash_server, redirect=redirect)
         self.startup_output = []
+        env = None
+        if IS_WINDOWS and not os.environ.get("IR_REPL_AUTH_TOKEN", "").strip():
+            # Native Poly/ML on Windows cannot open Cygwin's /dev/urandom, so
+            # Tcp_Handler.generate_token would fall back to a predictable
+            # time-derived token.  Python can reach the OS CSPRNG, so mint the
+            # token here and hand it over; generate_token prefers this variable.
+            # POSIX is left untouched -- /dev/urandom works there.
+            env = dict(os.environ)
+            env["IR_REPL_AUTH_TOKEN"] = secrets.token_hex(24)
         self.proc = subprocess.Popen(
             self.cmd,
             stdin=subprocess.DEVNULL,
             stdout=subprocess.PIPE,
             stderr=subprocess.STDOUT,
             bufsize=0,
-            start_new_session=True,
+            env=env,
+            **SPAWN_KW,
         )
 
     def read_actual_port(self, timeout=60):
@@ -677,25 +694,25 @@ class PolyMLProcess:
     @staticmethod
     def _build_cmd(isabelle, session, directory, ml_dir, port,
                    bash_server=None, redirect=False):
-        cmd = [isabelle, "ML_process"]
+        isa_args = ["ML_process"]
         if directory:
-            cmd += ["-d", directory]
-        cmd += ["-l", session]
+            isa_args += ["-d", directory]
+        isa_args += ["-l", session]
         if bash_server:
-            cmd += ["-o", f"bash_process_address={bash_server.address}",
+            isa_args += ["-o", f"bash_process_address={bash_server.address}",
                     "-o", f"bash_process_password={bash_server.password}"]
         if redirect:
-            cmd.append("-r")
+            isa_args.append("-r")
         # Forward ISABELLE_REMOTE options (e.g. process_policy for I/P remote execution)
         isabelle_remote = os.environ.get("ISABELLE_REMOTE", "")
         if isabelle_remote:
-            cmd += shlex.split(isabelle_remote)
+            isa_args += shlex.split(isabelle_remote)
         # Load order: tcp_handler, ir, ml_repl (ml_repl wires them together)
-        cmd += ["-f", os.path.join(ml_dir, "tcp_handler.ML"),
+        isa_args += ["-f", os.path.join(ml_dir, "tcp_handler.ML"),
                 "-f", os.path.join(ml_dir, "ir.ML"),
                 "-f", os.path.join(ml_dir, "ml_repl.ML"),
                 "-e", f"case ML_Repl.start {port} of SOME (_, t) => Isabelle_Thread.join t | NONE => ();"]
-        return cmd
+        return isabelle_argv(isabelle, isa_args)
 
     def alive(self):
         return self.proc.poll() is None
@@ -715,16 +732,14 @@ class PolyMLProcess:
                 self.proc.wait(timeout=5)
             except subprocess.TimeoutExpired:
                 pass
-        # Step 2: SIGTERM to process group (catchable — lets ml_proxy cleanup run)
+        # Step 2: terminate the process tree (catchable SIGTERM on POSIX lets
+        # ml_proxy cleanup run; taskkill /T on Windows).
         if self.proc.poll() is None:
-            try:
-                os.killpg(self.proc.pid, signal.SIGTERM)
-            except OSError:
-                self.proc.terminate()
+            terminate_tree(self.proc)
             try:
                 self.proc.wait(timeout=10)
             except subprocess.TimeoutExpired:
-                print("WARNING: Poly/ML process did not exit after SIGTERM",
+                print("WARNING: Poly/ML process did not exit after termination",
                       flush=True)
 
 
@@ -978,7 +993,12 @@ class Server:
         # loop by retrying acquire on subsequent commands.
         self.pool_acquire_timeout = float(pool_acquire_timeout)
         self.sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
-        self.sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+        # Not on Windows: there SO_REUSEADDR also permits binding a port another
+        # process is actively listening on, so a second daemon would silently
+        # announce a port it does not own and clients would reach the first one.
+        # (Same trap as in tcp_handler.ML; Windows rebinds TIME_WAIT anyway.)
+        if not IS_WINDOWS:
+            self.sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
         if port == 0:
             # Try default port first; fall back to OS-assigned.
             try:
@@ -1516,7 +1536,12 @@ class Server:
                     return
                 auth_buf += chunk
             auth_line, buf = auth_buf.split(b"\n", 1)
-            received_token = auth_line.decode("utf-8", errors="replace")
+            # Tolerate CRLF.  Java's PrintWriter.println() uses the platform
+            # line separator, so I/Q's IRClient sends "<token>\r\n" on Windows;
+            # without this the compare below always fails and every repl_* tool
+            # reports "REPL authentication failed" while repl_connect (which
+            # never authenticates) still looks fine.
+            received_token = auth_line.decode("utf-8", errors="replace").rstrip("\r")
             if not hmac.compare_digest(received_token, self.token):
                 client.sendall(b"ERR: authentication failed\n")
                 disconnect_reason = "authentication failed"
@@ -1537,7 +1562,7 @@ class Server:
                         self.clients[client]["bytes_in"] += len(chunk)
                 while b"\n" in buf:
                     line, buf = buf.split(b"\n", 1)
-                    text = line.decode("utf-8")
+                    text = line.decode("utf-8").rstrip("\r")   # CRLF-tolerant
                     # Intercept /-commands before command accumulation
                     if not cmd_lines and text.strip().startswith("/"):
                         local_result = self._handle_local_command(text)
@@ -2059,11 +2084,88 @@ def discover_mgmt_sockets():
     return results
 
 
+# --- Management-console transport -------------------------------------------
+#
+# POSIX uses an AF_UNIX socket at sock_path, with mode 0600 keeping other local
+# users out (see the README threat model).  Windows CPython does not expose
+# AF_UNIX at all, so there we listen on an ephemeral 127.0.0.1 TCP port and use
+# sock_path as a *rendezvous file* holding "<port>\n<token>\n".  Since a
+# localhost port is reachable by every local user, the token restores the
+# same-user restriction that 0600 gave us; the file itself is ACL'd to the
+# current user so only they can read the token.
+#
+# Keeping the rendezvous file at exactly the path the socket would have used
+# means mgmt_socket_path()/discover_mgmt_sockets() and every os.path.exists /
+# os.unlink call around them work identically on both platforms.
+
+def mgmt_listen(sock_path):
+    """Bind the management-console listener.  Returns ``(sock, token)``.
+
+    ``token`` is None on POSIX (filesystem permissions are the access control)
+    and a random string on Windows, which clients must send as their first
+    line.  Removes any stale socket/rendezvous file at *sock_path* first.
+    """
+    if os.path.exists(sock_path):
+        os.unlink(sock_path)
+    if not IS_WINDOWS:
+        sock = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+        sock.bind(sock_path)
+        restrict_file_to_user(sock_path)
+        sock.listen(4)
+        return sock, None
+    sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    sock.bind(("127.0.0.1", 0))
+    sock.listen(4)
+    token = secrets.token_urlsafe(24)
+    # Create the file before writing, so the ACL is tightened while it is still
+    # empty and the token is never briefly world-readable.
+    fd = os.open(sock_path, os.O_CREAT | os.O_EXCL | os.O_WRONLY, 0o600)
+    os.close(fd)
+    if not restrict_file_to_user(sock_path):
+        print(f"{YELLOW}WARNING: could not restrict permissions on "
+              f"{sock_path}; the management token may be readable by other "
+              f"local users.{RST}", file=sys.stderr, flush=True)
+    with open(sock_path, "w", encoding="utf-8") as f:
+        f.write(f"{sock.getsockname()[1]}\n{token}\n")
+    return sock, token
+
+
+def mgmt_connect(sock_path):
+    """Connect to a daemon's management console.  Returns a connected socket.
+
+    Raises OSError if the daemon is unreachable, or the rendezvous file is
+    malformed, or (Windows) the token is rejected.
+    """
+    if not IS_WINDOWS:
+        sock = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+        sock.connect(sock_path)
+        return sock
+    with open(sock_path, encoding="utf-8") as f:
+        parts = f.read().split("\n")
+    if len(parts) < 2 or not parts[0].strip().isdigit():
+        raise OSError(f"malformed management rendezvous file {sock_path}")
+    sock = socket.create_connection(("127.0.0.1", int(parts[0].strip())))
+    sock.sendall((parts[1] + "\n").encode("utf-8"))
+    reply = b""
+    while b"\n" not in reply:
+        chunk = sock.recv(4096)
+        if not chunk:
+            sock.close()
+            raise OSError("management console closed during authentication")
+        reply += chunk
+    if not reply.startswith(b"OK"):
+        sock.close()
+        raise OSError(reply.split(b"\n", 1)[0].decode("utf-8", "replace"))
+    return sock
+
+
 class MgmtSocketServer:
-    """Unix socket server for the management console in daemon mode.
+    """Socket server for the management console in daemon mode.
 
     Accepts multiple connections. Output is broadcast to all connected
     clients. Input from any client is fed to process_mgmt_console_input.
+    Transport is AF_UNIX on POSIX and token-authenticated localhost TCP on
+    Windows -- see mgmt_listen().
     """
 
     def __init__(self, server, sock_path, completer=None):
@@ -2074,12 +2176,7 @@ class MgmtSocketServer:
         self.clients_lock = threading.Lock()
         # Wire server output to broadcast
         server.mgmt_output = self.broadcast
-        self.sock = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
-        if os.path.exists(sock_path):
-            os.unlink(sock_path)
-        self.sock.bind(sock_path)
-        os.chmod(sock_path, 0o600)
-        self.sock.listen(4)
+        self.sock, self.token = mgmt_listen(sock_path)
         self.running = True
 
     def broadcast(self, msg):
@@ -2108,16 +2205,74 @@ class MgmtSocketServer:
                 continue
             except OSError:
                 break
-            with self.clients_lock:
-                self.clients.append(client)
-            print("Management console attached", flush=True)
+            # Registration happens in _handle_client, after authentication, so
+            # an unauthenticated peer never receives broadcast output.
             threading.Thread(target=self._handle_client, args=(client,),
                              daemon=True).start()
 
-    def _handle_client(self, client):
-        cmd_lines = []
+    def _authenticate(self, client):
+        """Consume the token line on Windows.  Returns (ok, leftover_bytes).
+
+        On POSIX there is no token -- AF_UNIX file permissions already limit
+        this to the same user -- so nothing is consumed.
+        """
+        if self.token is None:
+            return True, b""
+        # Bounded wait so a peer that connects and stays silent cannot pin a
+        # thread (or an accept slot) indefinitely.
+        client.settimeout(10.0)
         buf = b""
         try:
+            while b"\n" not in buf:
+                chunk = client.recv(4096)
+                if not chunk:
+                    return False, b""
+                buf += chunk
+                if len(buf) > 4096:
+                    return False, b""
+        except (OSError, socket.timeout):
+            return False, b""
+        finally:
+            client.settimeout(None)
+        line, rest = buf.split(b"\n", 1)
+        # CRLF-tolerant, same reasoning as Server._handle_client.
+        if not hmac.compare_digest(
+                line.decode("utf-8", errors="replace").rstrip("\r"),
+                self.token):
+            try:
+                client.sendall(b"ERR: authentication failed\n")
+            except OSError:
+                pass
+            return False, b""
+        try:
+            client.sendall(b"OK\n")
+        except OSError:
+            return False, b""
+        return True, rest
+
+    def _handle_client(self, client):
+        cmd_lines = []
+        ok, buf = self._authenticate(client)
+        if not ok:
+            try:
+                client.close()
+            except OSError:
+                pass
+            return
+        with self.clients_lock:
+            self.clients.append(client)
+        print("Management console attached", flush=True)
+        try:
+            # Any bytes that arrived in the same packet as the token still
+            # need processing before we read more.
+            while b"\n" in buf:
+                line_bytes, buf = buf.split(b"\n", 1)
+                line = line_bytes.decode("utf-8", errors="replace").rstrip("\r")
+                if process_mgmt_console_input(line, self.server, cmd_lines,
+                                              output_fn=self.broadcast,
+                                              completer=self.completer):
+                    self.server.running = False
+                    return
             while self.running and self.server.running:
                 chunk = client.recv(4096)
                 if not chunk:
@@ -2125,7 +2280,7 @@ class MgmtSocketServer:
                 buf += chunk
                 while b"\n" in buf:
                     line_bytes, buf = buf.split(b"\n", 1)
-                    line = line_bytes.decode("utf-8", errors="replace")
+                    line = line_bytes.decode("utf-8", errors="replace").rstrip("\r")
                     if process_mgmt_console_input(line, self.server, cmd_lines,
                                                   output_fn=self.broadcast,
                                                   completer=self.completer):
@@ -2195,10 +2350,9 @@ def attach_mode(sock_path):
         print(f"{DIM}Start with: repl.py --daemon{RST}", file=sys.stderr)
         sys.exit(1)
 
-    sock = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
     try:
-        sock.connect(sock_path)
-    except (ConnectionRefusedError, OSError) as e:
+        sock = mgmt_connect(sock_path)
+    except OSError as e:
         print(f"{RED}Cannot connect to {sock_path}: {e}{RST}", file=sys.stderr)
         sys.exit(1)
 
@@ -2277,7 +2431,11 @@ def find_isabelle_installation(isabelle_arg):
     candidates = []
 
     if isabelle_arg:
-        expanded = os.path.expanduser(isabelle_arg)
+        # The I/Q plugin passes --isabelle Isabelle_System.getenv("ISABELLE_HOME"),
+        # which on Windows is a Cygwin path (/cygdrive/c/...) that native Python
+        # cannot stat.  Convert it back before looking anything up; this is a
+        # no-op on POSIX and for paths already in Windows form.
+        expanded = os.path.expanduser(from_cygwin_path(isabelle_arg))
         # If it's a directory, try common binary locations
         if os.path.isdir(expanded):
             candidates.extend([
@@ -2292,6 +2450,14 @@ def find_isabelle_installation(isabelle_arg):
             candidates.extend([
                 "/Applications/Isabelle2025-2.app/bin/isabelle",
                 os.path.expanduser("~/Isabelle2025-2.app/bin/isabelle"),
+            ])
+        elif os.name == "nt":
+            # Windows: try common install locations (the bash script under bin/;
+            # it is invoked via Cygwin bash by win_compat.isabelle_argv).
+            candidates.extend([
+                os.path.expanduser("~/Isabelle2025-2/bin/isabelle"),
+                os.path.expanduser("~/Documents/Isabelle2025-2/bin/isabelle"),
+                r"C:\Isabelle2025-2\bin\isabelle",
             ])
         else:
             # Linux: try home directory
@@ -2355,7 +2521,8 @@ def main():
     p.add_argument("--kill-daemon", action="store_true",
                    help="Kill a running daemon and exit")
     p.add_argument("--mgmt-socket", default=None,
-                   help="Unix socket path for --daemon/--attach "
+                   help="Management console socket path for --daemon/--attach "
+                        "(Windows: rendezvous file for the mgmt TCP port) "
                         "(default: auto-derived from TCP port)")
     p.add_argument("--pool-size", type=int, default=5,
                    help="Number of persistent ML connections (default: 5, "
@@ -2397,8 +2564,7 @@ def main():
             print(f"{DIM}No daemon running (no socket at {sock_path}){RST}")
             sys.exit(0)
         try:
-            sock = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
-            sock.connect(sock_path)
+            sock = mgmt_connect(sock_path)
             sock.sendall(b"/quit\n")
             sock.close()
             # Wait for socket file to disappear
@@ -2634,7 +2800,7 @@ def main():
             # because the ML process only knows the remote platform name.
             # Local case: ML_System.platform is correct.
             ml_system = subprocess.check_output(
-                [args.isabelle, "getenv", "-b", "ML_SYSTEM"],
+                isabelle_argv(args.isabelle, ["getenv", "-b", "ML_SYSTEM"]),
                 text=True, timeout=10).strip()
             isa_remote = os.environ.get("ISABELLE_REMOTE", "")
             m = re.search(r'-o\s+ML_platform=(\S+)', isa_remote)
@@ -2711,7 +2877,8 @@ def main():
             heap_info.close()
         sys.exit(128 + signum)
     signal.signal(signal.SIGTERM, _signal_cleanup)
-    signal.signal(signal.SIGHUP, _signal_cleanup)
+    if hasattr(signal, "SIGHUP"):   # SIGHUP does not exist on Windows
+        signal.signal(signal.SIGHUP, _signal_cleanup)
 
     pool_size = args.pool_size
     if poly and poly.max_connections is not None:

--- a/ir/tcp_handler.ML
+++ b/ir/tcp_handler.ML
@@ -89,17 +89,58 @@ fun constant_time_equal a b =
             Word8.fromInt (Char.ord (String.sub (b, i))))))
     in go 0 (Word8.fromInt 0) = Word8.fromInt 0 end;
 
-(* Generate a random hex token from /dev/urandom. *)
+(* Generate a random hex token.  Sources, in order of preference:
+
+     1. IR_REPL_AUTH_TOKEN from the environment.  repl_srv.py sets this to a
+        secrets.token_hex() value when it spawns us on Windows, where the OS
+        CSPRNG is reachable from Python but not from native Poly/ML.  (This is
+        the same variable a user sets to hand a token to --expect-ml mode, so
+        the two directions stay symmetric.)
+     2. /dev/urandom -- the CSPRNG on POSIX.  Native Poly/ML on Windows cannot
+        open Cygwin's virtual /dev/urandom, so this fails there.
+     3. A time/serial-derived token, as a last resort.
+
+   (3) is *predictable*: Time.now () barely moves between adjacent calls and
+   serial () is a plain counter, so consecutive tokens share nearly all of
+   their digits.  It does not meet the README threat model's "keep other local
+   OS users out" bar, and exists only so that start () still yields a token
+   instead of raising.  We warn loudly whenever it is reached. *)
 fun generate_token () =
   let
-    val stream = BinIO.openIn "/dev/urandom"
-    val bytes = BinIO.inputN (stream, 24)
-    val _ = BinIO.closeIn stream
     fun byte_hex b =
       let val s = Word8.fmt StringCvt.HEX b
       in if String.size s < 2 then "0" ^ s else s end
-  in String.translate (str o Char.toLower)
-       (String.concat (Word8Vector.foldr (fn (b, acc) => byte_hex b :: acc) [] bytes))
+    fun hex_of_bytes bytes =
+      String.translate (str o Char.toLower)
+        (String.concat (Word8Vector.foldr (fn (b, acc) => byte_hex b :: acc) [] bytes))
+    fun from_env () =
+      let val t = getenv "IR_REPL_AUTH_TOKEN"
+      in if size t >= 16 then SOME t else NONE end
+    fun from_urandom () =
+      let
+        val stream = BinIO.openIn "/dev/urandom"
+        val bytes = BinIO.inputN (stream, 24)
+        val _ = BinIO.closeIn stream
+      in SOME (hex_of_bytes bytes) end
+      (* Not "handle _": that would also swallow Interrupt. *)
+      handle IO.Io _ => NONE | OS.SysErr _ => NONE
+    fun fallback () =
+      let
+        fun chunk () =
+          LargeInt.fmt StringCvt.HEX (Time.toNanoseconds (Time.now ()))
+          ^ LargeInt.fmt StringCvt.HEX (LargeInt.fromInt (serial ()))
+        val raw = String.concat [chunk (), chunk (), chunk (), chunk ()]
+        val lower = String.translate (str o Char.toLower) raw
+        val _ = warning ("Tcp_Handler: no CSPRNG available; falling back to a " ^
+          "PREDICTABLE time-derived token.  Set IR_REPL_AUTH_TOKEN to a strong " ^
+          "random value to secure this listener.")
+      in
+        if String.size lower >= 48 then String.substring (lower, 0, 48) else lower
+      end
+  in
+    case from_env () of
+      SOME t => t
+    | NONE => (case from_urandom () of SOME t => t | NONE => fallback ())
   end;
 
 (* Wrap an accepted socket into BinIO streams, following Socket_IO.make_streams. *)
@@ -214,7 +255,18 @@ fun start port =
          In both cases, actual_port is read back via getSockName. *)
       val SOME me = NetHostDB.getByName "127.0.0.1"
       val ssock : Socket.passive INetSock.stream_sock = INetSock.TCP.socket ()
-      val _ = Socket.Ctl.setREUSEADDR (ssock, true)
+      (* SO_REUSEADDR means different things on the two platforms.  On POSIX it
+         only permits rebinding a port left in TIME_WAIT, which is what we want.
+         On Windows it ALSO permits binding a port another process is actively
+         listening on: bind then silently "succeeds", we announce a port we do
+         not own, and every client is delivered to the other process instead --
+         producing a hang with no diagnostic (this bites when a jEdit/I/Q
+         session already holds the default port 9146).  Windows lets us rebind
+         TIME_WAIT ports without the option, so we skip it there and let bind
+         fail loudly with EADDRINUSE instead. *)
+      val _ =
+        if getenv "ISABELLE_PLATFORM_FAMILY" = "windows" then ()
+        else Socket.Ctl.setREUSEADDR (ssock, true)
       val _ =
         if port = 0 then
           (Socket.bind (ssock, INetSock.toAddr (NetHostDB.addr me, default_port))

--- a/ir/win_compat.py
+++ b/ir/win_compat.py
@@ -1,0 +1,201 @@
+
+"""Windows compatibility helpers for the I/R Python daemon.
+
+The `isabelle` launcher is a Cygwin *bash script*, not a native Windows
+executable, so `subprocess` cannot run it directly on Windows -- CreateProcess
+raises ``WinError 193: %1 is not a valid Win32 application``.  On Windows we
+therefore run it as  ``bash <isabelle-script> <args...>``  using the Cygwin
+bash that ships with Isabelle, converting absolute Windows path arguments to
+``/cygdrive/`` form so Cygwin can open them.
+
+On POSIX every function here is a thin pass-through, so behaviour on
+Linux/macOS is unchanged.
+"""
+
+import getpass
+import os
+import re
+import shutil
+import subprocess
+import sys
+
+IS_WINDOWS = (os.name == "nt")
+
+# Matches an absolute Windows path such as  C:\x  or  C:/x .  Used to decide
+# which argv elements are filesystem paths that need /cygdrive/ conversion;
+# ML expressions, option strings and session names never match.
+_WIN_ABS = re.compile(r'^[A-Za-z]:[\\/]')
+
+
+def to_cygwin_path(p):
+    r"""Convert  C:\Users\me\x  ->  /cygdrive/c/Users/me/x .
+
+    Non-(absolute-Windows) strings are returned unchanged, so this is safe to
+    apply to every argument.
+    """
+    if not isinstance(p, str) or not _WIN_ABS.match(p):
+        return p
+    drive = p[0].lower()
+    rest = p[2:].replace("\\", "/")
+    if not rest.startswith("/"):
+        rest = "/" + rest
+    return "/cygdrive/" + drive + rest
+
+
+_CYGDRIVE = re.compile(r'^/cygdrive/([A-Za-z])(/.*)?$')
+
+
+def from_cygwin_path(p):
+    r"""Convert  /cygdrive/c/Users/me/x  ->  C:\Users\me\x  (Windows only).
+
+    Values that Isabelle returns (e.g. ``isabelle getenv ISABELLE_HOME``) are
+    Cygwin POSIX paths; native Windows Python's ``open``/``os.path`` cannot use
+    them.  Non-cygdrive strings and all POSIX platforms are passed through
+    unchanged, so this is safe to apply to any getenv result.
+    """
+    if not IS_WINDOWS or not isinstance(p, str):
+        return p
+    m = _CYGDRIVE.match(p)
+    if not m:
+        return p
+    drive = m.group(1).upper()
+    rest = (m.group(2) or "").replace("/", os.sep)
+    return drive + ":" + (rest if rest else os.sep)
+
+
+def find_cygwin_bash(isabelle_bin):
+    """Locate the Cygwin ``bash.exe`` bundled with Isabelle.
+
+    Priority: the ``ISABELLE_CYGWIN_BASH`` override, then well-known locations
+    relative to the Isabelle distribution root (derived from the path of the
+    ``isabelle`` script), then any ``bash`` on PATH.
+    """
+    override = os.environ.get("ISABELLE_CYGWIN_BASH")
+    if override and os.path.isfile(override):
+        return override
+    # <root>/bin/isabelle  ->  <root>
+    root = os.path.dirname(os.path.dirname(os.path.abspath(isabelle_bin)))
+    candidates = [
+        os.path.join(root, "cygwin", "bin", "bash.exe"),
+        os.path.join(root, "contrib", "cygwin", "bin", "bash.exe"),
+    ]
+    for c in candidates:
+        if os.path.isfile(c):
+            return c
+    found = shutil.which("bash")
+    if found:
+        return found
+    raise RuntimeError(
+        "Could not locate the Cygwin bash bundled with Isabelle. "
+        "Set the ISABELLE_CYGWIN_BASH environment variable to the full path "
+        "of <Isabelle>/cygwin/bin/bash.exe")
+
+
+_cygwin_path_done = False
+
+
+def _ensure_cygwin_on_path(bash):
+    """Prepend Cygwin's bin directory to PATH (once).
+
+    Launched straight from Windows, bash inherits the Windows PATH, which does
+    not contain Cygwin's bin -- so the isabelle script's calls to ``basename``,
+    ``dirname`` etc. fail with "command not found", which in turn breaks its
+    ISABELLE_HOME computation.  Cygwin translates the inherited Windows PATH to
+    POSIX form on startup, so adding the bin dir here makes those tools resolve.
+    """
+    global _cygwin_path_done
+    if _cygwin_path_done:
+        return
+    cyg_bin = os.path.dirname(os.path.abspath(bash))
+    parts = os.environ.get("PATH", "").split(os.pathsep)
+    if cyg_bin.lower() not in (p.lower() for p in parts):
+        os.environ["PATH"] = cyg_bin + os.pathsep + os.environ.get("PATH", "")
+    _cygwin_path_done = True
+
+
+def isabelle_argv(isabelle_bin, args):
+    """Return an argv list that runs ``isabelle <args>`` on this platform.
+
+    POSIX: ``[isabelle_bin, *args]`` unchanged.
+    Windows: ``[bash, <isabelle-as-cygwin-path>, *args-with-paths-converted]``,
+    with Cygwin's bin ensured on PATH so the script's Unix tools resolve.
+    """
+    args = list(args)
+    if not IS_WINDOWS:
+        return [isabelle_bin] + args
+    bash = find_cygwin_bash(isabelle_bin)
+    _ensure_cygwin_on_path(bash)
+    return [bash, to_cygwin_path(isabelle_bin)] + [to_cygwin_path(a) for a in args]
+
+
+# Spawn keyword args: POSIX puts the child in its own session so a later
+# os.killpg() reaches the whole tree; Windows uses a new process group and is
+# torn down with taskkill /T (see terminate_tree).
+if IS_WINDOWS:
+    SPAWN_KW = {"creationflags": subprocess.CREATE_NEW_PROCESS_GROUP}
+else:
+    SPAWN_KW = {"start_new_session": True}
+
+
+def force_utf8_stdio():
+    """Make stdout/stderr UTF-8 on Windows, whatever the console codepage is.
+
+    Native Windows Python encodes stdout with the locale codepage (e.g.
+    cp1252), so the ``●`` in our status lines raises UnicodeEncodeError and
+    kills the process during startup.  ``PYTHONUTF8=1`` fixes it, but the I/Q jEdit
+    plugin spawns ``python3 repl.py`` with no flags and its own environment, so
+    we cannot rely on that being set -- we have to be robust on our own.
+
+    ``errors="replace"`` means an unencodable character can never be fatal.
+    Java 18+ (JEP 400) decodes subprocess output as UTF-8 by default, so I/Q
+    reads these bytes correctly.  No-op on POSIX.
+    """
+    if not IS_WINDOWS:
+        return
+    for stream in (sys.stdout, sys.stderr):
+        try:
+            stream.reconfigure(encoding="utf-8", errors="replace")
+        except (AttributeError, ValueError, OSError):
+            pass   # not a reconfigurable TextIOWrapper (e.g. already wrapped)
+
+
+def restrict_file_to_user(path):
+    """Restrict *path* to the current user only.  Returns True on success.
+
+    POSIX uses ``chmod 0600``.  Windows has no mode bits, so we reset the
+    file's inherited ACEs and grant full control to the current user alone via
+    ``icacls``.  This matters because on Windows the management-console
+    rendezvous file holds an auth token (see ``mgmt_listen`` in repl_srv.py);
+    the README threat model requires keeping other local OS users out.
+    """
+    if not IS_WINDOWS:
+        os.chmod(path, 0o600)
+        return True
+    user = os.environ.get("USERNAME") or getpass.getuser()
+    try:
+        r = subprocess.run(
+            ["icacls", path, "/inheritance:r", "/grant:r", f"{user}:F"],
+            stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL, timeout=15)
+        return r.returncode == 0
+    except (OSError, subprocess.SubprocessError):
+        return False
+
+
+def terminate_tree(proc):
+    """Terminate a child process *and its descendants*, cross-platform.
+
+    POSIX: ``os.killpg(proc.pid, SIGTERM)``, with ``proc.terminate()`` as the
+    fallback if the process group is already gone.  Windows has no ``killpg``,
+    so use ``taskkill /F /T`` (kill tree) there instead.
+    """
+    if proc is None or proc.poll() is not None:
+        return
+    if IS_WINDOWS:
+        subprocess.run(["taskkill", "/F", "/T", "/PID", str(proc.pid)],
+                       stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+    else:
+        import signal
+        try:
+            os.killpg(proc.pid, signal.SIGTERM)
+        except OSError:
+            proc.terminate()


### PR DESCRIPTION
*Description of changes:*

Makes the I/R daemon run under native Windows Python (no WSL). Linux and macOS
behaviour is unchanged -- every platform branch is guarded by `IS_WINDOWS` /
`os.name` (`ISABELLE_PLATFORM_FAMILY` in ML), and the new helpers in
`ir/win_compat.py` are pass-throughs on POSIX.

What was broken on Windows:

- `isabelle` is a Cygwin bash script → `WinError 193` on every subprocess call.
  Now run via Isabelle's bundled bash, with `/cygdrive/` conversion for
  arguments going in and Windows form for `getenv` values coming out.
- `os.killpg` / `start_new_session` / `SIGHUP` unavailable → `terminate_tree()`,
  `SPAWN_KW`, guarded signal registration.
- `AF_UNIX` not exposed by CPython on Windows → the mgmt console uses an
  ephemeral localhost port plus a rendezvous file at the same path. That port is
  reachable by any local user, unlike a 0600 socket, so the Windows path adds a
  token and a per-user ACL on the file.
- Locale codepage (e.g. cp1252) → UTF-8 reads failed, and the `●` in the status
  lines killed startup with `UnicodeEncodeError`. Explicit UTF-8 reads + stdio.
- Native Poly/ML cannot open Cygwin's `/dev/urandom` → `generate_token` prefers
  `IR_REPL_AUTH_TOKEN`, minted by Python's CSPRNG.
- `SO_REUSEADDR` on Windows also permits binding a port another process is
  actively listening on → I/R announced a port it did not own and hung with no
  diagnostic. Not set there now.
- Java's `PrintWriter.println` sends CRLF → every `repl_*` call failed auth while
  `repl_connect` (which never authenticates) reported success. Line parsing is
  now CRLF-tolerant.

Tested on Windows 11 / Isabelle2025-2 / CPython 3.12: standalone `--daemon`, the
I/Q `--daemon --expect-ml` path, mgmt console auth accept/reject, `--kill-daemon`.
Not run on Linux locally.

`ir/test_repl.py` is untouched and still POSIX-only (`os.killpg`), so this file still does not run on Windows.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
