### PR TITLE
IC2: point proof iteration at I/R REPLs, and name the timed-out command

### DIFF
--- a/ic2/README.md
+++ b/ic2/README.md
@@ -28,9 +28,11 @@ see where a theory stands and to confirm a finished proof, and
 
 ## Prerequisites
 
-  * **Isabelle2025-2** — IC2 is built and tested against it (the headless
-    goal-state readout relies on its `show_states` option). Set `ISABELLE_HOME`
-    to the directory containing the `isabelle` binary.
+  * **Isabelle2025-2** — IC2 is built and tested against it; the headless
+    goal-state readout uses its `print_state` query plumbing (see
+    `src/Extended_Query_Operation.scala`). The `Makefile` reads `ISABELLE_HOME`
+    as the directory containing the `isabelle` binary (not Isabelle's own
+    `ISABELLE_HOME`, which is the distribution root).
   * For the I/R / MCP integration (on by default): **`python3`** and the I/R
     Python deps — `pip install -r ../ir/requirements.txt`. Without them, I/R
     bring-up is skipped and `server status` shows `no I/R`; plain checking still
@@ -49,19 +51,20 @@ isabelle ic2 server start --daemon -l HOL
 isabelle ic2 server start --daemon -l AutoCorrode -d AutoCorrode
 
 # Wait until the session is ready, then check a file:
-isabelle ic2 server status                  # state: building → loading → ready
+isabelle ic2 server status                  # state=building → loading → ready
 isabelle ic2 check /abs/path/to/Foo.thy     # submit
 isabelle ic2 check status                   # poll result (reports file:line)
 
 # Work on the proof that failed in a REPL; paste it back, then check once more:
-isabelle ic2 repl-create /abs/path/to/Foo.thy:87 r87
+isabelle ic2 repl-create /abs/path/to/Foo.thy:87 r
 
 # Stop:
 isabelle ic2 server stop
 ```
 
 The flags mirror `isabelle jedit` (`-l` logic, `-d` session dir, `-i` include
-session, `-o` option, `-n` server name). `server start` runs in the foreground
+session, `-o` option). Two deliberately diverge: `-n` is the server name (in
+`isabelle jedit` it means no-build) and `-N` is no-build. `server start` runs in the foreground
 until Ctrl-C; `--daemon` backgrounds it and logs to
 `$ISABELLE_HOME_USER/ic2/<name>.log` (override with `-L FILE`).
 
@@ -69,13 +72,14 @@ until Ctrl-C; `--daemon` backgrounds it and logs to
 heap build can outlast its ~30 s wait, in which case it still returns 0 with a
 "still starting" note and the build continues in the background. A `check`
 submitted before the session is ready fails fast, so gate on
-`ic2 server status` reporting `state: ready` first (or `ic2 server attach` to
+`ic2 server status` reporting `state=ready` first (or `ic2 server attach` to
 watch a cold build to completion).
 
 ## `ic2 check`
 
-Submits `.thy` files (absolute paths) to be type-checked by the running server
-and returns immediately. Poll with `check status`; cancel with `check cancel`.
+Submits `.thy` files to be type-checked by the running server and returns
+immediately. Prefer absolute paths: a relative one is resolved against YOUR cwd,
+not the server's (and the `check` MCP tool rejects relative paths outright). Poll with `check status`; cancel with `check cancel`.
 
 ```bash
 isabelle ic2 check Foo.thy Bar.thy      # submit both
@@ -170,20 +174,16 @@ e.g. to develop a proof step-by-step from the goal state at that line. (The bare
 `repl.py cli` can't do this: mapping a source line to a prover command id needs
 the live document, which only the ic2 server holds.)
 
-This is where proof development belongs: `check` once to see where the theory
-stands, `repl-create` at the proof, iterate there (`step`, `state`,
-`sledgehammer`, `fork` per subgoal, `text` for the script), paste the finished
-proof into the file, `check` once to confirm.
-
 ```
 $ isabelle ic2 repl-create AutoCorrode/Misc/Word.thy:142 w
-REPL 'w' from document Misc.Word cmd 37
+Created REPL "w" from document "Misc.Word" command 37 [proof]
 <proof state at that command...>
 
-Drive this REPL with `repl.py cli`:
+Drive this REPL with `repl.py cli` (one-shot client; `cli help` lists all verbs):
   step:       IR_AUTH_TOKEN=… python3 …/ir/repl.py cli --port 59498 step w 'apply simp'
   show state: IR_AUTH_TOKEN=… python3 …/ir/repl.py cli --port 59498 state w -1
   full text:  IR_AUTH_TOKEN=… python3 …/ir/repl.py cli --port 59498 text w
+  any ML:     IR_AUTH_TOKEN=… python3 …/ir/repl.py cli --port 59498 raw  -- 'Ir.show "w"' 
 ```
 
 `repl-create` resolves `LINE` to the command spanning it, creates the REPL, and
@@ -207,18 +207,23 @@ Key flags beyond the `isabelle jedit` set: `--daemon` (background it — see
 several coexist), `-N` (no build — fail fast if the heap is missing), `--no-iq` /
 `--mcp` (see below).
 
