### PR TITLE
I/P: Disable `ip-test` CI job temporarily

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -147,6 +147,10 @@ jobs:
           make install ISABELLE_HOME=$ISABELLE_HOME
 
   ip-test:
+    # Temporarily disabled, see issue #263: the `Configure I/P remote` step
+    # fails because the Isabelle download seems to be blocked for GitHub runners.
+    # Set to `true` (or delete this line) to re-enable.
+    if: false
     runs-on: ubuntu-latest
     container:
       image: makarius/isabelle:Isabelle2025-2


### PR DESCRIPTION
See also Issue #263: this job seems to consistently fail - the test attempts to download Isabelle and gets no response.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
