### PR TITLE
IC2: Show long-running commands and allow registering per-command timeout

### DIFF
--- a/ic2/README.md
+++ b/ic2/README.md
@@ -72,11 +72,19 @@ and returns immediately. Poll with `check status`; cancel with `check cancel`.
 isabelle ic2 check Foo.thy Bar.thy      # submit both
 isabelle ic2 check status               # state + per-theory status
 isabelle ic2 check Foo.thy --line 87    # submit partial check up to line 87
+isabelle ic2 check Foo.thy --command-timeout 15
 isabelle ic2 check cancel               # abort the in-flight check
 ```
 
 `--line N` evaluates only the prefix up to line `N`, leaving the rest
 unprocessed and re-checkable — handy for iterating on the line you're editing.
+
+Every individual command has a 5-second wall-clock timeout by default. If one
+exceeds the limit, IC2 aborts the whole check with reason `command_timeout`;
+`check status` identifies the command and reports its source location, elapsed
+time, and preview. Use `--command-timeout SECS` to override the limit for one
+check (decimal seconds are accepted), or `--command-timeout 0` to disable it.
+The daemon enforces the limit, so it remains active after detached submission.
 
 Exit codes drop into scripts and editor integrations:
 
@@ -222,7 +230,9 @@ With `--mcp` (opt-in, off by default), the server also stands up a generic
     serves ic2's headless session and I/Q's live PIDE session — the `query` CLI
     routes through the same dispatch;
   * **`check` / `check_async` / `check_status` / `check_cancel`** — the MCP
-    analogue of `isabelle ic2 check` (with MCP progress notifications).
+    analogue of `isabelle ic2 check` (with MCP progress notifications). Both
+    submit tools accept `command_timeout_secs` (default 5; 0 disables);
+    blocking `check` also retains its separate whole-check `timeout_secs`.
 
 ### Connecting an MCP client
 

--- a/ic2/src/check_engine.scala
+++ b/ic2/src/check_engine.scala
@@ -19,9 +19,9 @@ The IC2 check engine, in three cleanly separated steps:
      = `all_preds required_node`), so we never mark ancestors ourselves.
 
   C) stop — the inverse of B: un-require the targets AND reclaim any still-running
-     in-flight execution (a fork left running by a cancelled / first-error / timed-
-     out check). A PAUSE, not a teardown — node text stays in the model for the next
-     incremental check.
+     in-flight execution in the import closure (a fork left running by a cancelled /
+     first-error / timed-out check). A PAUSE, not a teardown — node text stays in the
+     model for the next incremental check.
 
 This replaces the former ic2_use_theories.scala, which was a copy of
 `Headless.Session.use_theories` that fused "update the model" with "evaluate" and
@@ -298,11 +298,12 @@ object Check_Engine {
     *
     *  1. RECLAIM in-flight execution. Dropping `required` alone does NOT interrupt a
     *     tactic already running on a worker thread — the perspective flip is
-    *     text-neutral, so PIDE keeps the fork alive. For each target with a running
-    *     or forked command, a text-CHANGING tail remint (SessionTools.resetNodeTails)
-    *     re-splits [frontier, EOF) so PIDE's version-assignment diff cancels the
-    *     superseded execs AND their fork groups — the primitive that truly interrupts
-    *     the ML tactic. That remint also flips those nodes to not-required.
+    *     text-neutral, so PIDE keeps the fork alive. For each closure node with a
+    *     running or forked command, a text-CHANGING tail remint
+    *     (SessionTools.resetNodeTails) re-splits [frontier, EOF) so PIDE's
+    *     version-assignment diff cancels the superseded execs AND their fork groups —
+    *     the primitive that truly interrupts the ML tactic. That remint also flips
+    *     those nodes to not-required.
     *  2. UN-REQUIRE the rest. Targets with nothing in flight only need their
     *     `required` flag cleared — a text-neutral perspective flip. This is a PAUSE,
     *     not a teardown: node text stays in the model, so the next check's
@@ -311,13 +312,14 @@ object Check_Engine {
     * Runs on every exit path of a check (normal completion, first-error, cancel,
     * timeout, exception). Best-effort; safe to call unconditionally — a fully
     * consolidated node has no running command, so it takes the cheap un-require path
-    * (`cancelFrontier` returns None). Operates on `model.targets` only: ancestors
-    * were never explicitly required, so they go dormant once no target pulls them in. */
+    * (`cancelFrontier` returns None). Running ancestors must be considered too:
+    * although they were never explicitly required, dropping the target's requirement
+    * does not interrupt work that has already started. */
   def stop(session: Headless.Session, model: Model): Unit =
     try {
-      // Targets with something still executing: reclaim via a text-changing tail
-      // edit (which also un-requires them). No-op on a settled node.
-      val cuts = model.targets.flatMap(n => SessionTools.cancelFrontier(session, n).map(n -> _))
+      // Any closure node with something still executing: reclaim via a
+      // text-changing tail edit (which also un-requires it). No-op on settled nodes.
+      val cuts = model.closure.flatMap(n => SessionTools.cancelFrontier(session, n).map(n -> _))
       val reclaimed = cuts.map(_._1).toSet
       // The remaining targets (nothing in flight) just need `required` cleared.
       val releaseEdits = model.targets.filterNot(reclaimed).map(_ -> notRequired)

--- a/ic2/src/client.scala
+++ b/ic2/src/client.scala
@@ -141,6 +141,10 @@ Usage: isabelle ic2 check [OPTIONS] FILE...
                         source line N (1-based). Fast partial check for
                         iterative development. Commands after line N are left
                         UNPROCESSED. Requires exactly one FILE.
+    --command-timeout SECS
+                        abort the whole check if any individual command runs
+                        longer than SECS (default 5; 0 disables). Decimal
+                        seconds are accepted.
 
   Submit a type-check of the given .thy files to the running server and return
   immediately. Track progress with `isabelle ic2 check status`; abort the
@@ -153,6 +157,7 @@ Usage: isabelle ic2 check [OPTIONS] FILE...
   Examples:
     isabelle ic2 check src/MyThy.thy               # submit full check
     isabelle ic2 check src/MyThy.thy --line 42     # submit up to line 42
+    isabelle ic2 check src/MyThy.thy --command-timeout 15
 
   Subcommands (in place of FILE...): status | attach | cancel — see
   `isabelle ic2 --help`.
@@ -165,7 +170,8 @@ Usage: isabelle ic2 check [OPTIONS] FILE...
     // `--line` is a long option, which Isabelle's single-letter Getopts can't
     // express; strip it ourselves first (same trick as `ic2 server start
     // --daemon`).
-    val (line_opt, rest_args) = extract_line(args)
+    val (command_timeout_opt, without_timeout) = extract_command_timeout(args)
+    val (line_opt, rest_args) = extract_line(without_timeout)
     val getopts = Getopts(check_usage_text,
       "n:" -> (a => name = Some(a)))
 
@@ -178,7 +184,7 @@ Usage: isabelle ic2 check [OPTIONS] FILE...
       sys.exit(2)
     }
     val server = resolve_name(name)
-    do_check_detach(server, files, line_opt)
+    do_check_detach(server, files, line_opt, command_timeout_opt)
   }
 
   private def reject_removed_check_options(args: List[String]): Unit =
@@ -203,6 +209,27 @@ Usage: isabelle ic2 check [OPTIONS] FILE...
       case Some(n) if n > 0 => (Some(n), args.take(i) ::: args.drop(i + 2))
       case _ =>
         Output.error_message("check: --line N expects a positive integer, got " + args(i + 1))
+        sys.exit(2)
+    }
+  }
+
+  /** Pull `--command-timeout SECS` from check arguments. The daemon supplies
+    * the 5s default when absent; Some(0) explicitly disables the watchdog. */
+  private def extract_command_timeout(args: List[String]): (Option[Double], List[String]) = {
+    val i = args.indexOf("--command-timeout")
+    if (i < 0) (None, args)
+    else if (i + 1 >= args.length) {
+      Output.error_message(
+        "check: --command-timeout requires a non-negative number of seconds")
+      sys.exit(2)
+    }
+    else args(i + 1).toDoubleOption match {
+      case Some(secs) if java.lang.Double.isFinite(secs) && secs >= 0 =>
+        (Some(secs), args.take(i) ::: args.drop(i + 2))
+      case _ =>
+        Output.error_message(
+          "check: --command-timeout SECS expects a finite non-negative number, got " +
+            args(i + 1))
         sys.exit(2)
     }
   }