-`status` prints a summary line — session, pid, uptime, idle/busy, checks in
-flight — plus the I/R endpoints. Without `-n` it surveys every running server;
+`status` prints a summary line — state, session, pid, uptime, idle/busy, checks
+in flight — then the options it was started with, its cwd and activity stamps,
+then the I/R endpoints. Without `-n` it surveys every running server;
 during the initial heap build it shows a live phase (building → loading →
 ready). `--full` adds per-node processing/errors.
 
 ```
 $ isabelle ic2 server status
-default: session=HOL pid=12345 up=42s idle conns=1
+default: state=ready session=HOL pid=12345 up=42s idle conns=1
+    started with: logic=HOL
+    cwd=/abs/AutoCorrode  started=2026-08-23 09:14:02  last=2026-08-23 09:14:39 (5s ago)
     I/R repl.py: port=59498 token=GSJpumMw…  (raw I/R protocol)
     I/R MCP:     port=8765  token=a1b2c3d4…  (connect MCP repl_* here)
     I/R cli:     IR_AUTH_TOKEN=GSJpumMw… python3 …/ir/repl.py cli --port 59498 raw -- 'Ir.theories ()'
-plain:   session=HOL pid=12346 up=5s idle conns=1
+plain:   state=ready session=HOL pid=12346 up=5s idle conns=1
+    started with: logic=HOL  no_iq
+    cwd=/tmp  started=2026-08-23 09:14:36  last=2026-08-23 09:14:36 (5s ago)
     no I/R
 ```
 
@@ -266,7 +271,7 @@ client config:
     "ic2": {
       "command": "python3",
       "args": ["/path/to/AutoCorrode/iq/iq_bridge.py"],
-      "env": { "IQ_MCP_BRIDGE_PORT": "8765", "IQ_AUTH_TOKEN": "…" }
+      "env": { "IQ_MCP_BRIDGE_PORT": "8765" }
     }
   }
 }
@@ -274,9 +279,12 @@ client config:
 
 Every tool except `initialize` / `tools/list` / `ping` requires auth: the client
 must first call the **`authenticate`** tool with the MCP token. That token comes
-from `IQ_AUTH_TOKEN` (the same variable I/Q uses) if set, else it is generated
-and reported by `ic2 server status` (`I/R MCP: … token=…`). Set `IQ_AUTH_TOKEN`
-in both the server's environment and the client config to fix it ahead of time.
+from the SERVER's `IQ_AUTH_TOKEN` (the same variable I/Q uses) if set, else it is
+generated and reported by `ic2 server status` (`I/R MCP: … token=…`). Set
+`IQ_AUTH_TOKEN` in the server's environment to fix it ahead of time. Note the
+bridge itself does not read it — `iq_bridge.py` reads only its own
+`IQ_MCP_BRIDGE_*` settings — so the token has to reach whatever calls
+`authenticate`.
 The in-prover `ML_Repl` is never advertised, so nothing can connect around the
 bridge to the prover.
 
@@ -342,14 +350,16 @@ src/daemon.scala    — `ic2 server start`: daemon, --daemon launch, status op
 src/iq.scala        — I/R + MCP bring-up (IRLauncher, McpServer + tools) and the
                       single-slot Check model (Job, cancel/reset, --line worker)
 src/client.scala    — check / query / server / repl-create + UIs
+src/check_engine.scala — the check engine: updateModel / evaluate / stop
 src/endpoint.scala  — socket-path discovery + the 0700 directory
 src/json_io.scala   — newline-delimited JSON over a socket channel
+src/IRClient.scala  — IRClient + IRLauncher (a COPY of iq/'s, already drifted)
 src/test_tool.scala — `isabelle ic2_test` runner
 src/tools.scala     — Isabelle_Scala_Tools registration
 
   shared from iq/ (symlinks), all in `package isabelle`:
-src/IRClient.scala      — IRClient + IRLauncher
 src/IRTools.scala       — the repl_* tool provider
+src/Extended_Query_Operation.scala — caret-free print_state queries
 src/McpServer.scala     — generic MCP server
 src/McpProtocol.scala   — JSON-RPC decode
 src/SessionTools.scala  — session-generic diagnostics
@@ -357,7 +367,8 @@ src/SessionClient.scala — their MCP registration
 src/ErrorCodes.scala, src/IQNormalization.scala
 ```
 
-For the wire protocol (newline-delimited JSON) and the internals of checking,
-cancellation, and the headless goal-state plumbing, see the comments in
-`src/daemon.scala` and `src/iq.scala`.
+For the wire protocol (newline-delimited JSON) see the comments in
+`src/daemon.scala`; for the single-slot Check model and cancellation,
+`src/iq.scala`; for the checking itself, `src/check_engine.scala`; for the
+headless goal-state plumbing, `src/Extended_Query_Operation.scala`.
 ```

--- a/ic2/README.md
+++ b/ic2/README.md
@@ -11,14 +11,20 @@ run side by side, with no host/port/token to configure):
 
   * **`ic2 server`** — start/stop/inspect the resident session.
   * **`ic2 check FILE...`** — submit `.thy` files for checking, then poll with
-    `check status`.
-  * **`ic2 query SUBTOOL FILE`** — read-only diagnostics over the session.
+    `check status`. Per theory, not per proof edit — see below.
   * **`ic2 repl-create FILE:LINE NAME`** — fork an interactive I/R REPL at a
-    source location.
+    source location. Where proof *development* happens.
+  * **`ic2 query SUBTOOL FILE`** — read-only diagnostics over the session.
 
 Unless `--no-iq`, the server also brings up I/R against the same session (`--mcp`
 additionally serves the `repl_*` tools over MCP), so an agent can drive Isar
 proofs without a separate Isabelle/jEdit + I/Q.
