### PR TITLE
PRELIMINARY / DO NOT MERGE: adapt to Isabelle_25-Jul-2026 (Isabelle2026 pre-release)

### DIFF
--- a/Autogen/AutoLens.thy
+++ b/Autogen/AutoLens.thy
@@ -164,11 +164,13 @@ ML\<open>
 
    \<comment> \<open>Extends the current context with an untyped definition \<^verbatim>\<open>definition \<open>name \<equiv> expr\<close>\<close>.\<close>
    fun typeless_def attribs name expr =
-      ( #2 o Specification.definition_cmd (SOME((Binding.qualified_name name), NONE, Mixfix.NoSyn))
-                                   [] [] ((Binding.empty, attribs), name ^ " \<equiv> " ^ expr) false)
+      ( #2 o Specification.definition_cmd {verbose = false}
+                                   (SOME((Binding.qualified_name name), NONE, Mixfix.NoSyn))
+                                   [] [] ((Binding.empty, attribs), name ^ " \<equiv> " ^ expr))
 
    fun declare_attribs attribs thm =
-     #2 o Specification.theorems_cmd "" [((Binding.empty, attribs), [(Facts.named thm, [])])] [] false
+     #2 o Specification.theorems_cmd {verbose = false, kind = ""}
+            [((Binding.empty, attribs), [(Facts.named thm, [])])] []
 \<close>
 
 subsection\<open>Automatic generation of lenses and lemmas\<close>

--- a/Autogen/AutoLocality.thy
+++ b/Autogen/AutoLocality.thy
@@ -696,7 +696,7 @@ ML\<open>
              Pretty.brk 1, Pretty.str "called"] |> Pretty.block,
           [Pretty.str "Term:", Pretty.brk 1, Syntax.pretty_term ctxt (Thm.term_of ctm)] |> Pretty.block]
           |> Pretty.chunks |> Pretty.writeln
-       val ctxt' = clear_simpset ctxt
+       val ctxt' = Simplifier.clear_simpset ctxt
        val lookup_facts = (fn s => (s, Position.none)) #> Named_Theorems.check ctxt #> Named_Theorems.get ctxt
 
        (* Identify redundant operations in the body of the attribute and hoist them out *)
@@ -722,9 +722,9 @@ ML\<open>
          (commutativity_theorems_for_record rec_name, Position.none)
 
        val locality_facts = commutativity_thms |> lookup_facts