@@ -245,15 +272,23 @@ Usage: isabelle ic2 check [OPTIONS] FILE...
 
   /** Submit a detached check: validate locally, send `{op:check, detach:true}`,
    *  report it started, and return (the check keeps running on the server). */
-  private def do_check_detach(name: String, files: List[String], line: Option[Int] = None): Unit = {
+  private def do_check_detach(
+    name: String,
+    files: List[String],
+    line: Option[Int] = None,
+    commandTimeoutSecs: Option[Double] = None
+  ): Unit = {
     val abs_files = files.map { f =>
       if (!f.endsWith(".thy")) { Output.error_message("not a .thy file: " + f); sys.exit(1) }
       val jfile = Path.explode(f).expand.absolute_file
       if (!jfile.isFile) { Output.error_message("file not found: " + f); sys.exit(1) }
       File.standard_path(jfile)
     }
-    val reply = request(name, JSON.Object("op" -> "check", "files" -> abs_files, "detach" -> true) ++
-      line.map(l => JSON.Object("line" -> l)).getOrElse(JSON.Object()))
+    val reply = request(name,
+      JSON.Object("op" -> "check", "files" -> abs_files, "detach" -> true) ++
+      line.map(l => JSON.Object("line" -> l)).getOrElse(JSON.Object()) ++
+      commandTimeoutSecs.map(s => JSON.Object("command_timeout_secs" -> s))
+        .getOrElse(JSON.Object()))
     JSON.string(reply, "event") match {
       case Some("submitted") =>
         Output.writeln("submitted (" +
@@ -401,6 +436,19 @@ Usage: isabelle ic2 $cmd [-n NAME] [-c N] [--long-running SECS]
       val msg = JSON.string(err, "message").getOrElse("(no message)")
       Output.writeln("error: " + loc)
       msg.linesIterator.foreach(l => Output.writeln("  " + l))
+    }
+    JSON.value(reply, "timeout").flatMap(JSON.Object.unapply).foreach { timeout =>
+      val theory = JSON.string(timeout, "theory").getOrElse("?")
+      val line = JSON.int(timeout, "line").getOrElse(0)
+      val loc = JSON.string(timeout, "file").getOrElse(theory) +
+        (if (line > 0) ":" + line else "")
+      val keyword = JSON.string(timeout, "keyword").getOrElse("?")
+      val limit = JSON.double(timeout, "limit_s").getOrElse(0.0)
+      val elapsed = JSON.double(timeout, "elapsed_s").getOrElse(0.0)
+      Output.writeln(
+        f"command timeout: $loc%s: $keyword%s exceeded $limit%.1fs ($elapsed%.1fs elapsed)")
+      JSON.string(timeout, "preview").filter(_.nonEmpty)
+        .foreach(preview => Output.writeln("  " + preview))
     }
     sys.exit(0)
   }

--- a/ic2/src/daemon.scala
+++ b/ic2/src/daemon.scala
@@ -800,17 +800,26 @@ Usage: isabelle ic2 server start [OPTIONS]
                   val files = JSON.strings(t, "files").getOrElse(Nil)
                   val detach = JSON.bool(t, "detach").getOrElse(false)
                   val line = JSON.int(t, "line")
-                  clog("check requested: " + files.length + " file(s)" +
-                    line.map(l => " up to line " + l).getOrElse("") +
-                    (if (detach) " [detached]" else "") + ": " + files.mkString(", "))
-                  ready_session match {
-                    case Some((session, resources)) =>
-                      if (detach) start_check_detached(io, session, resources, files, line)
-                      else start_check_blocking(io, session, resources, files, line)
-                    // Not ready: fail_check emits server_error AND a terminal
-                    // `finished`, so a streaming foreground check client exits
-                    // rather than hanging waiting for events that never come.
-                    case None => fail_check(io, not_ready_msg)
+                  parse_command_timeout_secs(t) match {
+                    case Left(msg) => fail_check(io, "check: " + msg)
+                    case Right(commandTimeoutSecs) =>
+                      clog("check requested: " + files.length + " file(s)" +
+                        line.map(l => " up to line " + l).getOrElse("") +
+                        " [command timeout " + commandTimeoutSecs + "s]" +
+                        (if (detach) " [detached]" else "") + ": " + files.mkString(", "))
+                      ready_session match {
+                        case Some((session, resources)) =>
+                          if (detach)
+                            start_check_detached(io, session, resources, files, line,
+                              commandTimeoutSecs)
+                          else
+                            start_check_blocking(io, session, resources, files, line,
+                              commandTimeoutSecs)
+                        // Not ready: fail_check emits server_error AND a terminal
+                        // `finished`, so a streaming foreground check client exits
+                        // rather than hanging waiting for events that never come.
+                        case None => fail_check(io, not_ready_msg)
+                      }
                   }
                 case Some("check_status") =>
                   state.note_activity()
@@ -884,6 +893,21 @@ Usage: isabelle ic2 server start [OPTIONS]
     private def server_error(msg: String): JSON.Object.T =
       JSON.Object("event" -> "server_error", "message" -> msg)
 
+    /** Parse the daemon-owned per-command watchdog policy. The CLI submits
+      * checks asynchronously, so this value must be validated and enforced in
+      * the daemon rather than in the submitting process. */
+    private def parse_command_timeout_secs(request: JSON.T): Either[String, Double] =
+      JSON.value(request, "command_timeout_secs") match {
+        case None => Right(Check.Default_Command_Timeout_Secs)
+        case Some(_) =>
+          JSON.double(request, "command_timeout_secs") match {
+            case Some(secs) if java.lang.Double.isFinite(secs) && secs >= 0 =>
+              Right(secs)
+            case _ =>
+              Left("'command_timeout_secs' must be a finite number >= 0 (0 = unlimited)")
+          }
+      }
+
     /** Reject an invalid `check` request: tell the client what was wrong AND
      *  emit `finished` so its read loop terminates (it only stops on
      *  `finished` or EOF). */
@@ -919,11 +943,11 @@ Usage: isabelle ic2 server start [OPTIONS]
      *  flavor the Job is, because both stream the same Event set. */
     private def submit_by_mode(
       session: Headless.Session, resources: Headless.Resources,
-      files: List[String], line: Option[Int]
+      files: List[String], line: Option[Int], commandTimeoutSecs: Double
     ): Either[String, Check.Job] =
       line match {
-        case Some(l) => Check.submitPartial(session, resources, files, l)
-        case None => Check.submit(session, resources, files)
+        case Some(l) => Check.submitPartial(session, resources, files, l, commandTimeoutSecs)
+        case None => Check.submit(session, resources, files, commandTimeoutSecs)
       }
 
     /* ---- check (foreground): submit the Job, stream its events to io, and
@@ -931,8 +955,9 @@ Usage: isabelle ic2 server start [OPTIONS]
 
     private def start_check_blocking(io: JSON_IO, session: Headless.Session,
       resources: Headless.Resources, files: List[String],
-      line: Option[Int] = None): Unit =
-      submit_by_mode(session, resources, files, line) match {
+      line: Option[Int] = None,
+      commandTimeoutSecs: Double = Check.Default_Command_Timeout_Secs): Unit =
+      submit_by_mode(session, resources, files, line, commandTimeoutSecs) match {
         case Left(msg) => fail_check(io, "check: " + msg)
         case Right(job) =>
           // Remember the job so a disconnect cancels exactly it. (Check.submit
@@ -970,8 +995,9 @@ Usage: isabelle ic2 server start [OPTIONS]
 
     private def start_check_detached(io: JSON_IO, session: Headless.Session,
       resources: Headless.Resources, files: List[String],
-      line: Option[Int] = None): Unit =
-      submit_by_mode(session, resources, files, line) match {
+      line: Option[Int] = None,
+      commandTimeoutSecs: Double = Check.Default_Command_Timeout_Secs): Unit =
+      submit_by_mode(session, resources, files, line, commandTimeoutSecs) match {
         case Left(msg) => fail_check(io, "check: " + msg)
         case Right(job) =>
           Check.logStart(server_progress, "conn " + conn_id + " detached", job.theories)

--- a/ic2/src/ic2.scala
+++ b/ic2/src/ic2.scala
@@ -71,6 +71,8 @@ Usage: isabelle ic2 COMMAND [ARGS...]
         --line N               check only the prefix of the (single) FILE
                                up to the command ending on or before source
                                line N; commands after N are left UNPROCESSED
+        --command-timeout SECS abort the whole check when one command exceeds
+                               SECS (default 5; 0 disables)
 
     query state-at FILE ...    Query document / proof state at a target
                                location. Location is FILE plus one of:

--- a/ic2/src/iq.scala
+++ b/ic2/src/iq.scala
@@ -688,7 +688,9 @@ object Check {
       if (finalStatus.nonEmpty) finalStatus
       else progress.snapshot_status.toList.sortBy(_._1.theory)
 
-    /** Status as a JSON object — for status replies and the submit ack. */
+    /** Status as a JSON object — for status replies and the submit ack. While
+      * running, attach the timing tracker's live commands to each node so polling
+      * clients see the same long-running-command detail as streamed progress. */
     def statusJson: JSON.Object.T = {
       val st = state
       JSON.Object(
@@ -701,7 +703,10 @@ object Check {
         "theories" -> theories,
         "elapsed_ms" -> elapsedMs,
         "nodes" -> progress.snapshot_status.toList.sortBy(_._1.theory)
-          .map { case (n, s) => nodeStatusJson(n, s, Nil, progress.updateSeqOf(n)) }) ++
+          .map { case (n, s) =>
+            val running = if (st == Outcome.Running) runningCommandsFor(session, n) else Nil
+            nodeStatusJson(n, s, running, progress.updateSeqOf(n))
+          }) ++
       (st match { case Outcome.Failed(r) if r.nonEmpty => JSON.Object("reason" -> r); case _ => JSON.Object() }) ++
       // The retained first error's location + message, so a detached `check
       // status` sees WHERE and WHY it failed (not just reason=errors). Omitted

--- a/ic2/src/iq.scala
+++ b/ic2/src/iq.scala
@@ -65,6 +65,10 @@ import scala.jdk.CollectionConverters._
  *  no registry, no job ids, and no per-check bookkeeping — just `slot`. */
 object Check {
 
+  /** Default wall-clock budget for one command. A zero budget disables the
+    * per-command watchdog for checks that explicitly opt out. */
+  val Default_Command_Timeout_Secs: Double = 5.0
+
   /* Headless.Session is batch-oriented: a bare stop-flag flip leaves the ML kernel
    * running the tactic, and its liveness signals over-count forked proofs. ic2
    * needs live progress and a real stop, so it reaches below the public API in two
@@ -187,6 +191,27 @@ object Check {
     * proofs apart without hunting for the line. */
   final case class RunningCommand(
     keyword: String, line: Int, elapsedSecs: Double, preview: String = "")
+
+  /** Durable description of the command that tripped a Job's watchdog. */
+  final case class Command_Timeout(
+    limitSecs: Double,
+    theory: String,
+    file: String,
+    line: Int,
+    keyword: String,
+    preview: String,
+    elapsedSecs: Double
+  ) {
+    def json: JSON.Object.T =
+      JSON.Object(
+        "limit_s" -> limitSecs,
+        "theory" -> theory,
+        "file" -> file,
+        "line" -> line,
+        "keyword" -> keyword,
+        "elapsed_s" -> elapsedSecs) ++
+      (if (preview.isEmpty) JSON.Object() else JSON.Object("preview" -> preview))
+  }
 
   /** A node's live status as a plain map (the shape used in progress/status).
     * If any commands in the node are currently running, they are attached as a
@@ -315,8 +340,24 @@ object Check {
               val cur = per_theory.value
               if (cur.nonEmpty) {
                 val running = snapshotRunning(cur)
-                if (running.nonEmpty)
+                if (running.nonEmpty) {
                   job.fan(Event.Progress(cur.toList.sortBy(_._1.theory), running, update_seq.value))
+                  if (job.commandTimeoutSecs > 0) {
+                    running.iterator
+                      .flatMap { case (name, commands) => commands.map(name -> _) }
+                      .filter { case (_, command) =>
+                        command.elapsedSecs >= job.commandTimeoutSecs
+                      }
+                      .toList
+                      .sortBy { case (name, command) =>
+                        (-command.elapsedSecs, name.theory, command.line, command.keyword)
+                      }
+                      .headOption
+                      .foreach { case (name, command) =>
+                        job.commandTimedOut(name, command)
+                      }
+                  }
+                }
               }
             } catch { case _: Throwable => }
             try Thread.sleep(tick_interval_ms) catch { case _: InterruptedException => return }
@@ -436,7 +477,8 @@ object Check {
     val nodeNames: List[Document.Node.Name],
     session: Headless.Session,
     val mode: Mode = Mode.Full,
-    resources: Option[Headless.Resources] = None
+    resources: Option[Headless.Resources] = None,
+    val commandTimeoutSecs: Double = Default_Command_Timeout_Secs
   ) {
     @volatile private var state: Outcome = Outcome.Running
     @volatile private var startMs: Long = 0L
@@ -455,6 +497,9 @@ object Check {
     // The live Event.Error channel is best-effort and non-replaying; this is the
     // durable record. Latched from the first Event.Error that fans out.
     @volatile private var firstError: Option[Event.Error] = None
+    // Retained watchdog culprit. It remains available to check_status after
+    // teardown has removed the timed-out command from the document.
+    @volatile private var commandTimeout: Option[Command_Timeout] = None
     private val latch = new java.util.concurrent.CountDownLatch(1)
     private val subscribers = new java.util.concurrent.CopyOnWriteArrayList[Event => Unit]()
     private val progress = new Job_Progress(this, session)
@@ -490,10 +535,34 @@ object Check {
       * fork via a text-changing tail remint — is step C (Check_Engine.stop), run in
       * runEngine's `finally`; the flip here does not itself interrupt a running ML
       * tactic. */
-    def cancel(reason: String = "cancelled"): Unit = {
-      if (cancelReason.isEmpty) cancelReason = Some(reason)
-      progress.stop()
+    def cancel(reason: String = "cancelled"): Unit = synchronized {
+      if (cancelReason.isEmpty && isRunning) {
+        cancelReason = Some(reason)
+        progress.stop()
+      }
     }
+
+    /** Latch the first watchdog culprit and cancel the whole check. This shares
+      * the Job monitor with cancel(), so whichever cancellation request arrives
+      * first determines the terminal reason. */
+    private[Check] def commandTimedOut(
+      name: Document.Node.Name, command: RunningCommand
+    ): Unit = synchronized {
+      if (cancelReason.isEmpty && isRunning) {
+        commandTimeout = Some(Command_Timeout(
+          commandTimeoutSecs,
+          name.theory,
+          name.path.expand.implode,
+          command.line,
+          command.keyword,
+          command.preview,
+          command.elapsedSecs))
+        cancelReason = Some("command_timeout")
+        progress.stop()
+      }
+    }
+
+    def commandTimeoutInfo: Option[Command_Timeout] = commandTimeout
 
     def await(): Outcome = { latch.await(); state }
     /** Bounded await; returns true if it reached a terminal state in time. */
@@ -671,7 +740,14 @@ object Check {
 
     /** Common finalize: record end time, set state, fan Finished, count down.
       * Both Full and Partial workers end here. */
-    private def settle(out: Outcome): Unit = {
+    private def settle(classified: Outcome): Unit = synchronized {
+      // Close the narrow race where classification produced Ok just before a
+      // synchronized cancel/timeout request won the Job monitor.
+      val out =
+        classified match {
+          case Outcome.Ok if cancelReason.isDefined => Outcome.Failed(cancelReason.get)
+          case _ => classified
+        }
       endMs = System.currentTimeMillis()
       state = out
       fan(Event.Finished(out.ok, out.reason))
@@ -702,6 +778,7 @@ object Check {
         "ok" -> st.ok,
         "theories" -> theories,
         "elapsed_ms" -> elapsedMs,
+        "command_timeout_secs" -> commandTimeoutSecs,
         "nodes" -> progress.snapshot_status.toList.sortBy(_._1.theory)
           .map { case (n, s) =>
             val running = if (st == Outcome.Running) runningCommandsFor(session, n) else Nil
@@ -716,7 +793,9 @@ object Check {
           (JSON.Object("theory" -> err.theory, "message" -> err.message) ++
            err.file.map(f => JSON.Object("file" -> f)).getOrElse(JSON.Object()) ++
            err.line.map(l => JSON.Object("line" -> l)).getOrElse(JSON.Object())))
-      }.getOrElse(JSON.Object())
+      }.getOrElse(JSON.Object()) ++
+      commandTimeout.map(timeout => JSON.Object("timeout" -> timeout.json))
+        .getOrElse(JSON.Object())
     }
   }
 
@@ -739,13 +818,16 @@ object Check {
     * error or an empty file list. Synchronized so two concurrent submits (e.g.
     * two MCP clients) can't both pass the busy check and race on the slot. */
   def submit(
-    session: Headless.Session, resources: Headless.Resources, files: List[String]
+    session: Headless.Session, resources: Headless.Resources, files: List[String],
+    commandTimeoutSecs: Double = Default_Command_Timeout_Secs
   ): Either[String, Job] = slot.synchronized {
     if (busy) Left("a check is already in flight; cancel it before submitting another")
+    else if (!java.lang.Double.isFinite(commandTimeoutSecs) || commandTimeoutSecs < 0)
+      Left("command timeout must be a finite number >= 0 (0 = unlimited)")
     else if (files.isEmpty) Left("empty files list")
     else resolveTargets(resources, files).map { resolved =>
       val job = new Job(resolved.map(_._1.theory), resolved.map(_._1), session,
-        resources = Some(resources))
+        resources = Some(resources), commandTimeoutSecs = commandTimeoutSecs)
       slot.set(Some(job))
       job.start()
       job
@@ -764,9 +846,12 @@ object Check {
     * files + a single line is meaningless). */
   def submitPartial(
     session: Headless.Session, resources: Headless.Resources,
-    files: List[String], line: Int
+    files: List[String], line: Int,
+    commandTimeoutSecs: Double = Default_Command_Timeout_Secs
   ): Either[String, Job] = slot.synchronized {
     if (busy) Left("a check is already in flight; cancel it before submitting another")
+    else if (!java.lang.Double.isFinite(commandTimeoutSecs) || commandTimeoutSecs < 0)
+      Left("command timeout must be a finite number >= 0 (0 = unlimited)")
     else if (files.length != 1)
       Left("partial check (--line) requires exactly one FILE, got " + files.length)
     else if (line <= 0) Left("line must be >= 1, got " + line)
@@ -774,7 +859,7 @@ object Check {
       val (name, _) = resolved.head
       val mode = Mode.Partial(name, line = line)
       val job = new Job(List(name.theory), List(name), session,
-        mode = mode, resources = Some(resources))
+        mode = mode, resources = Some(resources), commandTimeoutSecs = commandTimeoutSecs)
       slot.set(Some(job))
       job.start()
       job
@@ -1109,7 +1194,9 @@ object IQ {
         "non-blocking submit, use `check_async`. With `line`, check only the " +
         "prefix of the (single) file up to and including the command that ends " +
         "on or before that source line — same UI, same cancel semantics, but " +
-        "later commands are left unprocessed. Useful for iterative development.",
+        "later commands are left unprocessed. Each command has a separate " +
+        "`command_timeout_secs` budget (default 5; 0 = unlimited); exceeding it " +
+        "aborts the whole check with reason \"command_timeout\".",
       inputSchema = Map(
         "type" -> "object",
         "properties" -> Map(
@@ -1120,28 +1207,42 @@ object IQ {
               "file up to line N (1-based). files must contain exactly one path.")),
           "timeout_secs" -> Map("type" -> "integer",
             "description" -> ("Abort the check after this many seconds " +
-              "(default 600; 0 = unlimited)."))),
+              "(default 600; 0 = unlimited).")),
+          "command_timeout_secs" -> Map("type" -> "number", "minimum" -> 0,
+            "description" -> ("Abort the whole check when any individual command " +
+              "exceeds this many seconds (default 5; 0 = unlimited)."))),
         "required" -> List("files"),
         "additionalProperties" -> false),
       handlerP = (params, progress) => {
         val (files, timeoutSecs, line) =
           (checkFiles(params), checkTimeoutSecs(params), checkLine(params))
         if (timeoutSecs < 0) Left("check: 'timeout_secs' must be >= 0 (0 = unlimited)")
-        else submit_by_mode_mcp(session, resources, files, line) match {
+        else checkCommandTimeoutSecs(params) match {
           case Left(msg) => Left("check: " + msg)
-          case Right(job) =>
-            Check.logStart(log, "mcp", job.theories)
-            val unsubscribe = subscribeMcpProgress(job, progress)
-            try {
-              val timeoutMs = timeoutSecs.toLong * 1000L
-              if (timeoutMs > 0 && !job.await(timeoutMs) && job.isRunning)
-                job.cancel("timeout")
-              val out = job.await()
-              Check.logFinish(log, "mcp", job.elapsedMs, out.ok, out.reason)
-              val base = Map[String, Any]("ok" -> out.ok, "theories" -> job.theories)
-              Right(McpToolResult.fromMap(
-                if (out.ok) base else base + ("reason" -> out.reason)))
-            } finally unsubscribe()
+          case Right(commandTimeoutSecs) =>
+            submit_by_mode_mcp(session, resources, files, line, commandTimeoutSecs) match {
+              case Left(msg) => Left("check: " + msg)
+              case Right(job) =>
+                Check.logStart(log, "mcp", job.theories)
+                val unsubscribe = subscribeMcpProgress(job, progress)
+                try {
+                  val timeoutMs = timeoutSecs.toLong * 1000L
+                  if (timeoutMs > 0 && !job.await(timeoutMs) && job.isRunning)
+                    job.cancel("timeout")
+                  val out = job.await()
+                  Check.logFinish(log, "mcp", job.elapsedMs, out.ok, out.reason)
+                  val base = Map[String, Any](
+                    "ok" -> out.ok,
+                    "theories" -> job.theories,
+                    "command_timeout_secs" -> job.commandTimeoutSecs)
+                  val withReason = if (out.ok) base else base + ("reason" -> out.reason)
+                  val result = job.commandTimeoutInfo match {
+                    case Some(timeout) => withReason + ("timeout" -> timeout.json)
+                    case None => withReason
+                  }
+                  Right(McpToolResult.fromMap(result))
+                } finally unsubscribe()
+            }
         }
       })
 
@@ -1160,7 +1261,8 @@ object IQ {
         "aborts it. Only one check runs at a time: this fails if one is already " +
         "in flight (cancel it and resubmit the merged set of files). Files must " +
         "be absolute .thy paths. Use plain `check` for a blocking call. With " +
-        "`line`, check only the prefix of the (single) file up to that line.",
+        "`line`, check only the prefix of the (single) file up to that line. " +
+        "Each command has a `command_timeout_secs` budget (default 5; 0 = unlimited).",
       inputSchema = Map(
         "type" -> "object",
         "properties" -> Map(
@@ -1168,21 +1270,29 @@ object IQ {
             "description" -> "Absolute paths of .thy files to check"),
           "line" -> Map("type" -> "integer",
             "description" -> ("If set, check only the prefix of the (single) " +
-              "file up to line N (1-based). files must contain exactly one path."))),
+              "file up to line N (1-based). files must contain exactly one path.")),
+          "command_timeout_secs" -> Map("type" -> "number", "minimum" -> 0,
+            "description" -> ("Abort the whole check when any individual command " +
+              "exceeds this many seconds (default 5; 0 = unlimited)."))),
         "required" -> List("files"),
         "additionalProperties" -> false),
       handler = params =>
-        submit_by_mode_mcp(session, resources, checkFiles(params), checkLine(params)) match {
+        checkCommandTimeoutSecs(params) match {
           case Left(msg) => Left("check_async: " + msg)
-          case Right(job) =>
-            Check.logStart(log, "mcp-async", job.theories)
-            // Log the boundary when the backgrounded check finishes (no waiter).
-            val _ = job.subscribe {
-              case Check.Event.Finished(ok, reason) =>
-                Check.logFinish(log, "mcp-async", job.elapsedMs, ok, reason)
-              case _ =>
+          case Right(commandTimeoutSecs) =>
+            submit_by_mode_mcp(session, resources, checkFiles(params), checkLine(params),
+              commandTimeoutSecs) match {
+              case Left(msg) => Left("check_async: " + msg)
+              case Right(job) =>
+                Check.logStart(log, "mcp-async", job.theories)
+                // Log the boundary when the backgrounded check finishes (no waiter).
+                val _ = job.subscribe {
+                  case Check.Event.Finished(ok, reason) =>
+                    Check.logFinish(log, "mcp-async", job.elapsedMs, ok, reason)
+                  case _ =>
+                }
+                Right(McpToolResult.fromMap(job.statusJson.asInstanceOf[Map[String, Any]]))
             }
-            Right(McpToolResult.fromMap(job.statusJson.asInstanceOf[Map[String, Any]]))
         })
 
   /** `check_status`: report the current/last check's state (running/ok/failed),
@@ -1193,7 +1303,9 @@ object IQ {
       name = "check_status",
       description = "Status of the current (or last) check: state " +
         "(running/ok/failed), elapsed time, per-theory processing status, and " +
-        "the failure reason if any. No argument — at most one check runs at a time.",
+        "the failure reason if any. Running nodes include live command timing; " +
+        "a command timeout retains the culprit's source location, preview, elapsed " +
+        "time, and limit. No argument — at most one check runs at a time.",
       inputSchema = Map(
         "type" -> "object", "properties" -> Map(), "additionalProperties" -> false),
       handler = _ =>
@@ -1233,6 +1345,17 @@ object IQ {
       case Some(n: Double) => n.toInt
       case _ => 600
     }
+  private def checkCommandTimeoutSecs(params: McpToolParams): Either[String, Double] =
+    params.toMap.get("command_timeout_secs") match {
+      case None => Right(Check.Default_Command_Timeout_Secs)
+      case Some(n: java.lang.Number) =>
+        val secs = n.doubleValue()
+        if (!java.lang.Double.isFinite(secs) || secs < 0)
+          Left("'command_timeout_secs' must be a finite number >= 0 (0 = unlimited)")
+        else Right(secs)
+      case Some(_) =>
+        Left("'command_timeout_secs' must be a finite number >= 0 (0 = unlimited)")
+    }
   private def checkLine(params: McpToolParams): Option[Int] =
     params.toMap.get("line") match {
       case Some(n: Long) => Some(n.toInt)
@@ -1243,11 +1366,11 @@ object IQ {
   /** Shared full-vs-partial submit dispatcher for the MCP tools. */
   private def submit_by_mode_mcp(
     session: Headless.Session, resources: Headless.Resources,
-    files: List[String], line: Option[Int]
+    files: List[String], line: Option[Int], commandTimeoutSecs: Double
   ): Either[String, Check.Job] =
     line match {
-      case Some(l) => Check.submitPartial(session, resources, files, l)
-      case None => Check.submit(session, resources, files)
+      case Some(l) => Check.submitPartial(session, resources, files, l, commandTimeoutSecs)
+      case None => Check.submit(session, resources, files, commandTimeoutSecs)
     }
 }
 

--- a/ic2/src/test_tool.scala
+++ b/ic2/src/test_tool.scala
@@ -158,6 +158,36 @@ Usage: isabelle ic2_test [OPTIONS] MODE [DIR]
       file.toAbsolutePath.toString
     }
 
+    /** A fresh target whose local import contains the expensive command. Returns
+      * (target path, dependency path, dependency theory name). */
+    private def fresh_slow_import(secs: Double = 8.0): (String, String, String) = {
+      val id = short_id()
+      val dependency = "Slow_Dep_" + id
+      val target = "Slow_Import_" + id
+      val dir = Files.createTempDirectory("ic2_slow_import")
+      val dependencyFile = dir.resolve(dependency + ".thy")
+      val targetFile = dir.resolve(target + ".thy")
+      val dependencyBody =
+        "theory " + dependency + "\n" +
+        "  imports Main\n" +
+        "begin\n\n" +
+        "lemma " + dependency + "_1: \"(n::nat) + 0 = n\" by simp\n\n" +
+        "ML ‹OS.Process.sleep (Time.fromReal " + secs + ")›\n\n" +
+        "lemma " + dependency + "_2: \"(n::nat) * 1 = n\" by simp\n\n" +
+        "end\n"
+      val targetBody =
+        "theory " + target + "\n" +
+        "  imports " + dependency + "\n" +
+        "begin\n\n" +
+        "lemma " + target + "_lemma: \"(n::nat) + 0 = n\" by simp\n\n" +
+        "end\n"
+      Files.write(dependencyFile, dependencyBody.getBytes("UTF-8"))
+      Files.write(targetFile, targetBody.getBytes("UTF-8"))
+      (targetFile.toAbsolutePath.toString,
+        dependencyFile.toAbsolutePath.toString,
+        dependency)
+    }
+
     /** Write a fresh theory whose expensive command is BEFORE a cheap marker
      *  command that tests can rewrite. Used to pin incremental re-checks: after
      *  a successful baseline check, changing only the marker must not re-run
@@ -478,6 +508,7 @@ Usage: isabelle ic2_test [OPTIONS] MODE [DIR]
         etest("check_detached_survives_disconnect") { e2e_detached_survives_disconnect(server_name, fixtures) }
         etest("check_cancel") { e2e_check_cancel(server_name, fixtures) }
         etest("recheck_after_cancel") { e2e_recheck_after_cancel(server_name, fixtures) }
+        etest("command_timeout") { e2e_command_timeout(server_name, fixtures) }
         etest("progress_display_changes") { e2e_progress_display_changes(server_name, fixtures) }
         etest("check_attach") { e2e_check_attach(server_name, fixtures) }
         etest("query_wire") { e2e_query_wire(server_name, fixtures) }
@@ -604,11 +635,15 @@ Usage: isabelle ic2_test [OPTIONS] MODE [DIR]
 
     /** Run one check on a fresh connection; return (all events, finished). */
     private def run_check(
-      name: String, files: List[String], deadline_secs: Int = 60
+      name: String, files: List[String], deadline_secs: Int = 60,
+      command_timeout_secs: Double = 0.0
     ): (List[JSON.T], Option[JSON.T]) = {
       val io = connection(name)
       try {
-        io.write(JSON.Object("op" -> "check", "files" -> files))
+        io.write(JSON.Object(
+          "op" -> "check",
+          "files" -> files,
+          "command_timeout_secs" -> command_timeout_secs))
         collect_events(io, deadline_secs)
       } finally io.close()
     }
@@ -1221,7 +1256,8 @@ Usage: isabelle ic2_test [OPTIONS] MODE [DIR]
       // streaming no progress and finishing before any timeout budget bites).
       val slowAbs = fresh_slow_theory()
       val slow2Abs = fresh_slow_theory()
-      val (progress, result) = mcp.callWithProgress("check", obj("files" -> List[Any](slowAbs)), "ptok-1")
+      val (progress, result) = mcp.callWithProgress("check",
+        obj("files" -> List[Any](slowAbs), "command_timeout_secs" -> 0), "ptok-1")
       if (JSON.bool(result, "ok") != Some(true))
         error("check(Slow) with progress: ok should be true, got " + JSON.Format(result))
       if (progress.isEmpty)
@@ -1256,13 +1292,18 @@ Usage: isabelle ic2_test [OPTIONS] MODE [DIR]
       // Timeout abort: a 1s budget against the fresh Slow2.thy (~8s, not yet
       // consolidated, so the check genuinely re-runs the ML sleep) aborts the
       // check, reporting reason "timeout" — not a crash or a transport error.
-      val timeoutRes = mcp.call("check", obj("files" -> List[Any](slow2Abs), "timeout_secs" -> 1))
+      val timeoutRes = mcp.call("check", obj(
+        "files" -> List[Any](slow2Abs),
+        "timeout_secs" -> 1,
+        "command_timeout_secs" -> 0))
       if (JSON.bool(timeoutRes, "ok") != Some(false))
         error("check(Slow2, timeout_secs=1): ok should be false, got " + JSON.Format(timeoutRes))
       if (JSON.string(timeoutRes, "reason").getOrElse("") != "timeout")
         error("check(Slow2, timeout_secs=1): reason should be 'timeout', got " + JSON.Format(timeoutRes))
       // A negative budget is a usage error (isError tool result).
       val _t = mcp.call("check", obj("files" -> List[Any](slow2Abs), "timeout_secs" -> -1), expectError = true)
+      val _ct = mcp.call("check", obj(
+        "files" -> List[Any](slow2Abs), "command_timeout_secs" -> -1), expectError = true)
     }
 
     /** Non-blocking MCP surface: check_async returns immediately while running;
@@ -1274,7 +1315,8 @@ Usage: isabelle ic2_test [OPTIONS] MODE [DIR]
       // running when check_status polls it (a re-check would already be ok).
       val slowAbs = fresh_slow_theory()
       // Submit a slow check without blocking.
-      val sub = mcp.call("check_async", obj("files" -> List[Any](slowAbs)))
+      val sub = mcp.call("check_async",
+        obj("files" -> List[Any](slowAbs), "command_timeout_secs" -> 0))
       if (JSON.string(sub, "state") != Some("running"))
         error("check_async(Slow): should be running, got " + JSON.Format(sub))
       // The no-arg check_status reports it running.
@@ -1514,7 +1556,8 @@ Usage: isabelle ic2_test [OPTIONS] MODE [DIR]
                 start.await(10, TimeUnit.SECONDS)
                 val io = connection(server_name)
                 try {
-                  io.write(JSON.Object("op" -> "check", "files" -> List(file)))
+                  io.write(JSON.Object("op" -> "check", "files" -> List(file),
+                    "command_timeout_secs" -> 0))
                   // Read until we learn accept (started) or refuse (server_error).
                   var verdict: Option[Boolean] = None
                   val deadline = System.currentTimeMillis() + 30000
@@ -1566,12 +1609,14 @@ Usage: isabelle ic2_test [OPTIONS] MODE [DIR]
       val trivial = (fixtures + Path.basic("Trivial_OK.thy")).expand.implode
       val io = connection(server_name)
       try {
-        io.write(JSON.Object("op" -> "check", "files" -> List(slow)))
+        io.write(JSON.Object("op" -> "check", "files" -> List(slow),
+          "command_timeout_secs" -> 0))
         // Wait for 'started' so the worker is registered.
         if (!await_event(io, "started", 30))
           error("never saw 'started' for the first check")
         // Fire a second check on the SAME connection.
-        io.write(JSON.Object("op" -> "check", "files" -> List(trivial)))
+        io.write(JSON.Object("op" -> "check", "files" -> List(trivial),
+          "command_timeout_secs" -> 0))
         // Expect a server_error about the in-flight check.
         var saw_reject = false
         val deadline = System.currentTimeMillis() + 10000
@@ -1628,7 +1673,8 @@ Usage: isabelle ic2_test [OPTIONS] MODE [DIR]
       val slow = fresh_slow_theory()
       val a = connection(server_name)
       try {
-        a.write(JSON.Object("op" -> "check", "files" -> List(slow)))
+        a.write(JSON.Object("op" -> "check", "files" -> List(slow),
+          "command_timeout_secs" -> 0))
         if (!await_event(a, "started", 30)) error("never saw 'started' for slow check")
         val t = query_status(server_name)   // opens + closes its own connection
         if (JSON.bool(t, "busy") != Some(true))
@@ -1654,7 +1700,8 @@ Usage: isabelle ic2_test [OPTIONS] MODE [DIR]
     private def e2e_disconnect_promptly(server_name: String, fixtures: Path): Unit = {
       val file = fresh_slow_theory()
       val io = connection(server_name)
-      io.write(JSON.Object("op" -> "check", "files" -> List(file)))
+      io.write(JSON.Object("op" -> "check", "files" -> List(file),
+        "command_timeout_secs" -> 0))
       if (!await_event(io, "started", 30)) error("never saw 'started' event")
       io.close()                 // disconnect mid-flight
       val drop_at = System.currentTimeMillis()
@@ -1686,7 +1733,8 @@ Usage: isabelle ic2_test [OPTIONS] MODE [DIR]
      *  no-arg check_status reports the terminal `ok`. */
     private def e2e_check_detached(server_name: String, fixtures: Path): Unit = {
       val file = (fixtures + Path.basic("Trivial_OK.thy")).expand.implode
-      val ack = request_op(server_name, JSON.Object("op" -> "check", "files" -> List(file), "detach" -> true))
+      val ack = request_op(server_name, JSON.Object("op" -> "check", "files" -> List(file),
+        "detach" -> true, "command_timeout_secs" -> 0))
       if (JSON.string(ack, "event") != Some("submitted"))
         error("detached check should ack 'submitted', got " + JSON.Format(ack))
       if (!JSON.strings(ack, "theories").getOrElse(Nil).exists(_.endsWith("Trivial_OK")))
@@ -1716,7 +1764,8 @@ Usage: isabelle ic2_test [OPTIONS] MODE [DIR]
       // consolidated by an earlier test would return in ~100ms.)
       val slow = fresh_slow_theory()
       // request_op opens a connection, gets the `submitted` ack, then CLOSES it.
-      val ack = request_op(server_name, JSON.Object("op" -> "check", "files" -> List(slow), "detach" -> true))
+      val ack = request_op(server_name, JSON.Object("op" -> "check", "files" -> List(slow),
+        "detach" -> true, "command_timeout_secs" -> 0))
       if (JSON.string(ack, "event") != Some("submitted"))
         error("detached submit should ack 'submitted', got " + JSON.Format(ack))
       // Right after the submitting connection closed, the check must still run.
@@ -1739,7 +1788,8 @@ Usage: isabelle ic2_test [OPTIONS] MODE [DIR]
      *  "cancelled"); with nothing running it is a no-op (cancelled:false). */
     private def e2e_check_cancel(server_name: String, fixtures: Path): Unit = {
       val slow = fresh_slow_theory()
-      val ack = request_op(server_name, JSON.Object("op" -> "check", "files" -> List(slow), "detach" -> true))
+      val ack = request_op(server_name, JSON.Object("op" -> "check", "files" -> List(slow),
+        "detach" -> true, "command_timeout_secs" -> 0))
       if (JSON.string(ack, "event") != Some("submitted")) error("detached submit failed: " + JSON.Format(ack))
       // Cancel the in-flight check.
       val cancelReply = request_op(server_name, JSON.Object("op" -> "check_cancel"))
@@ -1773,7 +1823,8 @@ Usage: isabelle ic2_test [OPTIONS] MODE [DIR]
     private def e2e_recheck_after_cancel(server_name: String, fixtures: Path): Unit = {
       val slow = fresh_slow_theory()
       // 1) Submit detached, wait until it's actually running, then cancel.
-      val ack = request_op(server_name, JSON.Object("op" -> "check", "files" -> List(slow), "detach" -> true))
+      val ack = request_op(server_name, JSON.Object("op" -> "check", "files" -> List(slow),
+        "detach" -> true, "command_timeout_secs" -> 0))
       if (JSON.string(ack, "event") != Some("submitted"))
         error("detached submit failed: " + JSON.Format(ack))
       if (JSON.string(request_op(server_name, JSON.Object("op" -> "check_status")), "state") != Some("running"))
@@ -1807,6 +1858,140 @@ Usage: isabelle ic2_test [OPTIONS] MODE [DIR]
       if (JSON.int(diR, "unprocessed").getOrElse(0) != 0 || JSON.int(diR, "failed").getOrElse(0) != 0)
         error("re-check after cancel: expected 0 unprocessed / 0 failed (clean re-eval), got " +
           JSON.Format(diR))
+    }
+
+    /** Per-command watchdog:
+     *   - omitting the option uses the daemon's 5s default and retains the
+     *     exact command in check_status;
+     *   - CLI decimal overrides and 0=unlimited are honored;
+     *   - malformed CLI values are usage errors; and
+     *   - a forked terminal `by` is reclaimed promptly enough that a new check
+     *     can run on the same resident session. */
+    private def e2e_command_timeout(server_name: String, fixtures: Path): Unit = {
+      def number(t: JSON.T, key: String): Double =
+        JSON.double(t, key)
+          .orElse(JSON.long(t, key).map(_.toDouble))
+          .orElse(JSON.int(t, key).map(_.toDouble))
+          .getOrElse(error("missing numeric field " + key + " in " + JSON.Format(t)))
+
+      val n = Bash.string(server_name)
+      val (slowTarget, slowDependency, slowDependencyTheory) =
+        fresh_slow_import(8.0)
+
+      // CLI omission: the daemon must enforce its default after this detached
+      // submitting process has already exited. The expensive command is in a
+      // local import, so this also covers closure-wide observation/reclamation.
+      val defaultStart = System.currentTimeMillis()
+      val submit = ic2("check -n " + n + " " + Bash.string(slowTarget))
+      if (submit.rc != 0)
+        error("default-timeout check should submit, got rc=" + submit.rc +
+          " err=" + submit.err.mkString)
+      val timedOut = wait_check_state(server_name, Set("failed"), deadline_secs = 20)
+      val defaultElapsed = System.currentTimeMillis() - defaultStart
+      if (JSON.string(timedOut, "reason") != Some("command_timeout"))
+        error("default watchdog should fail with reason=command_timeout, got " +
+          JSON.Format(timedOut))
+      if (math.abs(number(timedOut, "command_timeout_secs") - 5.0) > 0.001)
+        error("omitted command_timeout_secs should default to 5, got " +
+          JSON.Format(timedOut))
+      if (defaultElapsed >= 12000)
+        error("5s command watchdog took " + defaultElapsed +
+          "ms to settle an 8s command; cancellation was not prompt")
+
+      val timeout = JSON.value(timedOut, "timeout").flatMap(JSON.Object.unapply)
+        .getOrElse(error("command_timeout status should retain a timeout object: " +
+          JSON.Format(timedOut)))
+      if (math.abs(number(timeout, "limit_s") - 5.0) > 0.001 ||
+          number(timeout, "elapsed_s") < 5.0)
+        error("timeout should report its 5s limit and elapsed >=5s, got " +
+          JSON.Format(timeout))
+      if (!JSON.string(timeout, "theory").exists(_.endsWith(slowDependencyTheory)) ||
+          !JSON.string(timeout, "file")
+            .exists(_.endsWith("/" + base_name_of(slowDependency) + ".thy")) ||
+          !JSON.int(timeout, "line").exists(_ > 0) ||
+          JSON.string(timeout, "keyword").forall(_.isEmpty) ||
+          !JSON.string(timeout, "preview").exists(_.contains("OS.Process.sleep")))
+        error("timeout should identify theory/file/line/keyword/preview, got " +
+          JSON.Format(timeout))
+
+      val rendered = ic2("check status -n " + n)
+      val renderedText = rendered.out.mkString + rendered.err.mkString
+      if (rendered.rc != 0 || !renderedText.contains("command timeout:") ||
+          !renderedText.contains("OS.Process.sleep"))
+        error("check status should render the retained timeout command, rc=" +
+          rendered.rc + " output=" + renderedText)
+
+      // A decimal override above the command's runtime permits the same
+      // reminted dependency to complete, proving the override reaches the
+      // daemon and dependency teardown interrupted (rather than reused) the
+      // first execution.
+      val raisedStart = System.currentTimeMillis()
+      val raised = ic2("check -n " + n + " --command-timeout 10.5 " +
+        Bash.string(slowTarget))
+      if (raised.rc != 0)
+        error("raised command timeout should submit, got rc=" + raised.rc)
+      val raisedStatus = wait_check_state(server_name, Set("ok", "failed"), deadline_secs = 20)
+      val raisedElapsed = System.currentTimeMillis() - raisedStart
+      if (JSON.string(raisedStatus, "state") != Some("ok") ||
+          math.abs(number(raisedStatus, "command_timeout_secs") - 10.5) > 0.001 ||
+          raisedElapsed < 6000)
+        error("10.5s override should allow an 8s command to finish, got " +
+          JSON.Format(raisedStatus) + " elapsed=" + raisedElapsed + "ms")
+
+      // Zero explicitly disables the watchdog for an otherwise over-default
+      // command.
+      val unlimitedSlow = fresh_slow_theory(6.0)
+      val unlimited = ic2("check -n " + n + " --command-timeout 0 " +
+        Bash.string(unlimitedSlow))
+      if (unlimited.rc != 0)
+        error("disabled command timeout should submit, got rc=" + unlimited.rc)
+      val unlimitedStatus =
+        wait_check_state(server_name, Set("ok", "failed"), deadline_secs = 15)
+      if (JSON.string(unlimitedStatus, "state") != Some("ok") ||
+          number(unlimitedStatus, "command_timeout_secs") != 0.0)
+        error("--command-timeout 0 should allow a 6s command, got " +
+          JSON.Format(unlimitedStatus))
+
+      val badArgs = List(
+        " --command-timeout",
+        " --command-timeout -1",
+        " --command-timeout nope",
+        " --command-timeout NaN")
+      for (suffix <- badArgs) {
+        val bad = ic2("check -n " + n + " " + Bash.string(slowTarget) + suffix)
+        if (bad.rc != 2)
+          error("invalid" + suffix + " should exit 2, got rc=" + bad.rc +
+            " err=" + bad.err.mkString)
+      }
+
+      // The original failure mode: a terminal `by` runs in a fork. Default
+      // enforcement must stop it well before either 15s/30s tactic finishes.
+      val spin = fixtures + Path.basic("SpinTactic.thy")
+      if (spin.is_file) {
+        val spinStart = System.currentTimeMillis()
+        val ack = request_op(server_name, JSON.Object(
+          "op" -> "check", "files" -> List(spin.expand.implode), "detach" -> true))
+        if (JSON.string(ack, "event") != Some("submitted"))
+          error("SpinTactic timeout check was not submitted: " + JSON.Format(ack))
+        val spinStatus =
+          wait_check_state(server_name, Set("failed"), deadline_secs = 20)
+        val spinElapsed = System.currentTimeMillis() - spinStart
+        val culprit = JSON.value(spinStatus, "timeout").flatMap(JSON.Object.unapply)
+          .getOrElse(error("SpinTactic timeout should retain its culprit: " +
+            JSON.Format(spinStatus)))
+        if (JSON.string(spinStatus, "reason") != Some("command_timeout") ||
+            JSON.string(culprit, "keyword") != Some("by") ||
+            !JSON.string(culprit, "preview").exists(_.contains("spin")) ||
+            spinElapsed >= 14000)
+          error("forked `by` should time out and settle before spin1 completes; elapsed=" +
+            spinElapsed + "ms status=" + JSON.Format(spinStatus))
+
+        val tiny = (fixtures + Path.basic("Trivial_OK.thy")).expand.implode
+        val (_, finished) = run_check(server_name, List(tiny), deadline_secs = 30)
+        if (finished.flatMap(JSON.bool(_, "ok")) != Some(true))
+          error("session should accept a new check after reclaiming timed-out `by`, got " +
+            finished)
+      }
     }
 
     /** Basename (no dir, no .thy) of an absolute theory path — for `query`
@@ -1867,7 +2052,8 @@ Usage: isabelle ic2_test [OPTIONS] MODE [DIR]
       }
       val io = connection(server_name)
       try {
-        io.write(JSON.Object("op" -> "check", "files" -> List(spin.expand.implode)))
+        io.write(JSON.Object("op" -> "check", "files" -> List(spin.expand.implode),
+          "command_timeout_secs" -> 0))
         val deadline = System.currentTimeMillis() + 30000
         var seen = false
         var closed = false
@@ -1934,7 +2120,8 @@ Usage: isabelle ic2_test [OPTIONS] MODE [DIR]
      *  didn't submit. */
     private def e2e_check_attach(server_name: String, fixtures: Path): Unit = {
       val slow = fresh_slow_theory()
-      val ack = request_op(server_name, JSON.Object("op" -> "check", "files" -> List(slow), "detach" -> true))
+      val ack = request_op(server_name, JSON.Object("op" -> "check", "files" -> List(slow),
+        "detach" -> true, "command_timeout_secs" -> 0))
       if (JSON.string(ack, "event") != Some("submitted")) error("detached submit failed: " + JSON.Format(ack))
       val io = connection(server_name)
       try {
@@ -2821,7 +3008,8 @@ Usage: isabelle ic2_test [OPTIONS] MODE [DIR]
         val io = connection(name)
         val started_ms = System.currentTimeMillis()
         try {
-          io.write(JSON.Object("op" -> "check", "files" -> List(file), "line" -> 13))
+          io.write(JSON.Object("op" -> "check", "files" -> List(file), "line" -> 13,
+            "command_timeout_secs" -> 0))
           val (events, finished) = collect_events(io, deadline_secs = 30)
           val elapsed_ms = System.currentTimeMillis() - started_ms
           if (finished.flatMap(JSON.bool(_, "ok")) != Some(true))
@@ -2916,7 +3104,8 @@ Usage: isabelle ic2_test [OPTIONS] MODE [DIR]
           def elapsedOf(rc: JSON.T): Double =
             JSON.double(rc, "elapsed_s").orElse(JSON.int(rc, "elapsed_s").map(_.toDouble)).getOrElse(0.0)
           try {
-            sio.write(JSON.Object("op" -> "check", "files" -> List(spin.expand.implode), "line" -> 41))
+            sio.write(JSON.Object("op" -> "check", "files" -> List(spin.expand.implode),
+              "line" -> 41, "command_timeout_secs" -> 0))
             val deadline = System.currentTimeMillis() + 60000
             var spin1Max = 0.0
             var spin2Max = 0.0
@@ -2973,7 +3162,8 @@ Usage: isabelle ic2_test [OPTIONS] MODE [DIR]
           val iio = connection(name)
           try {
             iio.write(JSON.Object("op" -> "check",
-              "files" -> List(imp.expand.implode), "line" -> 20))
+              "files" -> List(imp.expand.implode), "line" -> 20,
+              "command_timeout_secs" -> 0))
             val (events, finished) = collect_events(iio, deadline_secs = 90)
             if (finished.flatMap(JSON.bool(_, "ok")) != Some(true))
               error("check --line 20 of SpinImport (imports SpinDep) should be ok — a " +
@@ -3034,7 +3224,8 @@ Usage: isabelle ic2_test [OPTIONS] MODE [DIR]
         val started_ms = System.currentTimeMillis()
         try {
           sio.write(JSON.Object("op" -> "check",
-            "files" -> List(spin.expand.implode), "line" -> 41))
+            "files" -> List(spin.expand.implode), "line" -> 41,
+            "command_timeout_secs" -> 0))
           val deadline = System.currentTimeMillis() + 60000
           var done = false
           while (!done && System.currentTimeMillis() < deadline) {
@@ -3092,7 +3283,8 @@ Usage: isabelle ic2_test [OPTIONS] MODE [DIR]
       val file = (fixtures + Path.basic("Slow.thy")).expand.implode
       val a = connection(server_name)
       try {
-        a.write(JSON.Object("op" -> "check", "files" -> List(file)))
+        a.write(JSON.Object("op" -> "check", "files" -> List(file),
+          "command_timeout_secs" -> 0))
         if (!await_event(a, "started", 30)) error("conn A never saw 'started'")
 
         val b = connection(server_name)

--- a/ic2/src/test_tool.scala
+++ b/ic2/src/test_tool.scala
@@ -1816,19 +1816,22 @@ Usage: isabelle ic2_test [OPTIONS] MODE [DIR]
       if (f.endsWith(".thy")) f.dropRight(4) else f
     }
 
-    /** Witnesses two progress-display properties:
+    /** Witnesses three progress-display properties:
      *   (a) the client's rendered frame lists in-flight theories in
      *       descending-percentage order (stable, not swapping around);
      *   (b) commands that have been running for a while are surfaced under
-     *       their theory's progress bar, with the correct source line.
+     *       their theory's progress bar, with the correct source line; and
+     *   (c) one-shot `check_status` polling carries the same long-running
+     *       command data, both on the wire and in the CLI rendering.
      *
      *  (a) is verified against Client.render_progress_frame with a synthetic
      *  multi-theory list — deterministic, no timing hazards. (b) is verified
-     *  end-to-end: submit SpinTactic.thy (whose two `by (spin 30; simp)`
-     *  proofs each spin ~30s) and watch the streamed progress events for a
-     *  `long_running` payload with keyword `by` and elapsed >= 5s. Closing
-     *  the connection when the payload is seen cancels the check on
-     *  disconnect, so the ~30s spins don't drag out cleanup.
+     *  end-to-end: submit SpinTactic.thy (whose two `by (spin N; simp)`
+     *  proofs spin for 15s and 30s) and watch the streamed progress events for a
+     *  `long_running` payload with keyword `by` and elapsed >= 5s. Once seen,
+     *  query `check_status` over a fresh connection and through the CLI before
+     *  closing the original connection; that close cancels the check, so the
+     *  ~30s spins don't drag out cleanup.
      *
      *  The forked `by` is the interesting case: it exercises ic2's
      *  Timing_Tracker (a per-exec-id counter over the raw command_timing
@@ -1895,6 +1898,34 @@ Usage: isabelle ic2_test [OPTIONS] MODE [DIR]
           error("no `progress` event carried a long_running `by` entry for " +
             "SpinTactic with elapsed >= 5s within 30s; the ~30s spinning `by` " +
             "commands should have shown up under the theory's bar.")
+
+        // (c) Polling must expose the same live command. This is the supported
+        // automation/agent path: unlike check_attach, it does not require a TTY.
+        val status = request_op(server_name, JSON.Object("op" -> "check_status"))
+        val statusHit =
+          JSON.string(status, "state") == Some("running") &&
+          JSON.array(status, "nodes").getOrElse(Nil).exists { n =>
+            JSON.string(n, "theory").map(base_name) == Some("SpinTactic") &&
+            JSON.array(n, "long_running").getOrElse(Nil).exists { rc =>
+              val elapsed =
+                JSON.double(rc, "elapsed_s")
+                  .orElse(JSON.int(rc, "elapsed_s").map(_.toDouble))
+                  .getOrElse(0.0)
+              JSON.string(rc, "keyword") == Some("by") &&
+              JSON.int(rc, "line").exists(_ > 0) &&
+              JSON.string(rc, "preview").exists(_.contains("spin")) &&
+              elapsed >= 5.0
+            }
+          }
+        if (!statusHit)
+          error("check_status did not carry the live long_running `by` command: " +
+            JSON.Format(status))
+
+        val cli = ic2("check status -n " + Bash.string(server_name))
+        val cliText = cli.out.mkString + cli.err.mkString
+        if (cli.rc != 0 || !cliText.contains("by (line ") || !cliText.contains("spin"))
+          error("check status CLI did not render the live long-running `by`: rc=" +
+            cli.rc + " output=" + cliText)
       } finally io.close()   // cancel-on-disconnect stops the spin
     }
 


### PR DESCRIPTION
Previously, IC2 only flagged long running commands in the live view, but not in the reduced status view consumed by agents. Agents therefore had no way of learning about a long running check being due to a looping command, nor did they have a means to identify that command except for manual bisection.

Similarly, IC2 did not provide a mechanism for aborting checks once any command surpasses a configurable threshold.

This PR fixes both: Agents now see long-running commands in their status checks. Also, IC2 provides a `--command-timeout` parameter for checks, defaulting to 5s. When any command surpasses the timeout, the check is aborted with reference to the offending command.

Thanks to @ike-mulder-aws for flagging this problem.