+
+**The two loops.** A check costs a client JVM (plus one per `check status` poll),
+re-runs everything below the edit, and answers with a verdict; a REPL step is one
+round-trip to the resident prover and answers with the goal state. So `check` to
+see where a theory stands and to confirm a finished proof, and
+[`repl-create`](#ic2-repl-create) for everything in between.
 
 ## Prerequisites
 
@@ -45,7 +51,10 @@ isabelle ic2 server start --daemon -l AutoCorrode -d AutoCorrode
 # Wait until the session is ready, then check a file:
 isabelle ic2 server status                  # state: building → loading → ready
 isabelle ic2 check /abs/path/to/Foo.thy     # submit
-isabelle ic2 check status                   # poll result
+isabelle ic2 check status                   # poll result (reports file:line)
+
+# Work on the proof that failed in a REPL; paste it back, then check once more:
+isabelle ic2 repl-create /abs/path/to/Foo.thy:87 r87
 
 # Stop:
 isabelle ic2 server stop
@@ -76,8 +85,11 @@ isabelle ic2 check Foo.thy --command-timeout 15
 isabelle ic2 check cancel               # abort the in-flight check
 ```
 
-`--line N` evaluates only the prefix up to line `N`, leaving the rest
-unprocessed and re-checkable — handy for iterating on the line you're editing.
+`--line N` evaluates only the prefix up to line `N`, leaving the rest unprocessed
+and re-checkable — use it after a *structural* edit (a changed definition, a new
+lemma, a moved block); for tactic iteration use
+[`repl-create`](#ic2-repl-create), which `check status` points at whenever it can
+locate the failure.
 
 Every individual command has a 5-second wall-clock timeout by default. If one
 exceeds the limit, IC2 aborts the whole check with reason `command_timeout`;
@@ -157,6 +169,11 @@ Starts an *interactive* [I/R](../ir) proof REPL anchored at a source location �
 e.g. to develop a proof step-by-step from the goal state at that line. (The bare
 `repl.py cli` can't do this: mapping a source line to a prover command id needs
 the live document, which only the ic2 server holds.)
+
+This is where proof development belongs: `check` once to see where the theory
+stands, `repl-create` at the proof, iterate there (`step`, `state`,
+`sledgehammer`, `fork` per subgoal, `text` for the script), paste the finished
+proof into the file, `check` once to confirm.
 
 ```
 $ isabelle ic2 repl-create AutoCorrode/Misc/Word.thy:142 w

--- a/ic2/SKILL.md
+++ b/ic2/SKILL.md
@@ -1,0 +1,121 @@
+---
+name: ic2
+description: "Activate when the user asks to work on an Isabelle session or theory (`.thy`) — make changes, develop a proof, fix a proof, resolve a sorry, refactor tactics, chase down an error. Prefer over `isabelle build`. If the user has not already picked a tool, clarify whether IC2 (headless, CLI-driven) or I/Q (interactive, jEdit GUI) is the right fit for the task; in headless/agent contexts default to IC2."
+---
+
+# Working on Isabelle theories
+
+## Which tool
+
+- **IC2** — headless, CLI-driven: iterating on a theory from a shell or an agent,
+  batch-checking, diagnostics, no display available. Entry point
+  `isabelle ic2 --help`. Default in headless/agent contexts, and what the rest of
+  this skill covers.
+- **I/Q** — the user is interactively driving Isabelle/jEdit. Use the I/Q MCP
+  server; if no connection is established, say so.
+- **Batch build** — one-shot `isabelle build`. ONLY if the user explicitly asks.
+
+If it is unclear, ask. Mentions of jEdit or I/Q mean I/Q; "IC2" or "headless"
+means IC2.
+
+## The two loops
+
+Checking a theory and developing a proof are different jobs with different tools.
+
+| | tool | cost per iteration | answers with |
+|---|---|---|---|
+| Does this theory go through? | `isabelle ic2 check` | a client JVM start (~2 s), another for each `check status` poll, and re-execution of every command from the edit to the end of the theory | a verdict |
+| Does this *proof step* go through? | an I/R REPL (`ic2 repl-create`) | one round-trip to the resident prover, from the REPL's cached state | the new goal state |
+
+So: **`check` locates the problem and confirms the fix. A REPL does the work in
+between.** Whenever `check status` can locate a failure, it prints the
+`repl-create` command for that line.
+
+### The loop, concretely
+
+```bash
+# 0) once: a resident server (skip if `ic2 server status` already shows one ready)
+isabelle ic2 server start --daemon -l AutoCorrode -d /abs/AutoCorrode
+isabelle ic2 server status                        # wait for state=ready
+
+# 1) check once — find out where the theory actually stands
+isabelle ic2 check /abs/path/Foo.thy
+isabelle ic2 check status                         # -> error: /abs/path/Foo.thy:87
+                                                  #    + the repl-create command
+
+# 2) fork a REPL at the failing proof and iterate THERE. REPL names must be
+#    fresh, so name it after the line (`check status` suggests exactly this).
+isabelle ic2 repl-create /abs/path/Foo.thy:87 r87
+#    prints the goal state and the token/port to drive this REPL. Set them up
+#    once (see below); every step here reuses $IR.
+$IR step r87 'apply (induction xs)'               # try a step
+$IR state r87 -1                                  # look at the goal
+$IR sledgehammer r87 5                            # ask for a proof
+$IR fork r87 r87_sub -1                           # sub-REPL from the latest state
+$IR text r87                                      # the accumulated script
+
+# 3) write the proof into Foo.thy, confirm — once — and drop the REPL
+isabelle ic2 check /abs/path/Foo.thy
+isabelle ic2 check status
+$IR remove r87                                    # frees the name for lap 2
+```
+
+Set `$IR` up once per server from what `repl-create` (or `ic2 server status`)
+prints — the token and port are stable for the server's lifetime. The token must
+go in the environment, NOT in the variable: a leading `VAR=value` is only
+recognised when the shell parses the line, so `IR="IR_AUTH_TOKEN=… python3 …"`
+would try to execute a command named `IR_AUTH_TOKEN=…`.
+
+```bash
+export IR_AUTH_TOKEN=<token>
+IR="python3 /abs/AutoCorrode/ir/repl.py cli --port <port>"
+```
+
+Reusing a name fails (`REPL "r87" already exists`): `$IR remove r87` first, or
+pick another. `fork`'s last argument is a **state index** (`0` = base, `-1` = latest), not a
+subgoal number. `$IR text r` returns the concatenated Isar text of the REPL's
+steps — it does not include the `lemma` line unless the REPL was forked from
+before it, so check what you have before pasting into the theory.
+
+Use `check --line N` to narrow a check after a *structural* edit (a changed
+definition, a new lemma, a moved block), not to iterate on a tactic.
+
+For the proof-development method itself — building a frame of `sorry`s top-down,
+one sub-REPL per `sorry`, merging back — follow the **isar-proof** skill, via the
+tool-name translation below.
+
+## Driving a REPL: MCP tool ↔ `repl.py cli`
+
+Same I/R engine, two front ends. `isar-proof`'s workflow applies once you
+translate the tool names (it writes them `mcp__iq__repl_*`). The rule:
+**`repl_X(repl, ...)` → `X R ...`** — drop the `repl_` prefix, arguments in the
+same order. `R` is a REPL name, `IDX` a state index (`0` = base, `-1` = latest).
+The exceptions:
+
+| I/Q MCP tool | `repl.py cli` form |
+|---|---|
+| `repl_connect()` | nothing to do — ic2 brings I/R up at `server start`; confirm with `$IR repls` |
+| `repl_init_from_source(repl, file, pattern)` | `isabelle ic2 repl-create FILE:LINE R` — only ic2 can resolve a source line |
+| `repl_list()` | `repls` |
+| `repl_find_theorems(repl, query, max_results)` | `find-theorems R N 'QUERY'` — note N *before* QUERY |
+| `repl_raw(ml_code)` | `raw -- 'ML'` |
+
+`$IR help` prints the full verb table. Semantics carry over exactly, including the
+important one: **a failed `step` leaves the REPL state unchanged — do not `back`
+after a failure**, just re-`step` with different text.
+
+With `--mcp` the `repl_*` tools are *also* served over MCP (both front ends
+coexist), and the left-hand column then applies directly — prefer that. Connecting
+needs the stdio↔TCP bridge and an `authenticate` call; see "Connecting an MCP
+client" in ic2/README.md.
+
+## Common gotchas
+
+- `isabelle` is the Isabelle installation, e.g. `/Applications/Isabelle2025-2.app/bin/isabelle`. If `ic2` is unavailable, register the component with `make -C ic2` in the AutoCorrode repository.
+- Server lifecycle, `check`, `query`, `repl-create` all have their own `isabelle ic2 <subcommand> --help`.
+- ic2 `check attach` is a live-TTY human UI — rejects agent contexts; use `check status` for polling.
+- Prefer absolute `.thy` paths: the CLI resolves relative ones against YOUR cwd, not the server's, and the MCP `check` tool rejects them outright.
+- If `server status` reports `no I/R`, the whole REPL path is unavailable — `pip install -r ir/requirements.txt` and restart the server without `--no-iq`.
+- Server discovery is by name; when multiple are running, pass `-n NAME`.
+- `repl-create` needs its FILE to be a checked node — run `check` on it once first.
+- At most one check runs server-wide; a second is refused while one is in flight.

--- a/ic2/src/client.scala
+++ b/ic2/src/client.scala
@@ -165,9 +165,11 @@ Usage: isabelle ic2 check [OPTIONS] FILE...
     -n NAME             server name (default: the sole running server)
     --line N            check only the prefix of the (single) FILE up to
                         and including the command that ends on or before
-                        source line N (1-based). Fast partial check for
-                        iterative development. Commands after line N are left
-                        UNPROCESSED. Requires exactly one FILE.
+                        source line N (1-based). Commands after line N are
+                        left UNPROCESSED. Requires exactly one FILE.
+                        Use it after a STRUCTURAL edit (a changed definition,
+                        a new lemma, a moved block); for tactic iteration use
+                        `repl-create`.
     --command-timeout SECS
                         abort the whole check if any individual command runs
                         longer than SECS (default 5; 0 disables). Decimal
@@ -176,6 +178,14 @@ Usage: isabelle ic2 check [OPTIONS] FILE...
   Submit a type-check of the given .thy files to the running server and return
   immediately. Track progress with `isabelle ic2 check status`; abort the
   in-flight check with `isabelle ic2 check cancel`.
+
+  Check once per theory, then iterate on a proof in an I/R REPL, where a step is
+  one prover round-trip and returns the goal state (`isabelle ic2 --help`):
+
+    isabelle ic2 check status                        # -> fails at MyThy.thy:87
+    isabelle ic2 repl-create /abs/MyThy.thy:87 r     # iterate here
+    <paste the finished proof into MyThy.thy>
+    isabelle ic2 check /abs/MyThy.thy                # confirm, once
 
   Live output is only available via `isabelle ic2 check attach`, which requires
   an interactive terminal with normal terminal capabilities and is intended for
@@ -839,7 +849,9 @@ Usage: isabelle ic2 $cmd [-n NAME] [-c N] [--long-running SECS]
    *  session + the I/R client); the bare `repl.py cli` cannot, so this is the
    *  way to start a REPL at a `.thy` position. Prints the REPL's initial state
    *  AND the exact `repl.py cli` commands to drive it. FILE must be a loaded