-       val ctm_reduce_eq = Simplifier.rewrite (ctxt' addsimps locality_facts) ctm
+       val ctm_reduce_eq = Simplifier.rewrite (ctxt' |> Simplifier.add_simps locality_facts) ctm
        val ctm_hoisted_reduce_eq =
-         Simplifier.rewrite (ctxt' addsimps locality_facts) ctm_hoisted RS @{thm Pure.symmetric}
+         Simplifier.rewrite (ctxt' |> Simplifier.add_simps locality_facts) ctm_hoisted RS @{thm Pure.symmetric}
 
        val _ = [ Pretty.str "Simplification original:", Pretty.brk 1,
                  Syntax.pretty_term ctxt (Thm.prop_of ctm_reduce_eq)]
@@ -745,7 +745,7 @@ ML\<open>
        val _ = "Cancellation facts:" |> tracing
        val _ = List.map (Thm.prop_of #> Syntax.pretty_term ctxt #> Pretty.writeln) cancellation_facts
        val _ = "Done" |> tracing
-       val ctm_hoisted_cancel_eq = Simplifier.rewrite (ctxt' addsimps cancellation_facts) ctm_hoisted
+       val ctm_hoisted_cancel_eq = Simplifier.rewrite (ctxt' |> Simplifier.add_simps cancellation_facts) ctm_hoisted
     in
        SOME (ctm_hoisted_cancel_eq RS (ctm_to_ctm_hoisted_eq RS @{thm Pure.transitive}))
     end end
@@ -770,7 +770,7 @@ ML\<open>
       val ptrn_str = make_locality_simproc_pattern attr_name num_args idx
       val ptrn = Syntax.read_term ctxt ptrn_str
     in
-       Simplifier.make_simproc ctxt {name = simproc_name, kind = Simproc, identifier = [], 
+       Simplifier.make_simproc ctxt {name = simproc_name, kind = Simplifier.Simproc, identifier = [],
           lhss = [ptrn], proc = K (locality_cancellation_simproc rec_name attr_name idx) }
     end
 
@@ -1204,14 +1204,14 @@ ML\<open>
       val attrs = get_attributes ctxt |> map snd
       val attr_simprocs = attrs |> List.map (#sp #> Option.valOf)
     in
-      Thm.declaration_attribute (K (Raw_Simplifier.map_ss (fn ctxt => ctxt addsimprocs attr_simprocs)))
+      Thm.declaration_attribute (K (Simplifier.map_simpset (fold Simplifier.add_proc attr_simprocs)))
     end
 
   fun locality_cancellation_simprocs_del_all ctxt : attribute =
     let
       val attr_simprocs = get_attributes ctxt |> map snd |> List.map (#sp #> Option.valOf)
     in
-      Thm.declaration_attribute (K (Raw_Simplifier.map_ss (fn ctxt => ctxt delsimprocs attr_simprocs)))
+      Thm.declaration_attribute (K (Simplifier.map_simpset (fold Simplifier.del_proc attr_simprocs)))
     end\<close>
 
 attribute_setup locality_cancel    = \<open>Args.context >> locality_cancellation_simprocs_add_all\<close>

--- a/Byte_Level_Encoding/byte_encoding_enum_cmd.ML
+++ b/Byte_Level_Encoding/byte_encoding_enum_cmd.ML
@@ -85,7 +85,7 @@ fun define_byte_enum typ_binding (specs : (binding * int) list) lthy =
        rules would trigger "Ignoring duplicate rewrite rule" warnings. *)
     val encoding_simps = [to_byte_def, from_byte_def]
     val simp_ctxt =
-      fold Splitter.add_split @{thms if_split if_split_asm} (lthy4 addsimps encoding_simps)
+      fold Splitter.add_split @{thms if_split if_split_asm} (lthy4 |> Simplifier.add_simps encoding_simps)
 
     val valid_thm = Goal.prove lthy4 [] [] valid_prop
       (fn {context = ctxt, ...} =>
@@ -129,7 +129,7 @@ fun define_byte_enum typ_binding (specs : (binding * int) list) lthy =
         ("(\<forall>e. " ^ from_str ^ " (" ^ to_str ^ " e) = Some e) \<and> " ^
          "(\<forall>w e. " ^ from_str ^ " w = Some e \<longrightarrow> " ^ to_str ^ " e = w)")
     val rep_simp_ctxt =
-      fold Splitter.add_split @{thms if_split if_split_asm} (lthy7 addsimps encoding_simps)
+      fold Splitter.add_split @{thms if_split if_split_asm} (lthy7 |> Simplifier.add_simps encoding_simps)
     val guard_thm = Goal.prove lthy7 [] [] guard_prop
       (fn {context = ctxt, ...} =>
         (resolve_tac ctxt @{thms conjI} 1
@@ -144,7 +144,7 @@ fun define_byte_enum typ_binding (specs : (binding * int) list) lthy =
       (fn {context = ctxt, ...} =>
         Local_Defs.unfold_tac ctxt [focus_def]
         THEN asm_full_simp_tac
-               (lthy7 addsimps [@{thm enum_byte_focus.rep_eq}, @{thm if_P} OF [guard_thm], prism_def]) 1)
+               (lthy7 |> Simplifier.add_simps [@{thm enum_byte_focus.rep_eq}, @{thm if_P} OF [guard_thm], prism_def]) 1)
     val lthy8 = lthy7
       |> Code.declare_abstract_eqn rep_thm
   in

--- a/Byte_Level_Encoding/byte_encoding_record_cmd.ML
+++ b/Byte_Level_Encoding/byte_encoding_record_cmd.ML
@@ -149,7 +149,8 @@ fun define_byte_record typ_binding (fields : (binding * string) list) lthy =
               (fn {context = ctxt, ...} =>
                 Local_Defs.unfold_tac ctxt [focus_def]
                 THEN EqSubst.eqsubst_tac ctxt [0] @{thms array_focus.rep_eq} 1
-                THEN asm_full_simp_tac (ctxt addsimps [elem_fw] delsimps @{thms One_nat_def}) 1)
+                THEN asm_full_simp_tac (ctxt |> Simplifier.add_simps [elem_fw]
+                       |> Simplifier.del_simps @{thms One_nat_def}) 1)
             val lthy_b = lthy_a |> Code.declare_abstract_eqn rep_thm
           in ("FocusParser " ^ focus_name, lthy_b) end
 

--- a/Crush/base.ML
+++ b/Crush/base.ML
@@ -399,8 +399,8 @@ struct
     CHANGED_PROP o REPEAT_ALL_NEW (ematch_tac ctxt thms)
 
   fun reset_ctxt congs thms =
-       clear_simpset
-    #> (fn ctxt => ctxt addsimps thms)
+       Simplifier.clear_simpset
+    #> Simplifier.add_simps thms
     #> fold Raw_Simplifier.add_cong congs
 
   val safe_simp_only_tac' : Proof.context -> thm list -> thm list -> int -> tactic = 

--- a/Crush/crush.ML
+++ b/Crush/crush.ML
@@ -121,19 +121,19 @@ struct
   (
     type T = simpset;
     val empty = crush_base_simpset
-    val merge = merge_ss;
+    val merge = Simplifier.merge_ss;
   );
 
   fun register_contracts (cs : thm list) : Context.generic -> Context.generic =
     fn ctxt => ctxt |> (
-       curry ((op addsimps) o swap) cs
-    |> simpset_map (Context.proof_of ctxt)
+       Simplifier.add_simps cs
+    |> Simplifier.simpset_map (Context.proof_of ctxt)
     |> URustContractSimps.map)
 
   fun unregister_contracts (cs : thm list) : Context.generic -> Context.generic =
     fn ctxt => ctxt |> (
-       curry ((op delsimps) o swap) cs
-    |> simpset_map (Context.proof_of ctxt)
+       Simplifier.del_simps cs
+    |> Simplifier.simpset_map (Context.proof_of ctxt)
     |> URustContractSimps.map)
 
   fun crush_register_contract_attrib (del : bool) = Thm.declaration_attribute (fn t => fn ctxt =>
@@ -283,7 +283,7 @@ struct
        TIME "crush_branch_call_intro_with_abort" (intro_tac @{thms wp_call_with_abortI} ctxt)
 
     (* Hoisted: simpset construction and the goal-independent SOLVED' arm of the abort check. *)
-    val abort_simp_tac = safe_asm_simp_tac (ctxt addsimps @{thms Let_def})
+    val abort_simp_tac = safe_asm_simp_tac (ctxt |> Simplifier.add_simps @{thms Let_def})
     val confirm_solved_arm = SOLVED' (TRY o unfold_contract_tac THEN' abort_simp_tac)
     val time_confirm_no_abort = TIME "crush_branch_call_confirm_no_abort"
     in
@@ -641,10 +641,11 @@ struct
 
         val ctxt' = fold Raw_Simplifier.del_cong (Named_Theorems.get ctxt @{named_theorems crush_cong_default_del}) ctxt
         val ctxt' = fold Raw_Simplifier.add_cong (Named_Theorems.get ctxt @{named_theorems crush_cong}) ctxt'
-        val ctxt' = ctxt' delsimps @{thms HOL.True_implies_equals}
-                          addsimps (Named_Theorems.get ctxt @{named_theorems crush_late_simps})
-                          addsimps (Named_Theorems.get ctxt @{named_theorems focus_simps})
-                          addsimps (Named_Theorems.get ctxt @{named_theorems focus_components})
+        val ctxt' = ctxt'
+          |> Simplifier.del_simps @{thms HOL.True_implies_equals}
+          |> Simplifier.add_simps (Named_Theorems.get ctxt @{named_theorems crush_late_simps})
+          |> Simplifier.add_simps (Named_Theorems.get ctxt @{named_theorems focus_simps})
+          |> Simplifier.add_simps (Named_Theorems.get ctxt @{named_theorems focus_components})
 
         (* We use the original context where possible, for better parallelism *)
         val guards_tac' = time_and_report ctxt "crush_step_instantiation_guards" (Config.get ctxt Crush_Config.time_step_instantiation)

--- a/Crush/seplog.ML
+++ b/Crush/seplog.ML
@@ -943,7 +943,7 @@ struct
 
   fun asepconj_solve_eq_tac ctxt i =
     if i = 1 then
-      simp_tac ((ctxt |> clear_simpset) addsimps @{thms asepconj_AC}) i
+      simp_tac (ctxt |> Simplifier.clear_simpset |> Simplifier.add_simps @{thms asepconj_AC}) i
     else
       all_tac
 
@@ -1087,7 +1087,7 @@ struct
   val ucincl_solve_tac : Proof.context -> int -> tactic = fn ctxt =>
      let val ucincl_intro = intro_tac (Named_Theorems.get ctxt @{named_theorems ucincl_intros}) ctxt
          val ucincl_elim  = elim_tac  (Named_Theorems.get ctxt @{named_theorems ucincl_elims}) ctxt
-         val ctxt' = ctxt addsimps @{thms Let_def}
+         val ctxt' = ctxt |> Simplifier.add_simps @{thms Let_def}
          fun NOTE msg =  Crush_Time.TIME' ctxt (Config.get ctxt Crush_Config.time_ucincl) msg
                       #> Crush_Tacticals.LOG' ctxt (Config.get ctxt Crush_Config.log_ucincl) msg
      in Crush_Tacticals.IF' is_ucincl ( NOTE "ucincl_solve" (

--- a/Enum_Theory/enum_cmd.ML
+++ b/Enum_Theory/enum_cmd.ML
@@ -234,7 +234,7 @@ fun add_equal_instance typ constr_terms constr_arg_typs case_eq_thms inject_simp
           HOLogic.mk_Trueprop (HOLogic.mk_eq (mk_side @{const_name HOL.equal}, mk_side @{const_name HOL.eq}))
           |> Syntax.check_term lthy_inst
         val ((_, (_, raw_def)), lthy_inst') =
-          Specification.definition NONE [] [] (Binding.empty_atts, spec) lthy_inst
+          Specification.definition {verbose = false} NONE [] [] (Binding.empty_atts, spec) lthy_inst
         val thy_ctxt = Proof_Context.init_global (Proof_Context.theory_of lthy_inst')
         val def = singleton (Proof_Context.export lthy_inst' thy_ctxt) raw_def
       in

--- a/Micro_Rust_Examples/Linked_List_Executable_Hybrid.thy
+++ b/Micro_Rust_Examples/Linked_List_Executable_Hybrid.thy
@@ -225,7 +225,7 @@ definition physical_memory_write :: \<open>phys \<Rightarrow> 64 word \<Rightarr
 
 definition physical_memory_write_many :: \<open>phys \<Rightarrow> 64 word \<Rightarrow> byte list \<Rightarrow> phys\<close>
   where \<open>physical_memory_write_many s addr vs \<equiv>
-    List.foldr (\<lambda>(i,b) s. physical_memory_write s (addr + (word64_of_nat i)) b) (List.enumerate 0 vs) s\<close>
+    List.foldr (\<lambda>(i,b) s. physical_memory_write s (addr + (word64_of_nat i)) b) (List.indexed_from 0 vs) s\<close>
 
 context
 begin

--- a/Micro_Rust_Examples/Linked_List_Executable_Physical_Memory.thy
+++ b/Micro_Rust_Examples/Linked_List_Executable_Physical_Memory.thy
@@ -111,7 +111,7 @@ definition physical_memory_write :: \<open>phys \<Rightarrow> 64 word \<Rightarr
 
 definition physical_memory_write_many :: \<open>phys \<Rightarrow> 64 word \<Rightarrow> byte list \<Rightarrow> phys\<close>
   where \<open>physical_memory_write_many s addr vs \<equiv>
-    List.foldr (\<lambda>(i,b) s. physical_memory_write s (addr + (word64_of_nat i)) b) (List.enumerate 0 vs) s\<close>
+    List.foldr (\<lambda>(i,b) s. physical_memory_write s (addr + (word64_of_nat i)) b) (List.indexed_from 0 vs) s\<close>
 
 context
 begin

--- a/Misc/Case_for_Typedefs.thy
+++ b/Misc/Case_for_Typedefs.thy
@@ -8,7 +8,7 @@ begin
 (*>*)
 
 definition find_index_offset :: \<open>'a list \<Rightarrow> nat \<Rightarrow> 'a \<Rightarrow> nat\<close> where
-  \<open>find_index_offset vs offset v \<equiv> (fst \<circ> the) (List.find (\<lambda> (_, r). r = v) (enumerate offset vs))\<close>
+  \<open>find_index_offset vs offset v \<equiv> (fst \<circ> the) (List.find (\<lambda> (_, r). r = v) (indexed_from offset vs))\<close>
 
 lemma find_index_offset_fst[simp]:
   shows \<open>find_index_offset (a # vs) n a = n\<close>
@@ -28,15 +28,15 @@ next
     by (simp add: find_index_offset_def)
 qed
 
-lemma in_set_enumerate_in_set:
-  assumes \<open>v \<in> set (enumerate n vs)\<close>
+lemma in_set_indexed_from_in_set:
+  assumes \<open>v \<in> set (indexed_from n vs)\<close>
   shows \<open>snd v \<in> set vs\<close>
   using assms
-  by (metis list.map(2) map_snd_enumerate not_Cons_self remdups.simps(2) remdups_map_remdups)
+  by (metis list.map(2) map_snd_indexed_from not_Cons_self remdups.simps(2) remdups_map_remdups)
 
 lemma find_index_offset_eqs:
   assumes \<open>distinct vs\<close>
-  shows \<open>list_all (\<lambda> (i, v). find_index_offset vs n v = i) (enumerate n vs)\<close>
+  shows \<open>list_all (\<lambda> (i, v). find_index_offset vs n v = i) (indexed_from n vs)\<close>
   using assms
 proof (induction vs arbitrary: n)
   case Nil
@@ -44,12 +44,12 @@ proof (induction vs arbitrary: n)
 next
   case (Cons a vs)
   moreover from calculation have 
-    \<open>list_all (\<lambda>(i, v). find_index_offset vs (Suc n) v = i) (enumerate (Suc n) vs)\<close>
+    \<open>list_all (\<lambda>(i, v). find_index_offset vs (Suc n) v = i) (indexed_from (Suc n) vs)\<close>
     by simp
   with \<open>distinct (a # vs)\<close> show ?case
     apply simp
     apply (erule list.pred_mono_strong)
-    by (force intro!: find_index_offset_not_fst dest!: in_set_enumerate_in_set
+    by (force intro!: find_index_offset_not_fst dest!: in_set_indexed_from_in_set
         split: prod.splits)
 qed
 
@@ -58,10 +58,10 @@ lemma find_index_offset_eqs_nth:
       and \<open>k < length vs\<close>
     shows \<open>find_index_offset vs n (vs ! k) = n + k\<close>
 proof -
-  note find_index_offset_eqs[OF assms(1), simplified list_all_length length_enumerate, where n=n,
+  note find_index_offset_eqs[OF assms(1), simplified list_all_length length_indexed_from, where n=n,
       THEN spec, THEN mp, OF assms(2)]
   with assms(2) show ?thesis
-    by (simp add: nth_enumerate_eq)
+    by (simp add: nth_indexed_from_eq)
 qed
 
 definition find_index :: \<open>'a list \<Rightarrow> 'a \<Rightarrow> nat\<close> where
@@ -69,7 +69,7 @@ definition find_index :: \<open>'a list \<Rightarrow> 'a \<Rightarrow> nat\<clos
 
 lemma find_index_eqs:
   assumes \<open>distinct vs\<close>
-  shows \<open>list_all (\<lambda> (i, v). find_index vs v = i) (enumerate 0 vs)\<close>
+  shows \<open>list_all (\<lambda> (i, v). find_index vs v = i) (indexed_from 0 vs)\<close>
   using find_index_offset_eqs[OF assms]
   by (simp add: find_index_def)
 
@@ -146,7 +146,7 @@ fun define_applied lthy name_str args rhs =
     val fun_type = fold_rev (fn a => fn T => fastype_of a --> T) args (fastype_of rhs)
     val lhs = list_comb (Free (name_str, fun_type), args)
     val spec = Logic.mk_equals (lhs, rhs)
-    val ((_, (_, def_thm)), lthy') = Specification.definition
+    val ((_, (_, def_thm)), lthy') = Specification.definition {verbose = false}
       (SOME (binding, NONE, NoSyn)) [] []
       ((Binding.name (name_str ^ "_def"), []), spec) lthy
     val full_name = Local_Theory.full_name lthy' binding
@@ -165,8 +165,8 @@ fun define_index lthy type_name elemT variant_list_term =
 
 (* Simp rules for reducing find_index_eqs into concrete index equalities *)
 fun indices_simp_rules variants_hol index_def =
-  @{thms enumerate_simps}
-  @ [variants_hol RS @{thm HOL.arg_cong[where f=\<open>enumerate 0\<close>]}]
+  @{thms indexed_from_simps}
+  @ [variants_hol RS @{thm HOL.arg_cong[where f=\<open>indexed_from 0\<close>]}]
   @ @{thms nth_Cons_numeral diff_numeral_Suc pred_numeral_simps
         One_nat_def[symmetric] diff_zero}
   @ @{thms Num.BitM.simps nth_Cons_0 nth_Cons_Suc list_all_Cons_iff prod.simps
@@ -178,8 +178,8 @@ fun indices_simp_rules variants_hol index_def =
 fun generate_indices lthy distinct_thm variants_hol index_def =
   Proof_Context.get_thm lthy "find_index_eqs"
   |> (fn th => th OF [distinct_thm])
-  |> Simplifier.simplify (clear_simpset lthy
-       addsimps (indices_simp_rules variants_hol index_def))
+  |> Simplifier.simplify (lthy |> Simplifier.clear_simpset
+       |> Simplifier.add_simps (indices_simp_rules variants_hol index_def))
   |> Conjunction.elim_conjunctions
 
 (* Step 2: Prove TYPE_indices_concrete and register as a fact *)

--- a/Misc/Simple_Word_Enums.thy
+++ b/Misc/Simple_Word_Enums.thy
@@ -384,7 +384,7 @@ fun note_thm name attrs thm lthy =
 fun define_const name rhs lthy =
   let
     val binding = Binding.name name
-    val ((_, (_, def_thm)), lthy) = Specification.definition
+    val ((_, (_, def_thm)), lthy) = Specification.definition {verbose = false}
       (SOME (binding, NONE, NoSyn)) [] []
       ((Binding.name (name ^ "_def"), []), Logic.mk_equals (Free (name, fastype_of rhs), rhs))
       lthy
@@ -396,7 +396,7 @@ fun define_const name rhs lthy =
    [simp only:]-style set: the variants are word numerals, and letting the default simp set
    loose on them is what makes the hand-written version slow for long lists. *)
 fun member_simps ctxt =
-  clear_simpset ctxt addsimps
+  ctxt |> Simplifier.clear_simpset |> Simplifier.add_simps
     @{thms eq_onp_same_args list.map comp_def snd_conv in_set_cons simp_thms}
 
 (* Step 1: define T_variants = [w1, ..., wn] and prove distinct (map unat T_variants). *)
@@ -432,7 +432,7 @@ fun define_typedef type_binding mapped_variants variants_def lthy =
               rule applications so that the cost does not grow with the variant list. *)
            (fn ctxt =>
               Local_Defs.unfold_tac ctxt [variants_def] THEN
-              simp_tac (clear_simpset ctxt addsimps @{thms list.map list.set}) 1 THEN
+              simp_tac (ctxt |> Simplifier.clear_simpset |> Simplifier.add_simps @{thms list.map list.set}) 1 THEN
               resolve_tac ctxt @{thms exI} 1 THEN
               resolve_tac ctxt @{thms insertI1} 1)
     val (_, lthy) =
@@ -492,7 +492,7 @@ fun define_all type_name wordT absT Abs_name Rep_name defs variants_const varian
       (HOLogic.mk_eq (all_const, HOLogic.mk_list absT variant_consts))
     val concrete_thm = Goal.prove lthy [] [] concrete_goal (fn { context = ctxt, ... } =>
       Local_Defs.unfold_tac ctxt [all_def, variants_def] THEN
-      simp_tac (clear_simpset ctxt addsimps
+      simp_tac (ctxt |> Simplifier.clear_simpset |> Simplifier.add_simps
         (@{thms map_simplifier_base comp_def}
          @ map (Thm.symmetric o Simpdata.mk_eq) (Named_Theorems.get ctxt defs))) 1)
     val (concrete_thm, lthy) =
@@ -782,7 +782,7 @@ fun generate_word_conversion (info: Simple_Word_Enum.enum_info) lthy =
     fun define name rhs lthy =
       let
         val binding = Binding.name name
-        val ((_, (_, def_thm)), lthy) = Specification.definition
+        val ((_, (_, def_thm)), lthy) = Specification.definition {verbose = false}
           (SOME (binding, NONE, NoSyn)) [] []
           ((Binding.name (name ^ "_def"), []),
            Logic.mk_equals (Free (name, fastype_of rhs), rhs)) lthy
@@ -821,7 +821,7 @@ fun generate_word_conversion (info: Simple_Word_Enum.enum_info) lthy =
     val (to_alt, lthy) = phase (to_name ^ "_alt") (fn () =>
       let
         val to_alt = Goal.prove lthy ["e"] [] alt_goal (fn { context = ctxt, ... } =>
-          simp_tac (ctxt addsimps [@{thm map_nth_find_index},
+          simp_tac (ctxt |> Simplifier.add_simps [@{thm map_nth_find_index},
                   (* the case rewrite chain, from setup_case_for_typedef *)
                   case_def, match_def, index_def,
                   (* fold T_variants away in favour of T_all, which all_total is about *)
@@ -852,7 +852,7 @@ fun generate_word_conversion (info: Simple_Word_Enum.enum_info) lthy =
         val from_alt = Goal.prove lthy ["w"] [] from_alt_goal (fn { context = ctxt, ... } =>
           let
             val enum_defs = Named_Theorems.get ctxt defs
-            fun only thms = simp_tac (clear_simpset ctxt addsimps thms) 1
+            fun only thms = simp_tac (ctxt |> Simplifier.clear_simpset |> Simplifier.add_simps thms) 1
           in
             only ([from_def] @ enum_defs @ @{thms into_Some_None_snoc_map into_map[of Ok]})
             THEN only ([Thm.symmetric (Simpdata.mk_eq variants_def),
@@ -874,10 +874,10 @@ fun generate_word_conversion (info: Simple_Word_Enum.enum_info) lthy =
     val (_, lthy) = phase (to_name ^ "_then_try_from") (fn () =>
       let
         val round = Goal.prove lthy ["e"] [] round_goal (fn { context = ctxt, ... } =>
-          simp_tac (ctxt addsimps [to_alt, from_alt]) 1
+          simp_tac (ctxt |> Simplifier.add_simps [to_alt, from_alt]) 1
           THEN (Method.insert_tac ctxt
                  [Thm.instantiate' [] [SOME (Thm.cterm_of ctxt e)] all_total] 1)
-          THEN clarsimp_tac (ctxt addsimps
+          THEN clarsimp_tac (ctxt |> Simplifier.add_simps
             (@{thms image_iff}
              @ [all_def, type_definition RS @{thm type_definition.Abs_inverse},
                 type_definition RS @{thm type_definition.Rep}])) 1)
@@ -1193,7 +1193,7 @@ fun generate_generate_debug (info: Simple_Word_Enum.enum_info) lthy =
           thy
           |> Class.instantiation ([tyco], [], \<^sort>\<open>generate_debug\<close>)
           |> (fn ilthy =>
-                Specification.definition NONE [] []
+                Specification.definition {verbose = false} NONE [] []
                   ((Binding.concealed (Binding.name (def_name ^ "_raw_def")), []),
                    Syntax.check_term ilthy raw_eq) ilthy
                 |> apfst (snd o snd))
@@ -1329,7 +1329,7 @@ fun mk_variant_eq_simproc absT type_name (info: Simple_Word_Enum.enum_info) =
                    (fn { context = c, ... } =>
                       resolve_tac c @{thms notI} 1
                       THEN dresolve_tac c [arg_cong_index c] 1
-                      THEN asm_full_simp_tac (clear_simpset c addsimps
+                      THEN asm_full_simp_tac (c |> Simplifier.clear_simpset |> Simplifier.add_simps
                         (idx_thms @ @{thms eq_numeral_simps rel_simps simp_thms})) 1)
                in SOME (neq RS @{thm Eq_FalseI}) end
          | _ => NONE)
@@ -1486,7 +1486,7 @@ fun generate_equal_instance (info: Simple_Word_Enum.enum_info) lthy =
           thy
           |> Class.instantiation ([tyco], [], \<^sort>\<open>equal\<close>)
           |> (fn ilthy =>
-                Specification.definition NONE [] []
+                Specification.definition {verbose = false} NONE [] []
                   ((Binding.concealed (Binding.name (def_name ^ "_raw_def")), []),
                    Syntax.check_term ilthy raw_eq) ilthy
                 |> apfst (snd o snd))
@@ -1496,7 +1496,7 @@ fun generate_equal_instance (info: Simple_Word_Enum.enum_info) lthy =
                      Rep_T_inject, which the typedef provides. *)
                   (fn ctxt => fn def_thm =>
                      Class.intro_classes_tac ctxt []
-                     THEN ALLGOALS (simp_tac (clear_simpset ctxt addsimps
+                     THEN ALLGOALS (simp_tac (ctxt |> Simplifier.clear_simpset |> Simplifier.add_simps
                        [def_thm, type_definition RS @{thm type_definition.Rep_inject}])))
                   def_thm)) lthy
       in

--- a/Shallow_Micro_Rust/Micro_Rust_Notations.thy
+++ b/Shallow_Micro_Rust/Micro_Rust_Notations.thy
@@ -591,7 +591,7 @@ fun shadow_check ctxt kind name T pos have_backend =
       else
         let
           \<comment>\<open>Render the constant via \<^ML>\<open>Syntax.pretty_term\<close> so name-space markup
-            (\<^verbatim>\<open>Name_Space.markup\<close> + \<^verbatim>\<open>Markup.const\<close>) is attached and ctrl-click
+            (\<^verbatim>\<open>Name_Space.markups\<close> + \<^verbatim>\<open>Markup.const\<close>) is attached and ctrl-click
             jumps to the defining \<^verbatim>\<open>definition\<close>/\<^verbatim>\<open>fun\<close>/\<^verbatim>\<open>primrec\<close> command.\<close>
           val pretty_const = Syntax.pretty_term ctxt (Const (full_name, const_T))
           val msg = Pretty.string_of (Pretty.chunks
@@ -693,7 +693,7 @@ fun resolve_bound ctxt =
   have full types and can do the typed table lookup.\<close>
 \<comment>\<open>Emit use-site markup at \<open>pos\<close> for every registered backend under
   \<open>(kind, name)\<close>: an entity ref to the registration site (so ctrl-click
-  jumps back to \<open>micro_rust_notation\<close>), plus a \<^verbatim>\<open>Name_Space.markup\<close> +
+  jumps back to \<open>micro_rust_notation\<close>), plus a \<^verbatim>\<open>Name_Space.markups\<close> +
   \<^verbatim>\<open>Markup.keyword3\<close> chain when the backend itself is a bare constant
   (ctrl-click to its definition, coloured as a keyword). Called by \<open>resolve\<close>
   ONLY when a marker is actually replaced by a registered backend ---
@@ -716,8 +716,8 @@ fun emit_use_markup_at_pos ctxt kind name pos =
             forms like \<^verbatim>\<open>lift_fun1 Some\<close> still get const-styling
             (color + ctrl-click) attached at the use site, not just the
             \<open>micro_rust_notation\<close> entity ref. We use the standard
-            \<^verbatim>\<open>Name_Space.markup\<close> (an entity-style markup keyed by the
-            constant's def-site serial) for the click target, plus the
+            \<^verbatim>\<open>Name_Space.markups\<close> (entity-style markup keyed by the
+            constant's def-site serials) for the click target, plus the
             \<^verbatim>\<open>Markup.keyword3\<close> kind tag for the colour face (so
             notation-resolved constants are coloured as keywords rather than
             as ordinary constants).\<close>
@@ -729,8 +729,8 @@ fun emit_use_markup_at_pos ctxt kind name pos =
           val const_markup =
             (case head_const hol_term of
                SOME c =>
-                 [Name_Space.markup (Consts.space_of (Proof_Context.consts_of ctxt)) c,
-                  Markup.keyword3]
+                 Name_Space.markups (Consts.space_of (Proof_Context.consts_of ctxt)) c @
+                   [Markup.keyword3]
              | NONE => [])
         in
           app (Context_Position.report ctxt pos) (notation_markup @ const_markup)

--- a/Shallow_Micro_Rust/Micro_Rust_Shallow_Embedding.thy
+++ b/Shallow_Micro_Rust/Micro_Rust_Shallow_Embedding.thy
@@ -156,7 +156,7 @@ ML\<open>
         Pretty.writeln (Pretty.chunks (map (fn s => Pretty.str ("• " ^ s)) bullets))
       end
 
-   fun make_lenses ((with_fields, rec_name), overrides) _ lthy =
+   fun make_lenses ((with_fields, rec_name), overrides) lthy =
       let val _ =
             if with_fields orelse null overrides then ()
             else error "micro_rust_record: a uRust-name mapping cannot be combined \
@@ -191,7 +191,7 @@ ML\<open>
         []
 
    val _ =
-      Outer_Syntax.local_theory' \<^command_keyword>\<open>micro_rust_record\<close> "make lenses for datatype record"
+      Outer_Syntax.local_theory \<^command_keyword>\<open>micro_rust_record\<close> "make lenses for datatype record"
        ((((Scan.optional ((Args.bracks (Args.$$$ "no_fields")) >> K false) true) -- Parse.short_ident)
             -- parse_field_overrides) >> make_lenses)
 \<close>

--- a/Shallow_Micro_Rust/Simple_Word_Enum_uRust.thy
+++ b/Shallow_Micro_Rust/Simple_Word_Enum_uRust.thy
@@ -220,7 +220,7 @@ fun generate_urust_conversion (info: Simple_Word_Enum.enum_info) lthy =
           let
             val name = type_name ^ "_" ^ base
             val binding = Binding.name name
-            val (_, lthy) = Specification.definition
+            val (_, lthy) = Specification.definition {verbose = false}
               (SOME (binding, NONE, NoSyn)) [] []
               ((Binding.name (name ^ "_def"), []),
                Logic.mk_equals (Free (name, fastype_of rhs), rhs)) lthy

--- a/ic2/Makefile
+++ b/ic2/Makefile
@@ -5,7 +5,7 @@
 # etc/build.props, but it only builds components that are *registered*, so the
 # `register` step below must run first.
 
-ISABELLE_VERSION ?= Isabelle2025-2
+ISABELLE_VERSION ?= Isabelle_25-Jul-2026
 ISABELLE_HOME ?= /Applications/$(ISABELLE_VERSION).app/bin
 ISABELLE ?= $(ISABELLE_HOME)/isabelle
 

--- a/iq/Isar_Explore.thy
+++ b/iq/Isar_Explore.thy
@@ -36,7 +36,7 @@ fun register {name, pri} f =
 
             (* Small delay to ensure status is processed
                TODO: This should not be necessary...? *)
-            val _ = OS.Process.sleep (Time.fromMilliseconds 100)
+            val _ = Time.sleep (Time.fromMilliseconds 100)
             fun main () =
               f {state = state, args = args, output_result = output_result,
                  writeln_result = writeln_result, instance=instance, exec_id=exec_id}
@@ -79,17 +79,13 @@ fun isar_explore exec_id instance text state =
       (* Without this, the execution fails with "Unregistered execution" *)
       |> List.map (Toplevel.exec_id exec_id)
 
+    (* Disable highest level of parallel proof checking since this forks
+       off threads for `by ...` statements which we have trouble capturing
+       the output of (they capture their own exceptions and convert them
+       directly into error_messages to Isabelle's output channel. *)
     fun run_transition (tr, st) =
-      let
-         (* Disable highest level of parallel proof checking since this forks
-            off threads for `by ...` statements which we have trouble capturing
-            the output of (they capture their own exceptions and convert them
-            directly into error_messages to Isabelle's output channel. *)
-         val old_parallel_proofs = ! Multithreading.parallel_proofs
-         val _ = Multithreading.parallel_proofs := Int.min(2, old_parallel_proofs)
-         val st' = Toplevel.command_exception false tr st
-         val _ = Multithreading.parallel_proofs := old_parallel_proofs
-      in st' end
+      Interactive.setmp_parallel_proofs (Int.min (2, Interactive.parallel_proofs ()))
+        (Toplevel.command_exception tr) st
   in
     List.foldl (fn (tr, st) => run_transition (tr, st)) state transitions
   end;

--- a/iq/Makefile
+++ b/iq/Makefile
@@ -7,11 +7,12 @@ endif
 
 # Paths (configurable via environment variables)
 PLUGIN_DIR := $(shell pwd)
-ISABELLE_HOME ?= /Applications/Isabelle2025-2.app
+ISABELLE_VERSION ?= Isabelle_25-Jul-2026
+ISABELLE_HOME ?= /Applications/$(ISABELLE_VERSION).app
 ISABELLE ?= $(if $(wildcard $(ISABELLE_HOME)/bin/isabelle),$(ISABELLE_HOME)/bin/isabelle,$(ISABELLE_HOME)/isabelle)
 JEDIT_DIR := $(shell ls -d $(ISABELLE_HOME)/contrib/jedit-* 2>/dev/null | head -1)
 JEDIT_JAR ?= $(JEDIT_DIR)/jedit5.7.0-patched/jedit.jar
-SCALA_HOME ?= $(ISABELLE_HOME)/contrib/scala-3.3.4
+SCALA_HOME ?= $(firstword $(wildcard $(ISABELLE_HOME)/contrib/scala-3.*))
 SCALAC ?= $(SCALA_HOME)/bin/scalac
 SCALAC_FLAGS ?= -deprecation -feature -unchecked -Werror -Wunused:imports,privates,locals,params -Xlint:all -Wvalue-discard -Wnonunit-statement
 SCALA ?= $(SCALA_HOME)/bin/scala
@@ -29,7 +30,7 @@ BUILD_DIR ?= $(PLUGIN_DIR)/build
 CLASSES_DIR ?= $(BUILD_DIR)/classes
 TEST_CLASSES_DIR ?= $(BUILD_DIR)/test-classes
 JAR_FILE ?= $(BUILD_DIR)/iq_plugin.jar
-INSTALL_DIR ?= $(HOME)/.isabelle/Isabelle2025-2/jedit/jars
+INSTALL_DIR ?= $(HOME)/.isabelle/$(ISABELLE_VERSION)/jedit/jars
 
 # Source files
 SCALA_SOURCES := $(wildcard src/*.scala)

--- a/iq/src/IQEditorHost.scala
+++ b/iq/src/IQEditorHost.scala
@@ -6,16 +6,16 @@ import isabelle.jedit._
 
 /** The jEdit-backed `Extended_Query_Operation.Host`: the editor-specific
   * capabilities a query operation needs (overlay mutation, flush, dispatch)
-  * delegated to Isabelle/jEdit's live `Editor` (`PIDE.editor`). Shared by the
+  * delegated to Isabelle/jEdit's live `Editor` (`JEdit_Editor`). Shared by the
   * I/Q server (IQServer) and the Explore dockable (IQExploreDockable) so both
   * drive the generic, session-based Extended_Query_Operation the same way. A
   * headless caller (ic2) would instead supply a Host backed by `session.update`. */
 object IQ_Editor_Host extends Extended_Query_Operation.Host {
   def insert_overlay(command: Command, fn: String, args: List[String]): Unit =
-    PIDE.editor.insert_overlay(command, fn, args)
+    JEdit_Editor.insert_overlay(command, fn, args)
   def remove_overlay(command: Command, fn: String, args: List[String]): Unit =
-    PIDE.editor.remove_overlay(command, fn, args)
-  def flush(): Unit = PIDE.editor.flush()
-  def require_dispatcher[A](body: => A): A = PIDE.editor.require_dispatcher(body)
-  def send_dispatcher(body: => Unit): Unit = PIDE.editor.send_dispatcher(body)
+    JEdit_Editor.remove_overlay(command, fn, args)
+  def flush(): Unit = JEdit_Editor.flush()
+  def require_dispatcher[A](body: => A): A = JEdit_Editor.require_dispatcher(body)
+  def send_dispatcher(body: => Unit): Unit = JEdit_Editor.send_dispatcher(body)
 }

--- a/iq/src/IQExploreDockable.scala
+++ b/iq/src/IQExploreDockable.scala
@@ -140,7 +140,7 @@ extends JPanel(new BorderLayout) with DefaultFocusComponent {
 
   /* output area */
 
-  private val output: Output_Area = new Output_Area(view)
+  private val output: Output_Area = new Output_Area(JEdit_Editor.Context(view))
   private val uiSettings = IQUISettings.current
 
   // Store accumulated messages to preserve them when results are displayed
@@ -795,7 +795,7 @@ extends JPanel(new BorderLayout) with DefaultFocusComponent {
               }
           }
         },
-        (snapshot, command_results, output) => {
+        (_, command_results, output) => {
           logDebug(s"I/Q Explore: Output callback called with ${output.size} XML trees")
           logDebug(s"I/Q Explore: Command results is_empty: ${command_results.is_empty}")
 
@@ -810,11 +810,11 @@ extends JPanel(new BorderLayout) with DefaultFocusComponent {
     if (currentCommandRadio.isSelected) {
       // Use the current command at cursor position. Resolving the caret command
       // is editor-specific, so it lives here (hoisted out of the generic op):
-      // find it via PIDE.editor, then drive apply_query_at_command.
+      // find it via JEdit_Editor, then drive apply_query_at_command.
       appendOutput(s"Using current command at cursor position with ${queryField.getText}")
-      PIDE.editor.current_node_snapshot(view) match {
+      JEdit_Editor.current_node_snapshot(JEdit_Editor.Context(view)) match {
         case Some(snapshot) =>
-          PIDE.editor.current_command(view, snapshot) match {
+          JEdit_Editor.current_command(JEdit_Editor.Context(view), snapshot) match {
             case Some(command) =>
               exploreOperation.foreach(_.apply_query_at_command(command, query))
             case None => appendOutput("Error: No command at the current cursor position")
@@ -887,13 +887,13 @@ extends JPanel(new BorderLayout) with DefaultFocusComponent {
 
   private def locateContext(): Unit = {
     // Hyperlink to the queried command in the editor. Editor-specific (hoisted
-    // out of the generic op): read the op's resolved location, jump via PIDE.editor.
+    // out of the generic op): read the op's resolved location, jump via JEdit_Editor.
     for {
       op <- exploreOperation
       command <- op.get_location
-      snapshot = PIDE.editor.node_snapshot(command.node_name)
-      link <- PIDE.editor.hyperlink_command(snapshot, command.id, focus = true)
-    } link.follow(view)
+      snapshot = JEdit_Editor.node_snapshot(command.node_name)
+      link <- JEdit_Editor.hyperlink_command(snapshot, command.id, focus = true)
+    } link.follow(JEdit_Editor.Context(view))
   }
 
   // Initialize

--- a/iq/src/IQServer.scala
+++ b/iq/src/IQServer.scala
@@ -7,10 +7,11 @@ import isabelle.jedit._
 import java.nio.file.Files
 import java.util.Locale
 import java.util.concurrent.{CountDownLatch, TimeUnit}
+import scala.annotation.unused
 import scala.util.Try
 import scala.util.Using
 
-import org.gjt.sp.jedit.{View, jEdit, Buffer}
+import org.gjt.sp.jedit.{View, jEdit}
 
 /**
  * Closed status vocabulary for command processing states.
@@ -403,7 +404,7 @@ class IQServer(
   private def waitForTheoryCompletion(
     model: Document_Model,
     timeout_ms: Option[Int],
-    timeoutPerCommandMs: Option[Int] = None
+    timeoutPerCommandMs: Option[Int]
   ): (Boolean, Document_Status.Node_Status) = {
 
     val startTime = System.currentTimeMillis()
@@ -1760,14 +1761,12 @@ class IQServer(
 
       if (statuses.nonEmpty && !allStatusesProcessed(statuses)) {
         val latch = new CountDownLatch(1)
-        var checkCount = 0
         var perCommandTimerStart: Option[Long] = None
 
         val consumer = Session.Consumer[Session.Commands_Changed](
           "IQServer.handleGetCommandCore"
         ) {
           case Session.Commands_Changed(_, nodes, _) if nodes.contains(node_name) =>
-            checkCount += 1
             statuses = retrieveStatuses()
 
             if (statuses.isEmpty || allStatusesProcessed(statuses)) {
@@ -2285,7 +2284,7 @@ class IQServer(
    * @param includeDetailedCommands Whether to include the detailed commands list
    * @return Map containing timing information
    */
-  private def calculateTimingInfo(model: Document_Model, text_content: String, timingThresholdMs: Int = 0, includeDetailedCommands: Boolean = true): Map[String, Any] = {
+  private def calculateTimingInfo(model: Document_Model, text_content: String, timingThresholdMs: Int = 0, includeDetailedCommands: Boolean): Map[String, Any] = {
     val node_name = model.node_name
     val snapshot = Document_Model.snapshot(model)
     val state = snapshot.state
@@ -2327,15 +2326,16 @@ class IQServer(
       Output.writeln(s"I/Q Server: calculateTimingInfo - timingThreshold=$timingThresholdMs ms")
 
       val commandTimingEntries = commands_above_threshold.toList.map {
-        case (cmd, timings) =>
-          val commandStart = node.command_start(cmd).getOrElse(0)
+        case (cmd_id, timings) =>
+          val cmd = snapshot.get_command(cmd_id)
+          val commandStart = cmd.flatMap(node.command_start).getOrElse(0)
           val start_line = offsetToLine(commandStart)
           val timingSeconds = formatDecimal(timings.sum(Date.now()).seconds)
           (
             timingSeconds,
             Map[String, Any](
               "line" -> start_line,
-              "source_preview" -> cmd.source.take(50),
+              "source_preview" -> cmd.map(_.source.take(50)).getOrElse(""),
               "timing_seconds" -> timingSeconds
             )
           )
@@ -2389,15 +2389,10 @@ class IQServer(
       // Create a Line.Document for line/column position conversion
       val line_document = Line.Document(text_content)
 
-      // Create the appropriate rendering
-      val rendering = model match {
-        case buffer_model: Buffer_Model =>
-          // For Buffer_Model, use JEdit_Rendering
-          JEdit_Rendering(snapshot, buffer_model, PIDE.options.value)
-        case _ =>
-          // For File_Model, use standard Rendering with session
-          new Rendering(snapshot, PIDE.options.value, PIDE.session)
-      }
+      // JEdit_Rendering takes any Document_Model (Buffer_Model or File_Model).
+      // Since Isabelle_25-Jul-2026 the generic Rendering is abstract (it needs a
+      // gui_style), so there is no longer a File_Model fallback to construct.
+      val rendering = JEdit_Rendering(snapshot, model, PIDE.options)
 
       val text_range = Text.Range(0, snapshot.node.source.length)
 
@@ -3032,7 +3027,7 @@ end"""
     lines: Array[String],
     startLine: Int,
     endLine: Int,
-    highlightLine: Option[Int] = None
+    highlightLine: Option[Int]
   ): String = {
     IQLineOffsetUtils.formatLinesWithNumbers(lines, startLine, endLine, highlightLine)
   }
@@ -3603,7 +3598,7 @@ end"""
         )
       } else {
         val startOffset = node.command_start(command).getOrElse(0)
-        val output = PIDE.editor.output(snapshot, startOffset)
+        val output = JEdit_Editor.output(snapshot, startOffset)
         val fallbackFreeVars = extractCommandFreeVars(snapshot, command, startOffset)
         analyzeGoalMessages(output.messages, fallbackFreeVars)
       }
@@ -4372,7 +4367,9 @@ end"""
       }
     }
 
-    def outputCallback(snapshot: Document.Snapshot, command_results: Command.Results, output: List[XML.Tree]): Unit = {
+    def outputCallback(@unused snapshot: Document.Snapshot,
+                       @unused command_results: Command.Results,
+                       output: List[XML.Tree]): Unit = {
       // Debug: log callback invocation
       Output.writeln(s"I/Q Server: outputCallback called with ${output.size} XML trees")
 

--- a/iq/src/IQUtils.scala
+++ b/iq/src/IQUtils.scala
@@ -473,7 +473,7 @@ object IQUtils {
     queryType match {
       case "sledgehammer" =>
         try {
-          PIDE.options.value.check_name("sledgehammer_provers").default_value
+          PIDE.options.check_name("sledgehammer_provers").default_value
         } catch {
           case _: Exception => "z3 cvc4 e spass" // Fallback default
         }
@@ -590,7 +590,7 @@ object IQUtils {
    * Block until a document model has a stable snapshot (no pending edits).
    * This is a utility function that can be used by both the server and dockable.
    *
-   * Flushes buffer edits to the session (via PIDE.editor.flush() on the EDT)
+   * Flushes buffer edits to the session (via JEdit_Editor.flush() on the EDT)
    * so that PIDE.session.snapshot() reflects pending changes, then uses an
    * event-driven wait (Session.Commands_Changed listener + CountDownLatch)
    * instead of polling, to avoid blocking the EDT.
@@ -602,7 +602,7 @@ object IQUtils {
     val node_name = model.node_name
 
     // Flush buffer edits so PIDE.session.snapshot() sees them
-    GUI_Thread.now { PIDE.editor.flush() }
+    GUI_Thread.now { JEdit_Editor.flush() }
 
     val initial_snapshot = PIDE.session.snapshot(node_name = node_name)
 

--- a/iq/src/McpServer.scala
+++ b/iq/src/McpServer.scala
@@ -667,7 +667,7 @@ final class McpServer(
 
   private def handleToolCall(
       request: McpProtocol.JsonRpcRequest,
-      send: String => Unit = _ => ()
+      send: String => Unit
   ): Either[(Int, String), Map[String, Any]] = {
     try {
       val toolCall = McpProtocol.decodeToolCall(request) match {

--- a/ir/ir.ML
+++ b/ir/ir.ML
@@ -336,11 +336,8 @@ fun exec_text timeout_secs text st =
   let val thy = Toplevel.theory_of st
       val transitions = Outer_Syntax.parse_text thy (fn () => thy) Position.none text
       fun run (tr, s) =
-        let val old = !Multithreading.parallel_proofs
-            val _ = Multithreading.parallel_proofs := Int.min (2, old)
-            val s' = Toplevel.command_exception false tr s
-            val _ = Multithreading.parallel_proofs := old
-        in s' end
+        Interactive.setmp_parallel_proofs (Int.min (2, Interactive.parallel_proofs ()))
+          (Toplevel.command_exception tr) s
       fun go () = List.foldl (fn (tr, s) => run (tr, s)) st transitions
   in if timeout_secs > 0
      then Timeout.apply (Time.fromSeconds (Int.toLarge timeout_secs)) go ()
@@ -783,7 +780,7 @@ fun theories () =
   List.app (fn s => out ("  " ^ s)) (Thy_Info.get_names ());
 
 fun is_interactive_session () =
-  ! Printer.show_markup_default;
+  Interactive.enabled ();
 
 (* Load a theory (and its transitive dependencies) by fully qualified name,
    e.g. "HOL-Library.Multiset".  After loading, the theory is available
@@ -794,8 +791,12 @@ fun load_theory name =
     error "load_theory is not available in interactive PIDE sessions. \
           \Open theories in Isabelle/jEdit and use init_from_document instead."
   else
-  let val opts = Options.update "record_theories" "true" (Options.default ())
-      val _ = Thy_Info.use_theories opts "" [(name, Position.none)]
+  (* Since Isabelle_25-Jul-2026, Thy_Info.use_theories takes an Options.update
+     per import instead of one global Options.T, so record_theories is set for
+     the requested theory only; its ancestors keep whatever the heap was built
+     with. *)
+  let val opts = [Options.spec "record_theories" "true"]
+      val _ = Thy_Info.use_theories "" [((name, Position.none), opts)]
   in out ("Loaded theory " ^ quote name) end;
 
 (* Sledgehammer via compiler bridge *)

--- a/isabelle-assistant/Makefile
+++ b/isabelle-assistant/Makefile
@@ -5,11 +5,12 @@ ifndef V
 endif
 
 PLUGIN_DIR := $(shell pwd)
-ISABELLE_HOME ?= /Applications/Isabelle2025-2.app
+ISABELLE_VERSION ?= Isabelle_25-Jul-2026
+ISABELLE_HOME ?= /Applications/$(ISABELLE_VERSION).app
 ISABELLE ?= $(if $(wildcard $(ISABELLE_HOME)/bin/isabelle),$(ISABELLE_HOME)/bin/isabelle,$(ISABELLE_HOME)/isabelle)
 JEDIT_DIR := $(shell ls -d $(ISABELLE_HOME)/contrib/jedit-* 2>/dev/null | head -1)
 JEDIT_JAR ?= $(JEDIT_DIR)/jedit5.7.0-patched/jedit.jar
-SCALA_HOME ?= $(ISABELLE_HOME)/contrib/scala-3.3.4
+SCALA_HOME ?= $(firstword $(wildcard $(ISABELLE_HOME)/contrib/scala-3.*))
 SCALAC ?= $(SCALA_HOME)/bin/scalac
 SCALAC_FLAGS ?= -deprecation -feature -unchecked -Werror -Wunused:imports,privates,locals,params -Xlint:all -Wvalue-discard -Wnonunit-statement
 # Test flags mirror the production flags except for -Wnonunit-statement:
@@ -36,7 +37,7 @@ LIB_CLASSPATH = $(shell echo $(LIB_JARS) | tr ' ' ':')
 BUILD_DIR ?= $(PLUGIN_DIR)/build
 CLASSES_DIR ?= $(BUILD_DIR)/classes
 JAR_FILE ?= $(BUILD_DIR)/isabelle_assistant.jar
-INSTALL_DIR ?= $(HOME)/.isabelle/Isabelle2025-2/jedit/jars
+INSTALL_DIR ?= $(HOME)/.isabelle/$(ISABELLE_VERSION)/jedit/jars
 
 # I/Q Plugin (dependency for proof verification features).
 # Compilation silently failed on an obscure scalac error if neither JAR
@@ -115,7 +116,7 @@ $(CLASSES_DIR)/.resources: $(RESOURCE_FILES) $(PROMPT_FILES) | $(CLASSES_DIR)
 $(CLASSES_DIR):
 	mkdir -p $(CLASSES_DIR)
 
-ISABELLE_SETTINGS_DIR ?= $(HOME)/.isabelle/Isabelle2025-2/etc
+ISABELLE_SETTINGS_DIR ?= $(HOME)/.isabelle/$(ISABELLE_VERSION)/etc
 COMPONENT_LINE := init_component "$(PLUGIN_DIR)"
 
 install: iq-install $(JAR_FILE)


### PR DESCRIPTION
> [!WARNING]
> **PRELIMINARY — DO NOT MERGE.**
> This is opened as a *draft* to record the precise change set now. It targets the
> **`Isabelle_25-Jul-2026` pre-release**, not a released Isabelle. Further
> Isabelle2026 pre-releases are expected, so this will need re-checking against
> each of them, and it should not land until the transition to Isabelle2026 proper.

## What this is

The set of source changes required to build AutoCorrode under the current
Isabelle2026 pre-release. It applies cleanly to `main` — none of the 25 touched
files have changed upstream since the snapshot this was developed against.

## Changes, by cause

**ML simplifier API** (`Crush/{crush,base,seplog}.ML`, `Misc/*`, `Autogen/AutoLocality.thy`,
`Byte_Level_Encoding/*`)
- the `addsimps` / `delsimps` / `addsimprocs` / `delsimprocs` infixes are discontinued
- `clear_simpset`, `simpset_map`, `merge_ss` and the `proc_kind` constructors are now
  qualified under `Simplifier`
- `Raw_Simplifier.map_ss` → `Simplifier.map_simpset`
- `Simplifier.add_proc` takes a single simproc, so simproc lists need a `fold`

**`Specification`** (`Autogen/AutoLens.thy`, `Enum_Theory/enum_cmd.ML`, `Misc/*`,
`Shallow_Micro_Rust/Simple_Word_Enum_uRust.thy`)
- the trailing interactive-mode flag moved into a leading record argument:
  `definition` / `definition_cmd` take `{verbose}`, `theorems_cmd` takes `{verbose, kind}`

**Isar / toplevel** (`Shallow_Micro_Rust/Micro_Rust_Shallow_Embedding.thy`, `ir/ir.ML`,
`iq/Isar_Explore.thy`)
- `Outer_Syntax.local_theory'` was removed along with the flag it supplied
- `Toplevel.command_exception` lost its `bool` argument
- interactive mode and `parallel_proofs` moved from the `Printer` / `Multithreading`
  refs into the new `Interactive` structure
- `OS.Process.sleep` is no longer exposed to user-space ML → `Time.sleep`
- `Thy_Info.use_theories` takes an `Options.update` **per import** instead of one
  global `Options.T`. `Ir.load_theory` therefore sets `record_theories` for the
  requested theory only; its ancestors keep whatever the heap was built with.
  *This is a small behavioural narrowing and is the one change here worth a second
  opinion.*
- `Name_Space.markup` → `Name_Space.markups`, returning a `Markup.T list`

**HOL** (`Micro_Rust_Examples/Linked_List_Executable_{Hybrid,Physical_Memory}.thy`,
`Misc/Case_for_Typedefs.thy`)
- the list constant `enumerate` was renamed `indexed_from`, with the corresponding
  lemma renames

**I/Q jEdit plugin** (`iq/src/*.scala`)
- `PIDE.editor` is gone; `JEdit_Editor` is now a top-level object
- `PIDE.options` is the resolved `Options`, no longer `JEdit_Options` (drop `.value`)
- `Output_Area`, `current_node_snapshot`, `current_command` and `Hyperlink.follow`
  take a `JEdit_Editor.Context` instead of a bare `View`
- `Document_Status.Node_Status.command_timings` is keyed by command id, not
  `Command`; resolved via `Snapshot.get_command`
- `Rendering` is now abstract (it needs a `gui_style`). `JEdit_Rendering` accepts any
  `Document_Model`, so it also covers the former `File_Model` fallback.
- Scala 3.3.8 with `-Werror` additionally rejects some latent unused imports,
  parameters and default arguments (note: `_`-prefixing does not suppress this;
  `@scala.annotation.unused` does)

**Build glue** (`iq/Makefile`, `ic2/Makefile`, `isabelle-assistant/Makefile`)
- stop hardcoding the Isabelle version and the contrib Scala version
- **for review:** the `ISABELLE_VERSION` default now names the pre-release. That
  will want changing to `Isabelle2026` when it is released.

## How it was checked

- the `AutoCorrode` session builds
- the full downstream NICE proof stack builds against it, and its theories were
  additionally checked interactively

Not checked: the `ic2` Scala component and the `isabelle-assistant` plugin were not
compiled, only their Makefiles adjusted. Isabelle/Scala's move to Explicit Nulls and
the new `Logger` arguments may yet affect them.