-   *  node — check it first. */
+   *  node — check it first. This is the entry point for working ON a proof:
+   *  anything iterative belongs here, and only the finished proof goes back into
+   *  the .thy for a single confirming `check`. */
   def repl_create(args: List[String]): Unit = {
     def usage(): Nothing = {
       Output.writeln(
@@ -848,6 +860,8 @@ Usage: isabelle ic2 $cmd [-n NAME] [-c N] [--long-running SECS]
         "  command on LINE (1-based) of the theory FILE (a loaded/checked node).\n" +
         "  Prints the REPL's initial state and the `repl.py cli` commands to\n" +
         "  drive it (step/state/text/...).\n\n" +
+        "  Use this to work on a proof: a step is one prover round-trip and returns\n" +
+        "  the new goal state. Iterate here, then `check` the file once to confirm.\n\n" +
         "  -n SERVER   server name (default: the sole running server)\n", stdout = true)
       sys.exit(2)
     }

--- a/ic2/src/client.scala
+++ b/ic2/src/client.scala
@@ -234,6 +234,26 @@ Usage: isabelle ic2 check [OPTIONS] FILE...
     }
   }
 
+  /** A nested JSON object by key, if present. */
+  private def sub_object(t: JSON.T, key: String): Option[JSON.Object.T] =
+    JSON.value(t, key).flatMap(JSON.Object.unapply)
+
+  /** The retained command-timeout culprit as display lines: which command tripped
+   *  the watchdog, where, for how long, and its source preview. Shared by the
+   *  one-shot `check status` frame and the streaming `check attach` tail, so a
+   *  `command_timeout` outcome never arrives without naming the command. */
+  private def format_command_timeout(timeout: JSON.T): List[String] = {
+    val theory = JSON.string(timeout, "theory").getOrElse("?")
+    val line = JSON.int(timeout, "line").getOrElse(0)
+    val loc = JSON.string(timeout, "file").getOrElse(theory) +
+      (if (line > 0) ":" + line else "")
+    val keyword = JSON.string(timeout, "keyword").getOrElse("?")
+    val limit = JSON.double(timeout, "limit_s").getOrElse(0.0)
+    val elapsed = JSON.double(timeout, "elapsed_s").getOrElse(0.0)
+    f"command timeout: $loc%s: $keyword%s exceeded $limit%.1fs ($elapsed%.1fs elapsed)" ::
+      JSON.string(timeout, "preview").filter(_.nonEmpty).map("  " + _).toList
+  }
+
   /** Read the check event stream from `io`, rendering started/progress/error to
    *  `ui` and reporting the terminal `finished` via setOk/setReason. Used by
    *  `check attach`. Returns when `finished` or EOF. */
@@ -258,6 +278,11 @@ Usage: isabelle ic2 check [OPTIONS] FILE...
             case Some("finished") =>
               val ok = JSON.bool(t, "ok").getOrElse(false)
               val reason = JSON.string(t, "reason").getOrElse("")
+              // A `command_timeout` reason on its own says nothing about WHICH
+              // command tripped the watchdog; the culprit rides along with the
+              // terminal event, so report it before the UI closes.
+              sub_object(t, "timeout")
+                .foreach(timeout => format_command_timeout(timeout).foreach(ui.note))
               setOk(ok)
               setReason(reason)
               done = true
@@ -437,19 +462,8 @@ Usage: isabelle ic2 $cmd [-n NAME] [-c N] [--long-running SECS]
       Output.writeln("error: " + loc)
       msg.linesIterator.foreach(l => Output.writeln("  " + l))
     }
-    JSON.value(reply, "timeout").flatMap(JSON.Object.unapply).foreach { timeout =>
-      val theory = JSON.string(timeout, "theory").getOrElse("?")
-      val line = JSON.int(timeout, "line").getOrElse(0)
-      val loc = JSON.string(timeout, "file").getOrElse(theory) +
-        (if (line > 0) ":" + line else "")
-      val keyword = JSON.string(timeout, "keyword").getOrElse("?")
-      val limit = JSON.double(timeout, "limit_s").getOrElse(0.0)
-      val elapsed = JSON.double(timeout, "elapsed_s").getOrElse(0.0)
-      Output.writeln(
-        f"command timeout: $loc%s: $keyword%s exceeded $limit%.1fs ($elapsed%.1fs elapsed)")
-      JSON.string(timeout, "preview").filter(_.nonEmpty)
-        .foreach(preview => Output.writeln("  " + preview))
-    }
+    sub_object(reply, "timeout")
+      .foreach(t => format_command_timeout(t).foreach(l => Output.writeln(l)))
     sys.exit(0)
   }
 

--- a/ic2/src/client.scala
+++ b/ic2/src/client.scala
@@ -129,6 +129,33 @@ object Client {
       socket_path.expand.implode + " (server not running, or socket stale?)"))
 
 
+  /* ==================== the I/R pointer ============================
+   * A check answers with a verdict; a REPL step answers with the goal state. A
+   * located failure is where the caller decides what to do next, so that is where
+   * `check status` offers the REPL as a ready-to-run command.
+   */
+
+  /** The `repl-create` pointer, anchored at `line` of `file`. Best-effort: the
+   *  named command is normally forkable (a command that FAILED has finished
+   *  evaluating), but a check aborted while an earlier command was still forked
+   *  can leave it reminted and unevaluated, in which case `repl-create` says so
+   *  and exits 3. The REPL is named after the line, so successive laps of the
+   *  loop — and two proofs in flight at once — do not collide on one name. */
+  private def repl_hint(name: String, file: String, line: Int): List[String] =
+    List(
+      "hint: fork an I/R REPL to iterate on the proof itself — one prover",
+      "      round-trip per step, no client JVM, nothing downstream re-run:",
+      "        isabelle ic2 repl-create " + file + ":" + line + " r" + line + " -n " + name,
+      "      step / state / sledgehammer there, then `check` once, when it is written.")
+
+  /** A `file:line` anchor from the retained `error` object, when it names both. */
+  private def anchor_of(o: JSON.Object.T): Option[(String, Int)] =
+    for {
+      file <- JSON.string(o, "file")
+      line <- JSON.int(o, "line") if line > 0
+    } yield (file, line)
+
+
   /* ============================ check ============================== */
 
   private val check_usage_text: String = """
@@ -450,9 +477,10 @@ Usage: isabelle ic2 $cmd [-n NAME] [-c N] [--long-running SECS]
     // (a finished/idle check has nothing in flight to draw).
     if (state == "running" && nodes.nonEmpty)
       render_progress_frame(nodes, bars).foreach(Output.writeln(_))
+    val error = sub_object(reply, "error")
     // Retained first error: WHERE (theory + file:line) and WHY (message), so a
     // detached poll sees the failure without needing to have been subscribed.
-    JSON.value(reply, "error").flatMap(JSON.Object.unapply).foreach { err =>
+    error.foreach { err =>
       val thy = JSON.string(err, "theory").getOrElse("?")
       val loc = JSON.string(err, "file") match {
         case Some(f) => f + JSON.int(err, "line").map(":" + _).getOrElse("")
@@ -464,6 +492,12 @@ Usage: isabelle ic2 $cmd [-n NAME] [-c N] [--long-running SECS]
     }
     sub_object(reply, "timeout")
       .foreach(t => format_command_timeout(t).foreach(l => Output.writeln(l)))
+    // The REPL alternative, anchored at the command that FAILED. Not at a
+    // command-timeout culprit: the watchdog cancels that command mid-eval, and
+    // `repl-create` rejects a command whose eval never finished (ir.ML:
+    // "is still being evaluated").
+    error.flatMap(anchor_of)
+      .foreach { case (file, at) => repl_hint(name, file, at).foreach(l => Output.writeln(l)) }
     sys.exit(0)
   }
 

--- a/ic2/src/daemon.scala
+++ b/ic2/src/daemon.scala
@@ -914,8 +914,7 @@ Usage: isabelle ic2 server start [OPTIONS]
     private def fail_check(io: JSON_IO, msg: String): Unit = {
       clog("check rejected — invalid request: " + msg)
       io.write(server_error(msg))
-      io.write(JSON.Object("event" -> "finished",
-        "ok" -> false, "reason" -> "invalid request"))
+      write_finished(io, Check.Outcome.Failed("invalid request"))
     }
 
     /** Render a job Event to this connection's wire JSON
@@ -932,10 +931,26 @@ Usage: isabelle ic2 server start [OPTIONS]
           file.map(f => JSON.Object("file" -> f)).getOrElse(JSON.Object()) ++
           line.map(l => JSON.Object("line" -> l)).getOrElse(JSON.Object()) ++
           JSON.Object("message" -> message))
-      case Check.Event.Finished(ok, reason) =>
-        if (ok) io.write(JSON.Object("event" -> "finished", "ok" -> true))
-        else io.write(JSON.Object("event" -> "finished", "ok" -> false, "reason" -> reason))
+      // Dropped, not encoded: the terminal event is written by `write_finished`
+      // from the awaited outcome (which alone knows the retained timeout
+      // culprit). The subscription DOES deliver Finished on every completion —
+      // this branch is what discards it, so there is one encoder, not two.
+      case _: Check.Event.Finished => ()
     }
+
+    /** The terminal `finished` event, with the retained command-timeout culprit
+     *  attached when there is one. A polling client re-reads the job via
+     *  `check_status`, which reports the culprit; a STREAMING client never does,
+     *  so without this it would see `reason=command_timeout` and no indication of
+     *  which command tripped the watchdog. The ONLY encoder of the terminal
+     *  event — `fail_check` and both relay paths go through here. */
+    private def write_finished(
+      io: JSON_IO, out: Check.Outcome, timeout: Option[Check.Command_Timeout] = None
+    ): Unit =
+      io.write(
+        JSON.Object("event" -> "finished", "ok" -> out.ok) ++
+        (if (out.ok) JSON.Object() else JSON.Object("reason" -> out.reason)) ++
+        timeout.map(t => JSON.Object("timeout" -> t.json)).getOrElse(JSON.Object()))
 
     /** Submit either a full (`line=None`) or partial (`line=Some(N)`) check.
      *  Small dispatcher: full checks go through `Check.submit`, partial through
@@ -968,10 +983,7 @@ Usage: isabelle ic2 server start [OPTIONS]
           // Stream the job's live progress/error events. Drop the streamed
           // Finished — we emit the terminal `finished` from the awaited outcome
           // (reliable even if a fast check finished before we subscribed).
-          val unsubscribe = job.subscribe {
-            case _: Check.Event.Finished => ()
-            case e => wireEvent(io)(e)
-          }
+          val unsubscribe = job.subscribe(wireEvent(io))
           // Wait on a RELAY thread, not the connection thread: the connection
           // thread must return to its read loop so a client disconnect is
           // detected (its `finally` then cancels this job).
@@ -982,7 +994,7 @@ Usage: isabelle ic2 server start [OPTIONS]
                 // Final progress snapshot (the awaited recorded status) so the
                 // client UI ends on a settled per-theory state, then finished.
                 wireEvent(io)(Check.Event.Progress(job.finalNodes))
-                wireEvent(io)(Check.Event.Finished(out.ok, out.reason))
+                write_finished(io, out, job.commandTimeoutInfo)
                 Check.logFinish(server_progress, "conn " + conn_id, job.elapsedMs, out.ok, out.reason)
               } finally { unsubscribe(); attached.set(None) }
           }, "ic2-check-relay-" + conn_id)
@@ -1029,10 +1041,7 @@ Usage: isabelle ic2 server start [OPTIONS]
           // `finished` from the awaited record, never depending on whether the
           // live Finished arrived before or after we subscribed. await() returns
           // immediately if the job is already done.
-          val unsubscribe = job.subscribe {
-            case _: Check.Event.Finished => ()
-            case e => wireEvent(io)(e)
-          }
+          val unsubscribe = job.subscribe(wireEvent(io))
           // Paint the current per-theory state immediately (after subscribing, so
           // no live tick is missed): a check wedged inside one long-running command
           // emits no nodes_status ticks, so without this the client would sit on a
@@ -1045,7 +1054,7 @@ Usage: isabelle ic2 server start [OPTIONS]
           try {
             val out = job.await()
             wireEvent(io)(Check.Event.Progress(job.finalNodes))
-            wireEvent(io)(Check.Event.Finished(out.ok, out.reason))
+            write_finished(io, out, job.commandTimeoutInfo)
           } finally unsubscribe()
       }
 

--- a/ic2/src/ic2.scala
+++ b/ic2/src/ic2.scala
@@ -34,22 +34,31 @@ Usage: isabelle ic2 COMMAND [ARGS...]
 
   ============================== Typical loop ==============================
 
+  `check` runs a whole theory: each cycle costs a client JVM (one more per
+  `check status` poll), re-runs everything from the edit down, and answers with a
+  verdict. A REPL step is one prover round-trip and answers with the goal state.
+  So iterate in a REPL, and check to confirm.
+
     1) Start the daemon once, backgrounded:
 
          isabelle ic2 server start --daemon -l HOL
 
-    2) Type-check a theory against the resident session:
+    2) Check the theory once, to see where it stands:
 
-         isabelle ic2 check src/MyThy.thy
+         isabelle ic2 check /abs/path/MyThy.thy
+         isabelle ic2 check status                  # poll; reports file:line
 
-       ...or check only up to a specific source line:
+    3) Fork an I/R REPL at the proof you are working on, and iterate THERE:
 
-         isabelle ic2 check src/MyThy.thy --line 42
+         isabelle ic2 repl-create /abs/path/MyThy.thy:42 r
 
-    3) Inspect the document/proof state at any position:
+       `repl-create` prints the REPL's goal state and the exact commands to
+       drive it: step an Isar command, show the state, sledgehammer, fork a
+       sub-REPL for a subgoal, print the accumulated proof text.
 
-         isabelle ic2 query state-at src/MyThy.thy --line 42
-         isabelle ic2 query state-at src/MyThy.thy --pattern 'apply simp'
+    4) Write the finished proof back into the .thy file, and check ONCE more:
+
+         isabelle ic2 check /abs/path/MyThy.thy
 
   ============================== Commands =================================
 
@@ -62,6 +71,8 @@ Usage: isabelle ic2 COMMAND [ARGS...]
 
     check [FILE...]            Submit .thy files to be type-checked by the
                                running server; returns after submission.
+                               Once per theory, not per proof edit — see
+                               Typical loop.
       Variants (in place of FILE...):
         check status           report the current/last check's state
         check attach           stream the in-flight check to completion;
@@ -70,7 +81,10 @@ Usage: isabelle ic2 COMMAND [ARGS...]
       Options:
         --line N               check only the prefix of the (single) FILE
                                up to the command ending on or before source
-                               line N; commands after N are left UNPROCESSED
+                               line N; commands after N are left UNPROCESSED.
+                               Use it after a STRUCTURAL edit (a changed
+                               definition, a new lemma); for tactic iteration
+                               use `repl-create`.
         --command-timeout SECS abort the whole check when one command exceeds
                                SECS (default 5; 0 disables)
 
@@ -91,12 +105,13 @@ Usage: isabelle ic2 COMMAND [ARGS...]
                                  ic2 query state-at Foo.thy --pattern 'by simp'
                                Use --json for the raw payload.
 
-    repl-create FILE:LINE NAME Create a snapshot of the document / proof
-                               state for out-of-document exploration:
-                               forks an interactive I/R REPL at the given
-                               source location. Prints the exact
-                               `repl.py cli` commands to drive it
-                               (step/state/text/...).
+    repl-create FILE:LINE NAME Fork an interactive I/R REPL at that source
+                               location — step Isar commands, inspect the goal,
+                               sledgehammer, fork sub-REPLs per subgoal, print
+                               the accumulated text; one prover round-trip per
+                               step. Prints the initial goal state and the
+                               `repl.py cli` commands to drive it. FILE must be
+                               a checked node, so `check` it once first.
 
     query SUBTOOL [FILE] ...   Other read-only diagnostics over the session
                                (list-files, entities, sorry, proof-blocks,
@@ -106,10 +121,13 @@ Usage: isabelle ic2 COMMAND [ARGS...]
   ============================== Concrete flow ============================
 
     isabelle ic2 server start --daemon -l HOL
-    isabelle ic2 check src/MyThy.thy                       # submit check
-    isabelle ic2 check status                              # poll result
-    isabelle ic2 check src/MyThy.thy --line 87             # only up to 87
-    isabelle ic2 query state-at src/MyThy.thy --line 87    # inspect goal
+    isabelle ic2 check /abs/MyThy.thy                # submit check
+    isabelle ic2 check status                        # poll: fails at line 87
+    isabelle ic2 query state-at /abs/MyThy.thy --line 87    # read the goal
+    isabelle ic2 repl-create /abs/MyThy.thy:87 r     # fork a REPL at line 87
+    ...iterate in the REPL until the proof goes through...
+    <edit MyThy.thy: paste the proof from the REPL's `text`>
+    isabelle ic2 check /abs/MyThy.thy                # confirm, once
     isabelle ic2 server stop
 
   Run `isabelle ic2 COMMAND --help` for a command's own options.

--- a/ic2/src/iq.scala
+++ b/ic2/src/iq.scala
@@ -826,7 +826,8 @@ object Check {
       Left("command timeout must be a finite number >= 0 (0 = unlimited)")
     else if (files.isEmpty) Left("empty files list")
     else resolveTargets(resources, files).map { resolved =>
-      val job = new Job(resolved.map(_._1.theory), resolved.map(_._1), session,
+      val nodes = resolved.map(_._1)
+      val job = new Job(nodes.map(_.theory), nodes, session,
         resources = Some(resources), commandTimeoutSecs = commandTimeoutSecs)
       slot.set(Some(job))
       job.start()
@@ -1196,7 +1197,10 @@ object IQ {
         "on or before that source line — same UI, same cancel semantics, but " +
         "later commands are left unprocessed. Each command has a separate " +
         "`command_timeout_secs` budget (default 5; 0 = unlimited); exceeding it " +
-        "aborts the whole check with reason \"command_timeout\".",
+        "aborts the whole check with reason \"command_timeout\". Checks a whole " +
+        "theory: to ITERATE on a proof use a REPL instead — repl_init_from_source " +
+        "at the proof, then repl_step / repl_fork / repl_sledgehammer — and check " +
+        "once, when the proof is written.",
       inputSchema = Map(
         "type" -> "object",
         "properties" -> Map(
@@ -1231,6 +1235,10 @@ object IQ {
                     job.cancel("timeout")
                   val out = job.await()
                   Check.logFinish(log, "mcp", job.elapsedMs, out.ok, out.reason)
+                  // A deliberately compact result: unlike check_async /
+                  // check_status this tool does NOT pass statusJson through,
+                  // because a blocking caller has no use for per-node progress
+                  // and every key of it lands in the client's context.
                   val base = Map[String, Any](
                     "ok" -> out.ok,
                     "theories" -> job.theories,
@@ -1262,7 +1270,10 @@ object IQ {
         "in flight (cancel it and resubmit the merged set of files). Files must " +
         "be absolute .thy paths. Use plain `check` for a blocking call. With " +
         "`line`, check only the prefix of the (single) file up to that line. " +
-        "Each command has a `command_timeout_secs` budget (default 5; 0 = unlimited).",
+        "Each command has a `command_timeout_secs` budget (default 5; 0 = unlimited). " +
+        "To ITERATE on a proof use a REPL instead (repl_init_from_source at the " +
+        "proof, then repl_step / repl_fork / repl_sledgehammer); check once, when " +
+        "the proof is written.",
       inputSchema = Map(
         "type" -> "object",
         "properties" -> Map(


### PR DESCRIPTION
Agents working a hard proof tend to re-run isabelle IC2 check after every small edit, polling check status between each. Each cycle costs a client JVM for the check and another per poll, re-runs every command below the edit, and answers with a verdict rather than a goal state: where an I/R REPL forked at the proof is one prover round-trip and returns the state. Nothing in the output said so, and the docs pointed the other way: --line N advertised itself as "handy for iterating on the line you're editing", and repl-create was described without a hint of when to reach for it.

check status now prints the repl-create command for the failing line whenever it can locate the failure, and the check / check_async MCP tool descriptions carry the same guidance, where a client reads it before choosing a tool. The docs are reframed to match (check locates and confirms, repl-create does the work in between) and a new ic2/SKILL.md carries the loop as a worked recipe plus the repl_* -> repl.py cli translation rule.

Separately, the terminal finished wire event carried only ok + reason, so a streaming client saw reason=command_timeout without learning which command tripped the watchdog. Three hand-rolled encodings of that event collapse into one write_finished that attaches the retained culprit.

A final commit fixes pre-existing README claims: the stale show_states rationale, -n listed among the flags mirroring isabelle jedit, two drifted transcripts, an inert IQ_AUTH_TOKEN.