### PR TITLE
[fix] I/P: Forward SMT/ATP solver env vars to the remote ML process

### DIFF
--- a/ip/ml_proxy.py
+++ b/ip/ml_proxy.py
@@ -1551,10 +1551,20 @@ def main():
 
     local_home = os.path.expanduser("~")
 
-    # Step 1: Query all remote environment in one SSH call
+    # Step 1: Query all remote environment in one SSH call.
+    # Besides the core ISABELLE_/ML_/POLYML_ settings, forward the variables of
+    # the bundled SMT/ATP solvers and counterexample generators: availability is
+    # a pure env probe inside the ML process (e.g. getenv "Z3_SOLVER" in
+    # HOL/Tools/SMT/smt_systems.ML), so dropping them makes smt, sledgehammer
+    # and nitpick report their backends as not installed under the proxy.
+    # The values come from the remote's own settings, so no path rewriting is
+    # needed.
+    env_prefixes = ("ISABELLE_|ML_|POLYML_|Z3_|CVC[0-9]_|E_|SPASS_|VERIT_|"
+                    "VAMPIRE_|ZIPPERPOSITION_|DUMMY_SMTLIB_|KODKODI|MINISAT_|"
+                    "NUNCHAKU_|SMBC_")
     env_dump = ssh_run_stdout(host,
         target_isabelle_home + "/bin/isabelle", "env", "bash", "-c",
-        "echo __HOME__=$HOME; env | grep -E '^(ISABELLE_|ML_|POLYML_)' | sort")
+        "echo __HOME__=$HOME; env | grep -E '^(" + env_prefixes + ")' | sort")
     if not env_dump:
         logger.error("Failed to query remote environment")
         sys.exit(1)


### PR DESCRIPTION
Fixes #273.

## Problem

`ip/ml_proxy.py` builds the remote poly process environment from a filtered dump of the remote's `isabelle env`, keeping only `ISABELLE_|ML_|POLYML_` variables. This drops `Z3_SOLVER`, `CVC5_SOLVER` and friends — and Isabelle decides SMT-solver availability by a pure env probe inside the ML process (`HOL/Tools/SMT/smt_systems.ML`: `getenv (name ^ "_SOLVER") <> ""`). So under the proxy every such proof fails with `The SMT solver "z3" is not installed` (the message names the requested solver), even though the solvers are installed on the remote. The same filter hides the sledgehammer ATPs (`E_HOME`, `SPASS_HOME`, `VAMPIRE_HOME`, `ZIPPERPOSITION_HOME`) and the nitpick/quickcheck backends (`KODKODI*`, `MINISAT_HOME`, …). `smt (verit)` was unaffected because its probe is keyed on `ISABELLE_VERIT`, which already passed the filter.

## Fix

Widen the allowlist to the bundled prover/counterexample-generator prefixes. The forwarded values come from the remote's own settings, so they are already correct remote paths and need no rewriting; the downstream env assembly iterates the parsed dict generically, so no other change is needed.

An allowlist (rather than forwarding everything minus a denylist) is kept deliberately: the raw `env` dump contains multi-line `BASH_FUNC_*` bodies that would break the proxy's line-based parsing.

## Verification

Reproduced and verified with the self-contained loopback setup from #273 (unprivileged sshd on 127.0.0.1:2222, "remote" = the local Isabelle2025-2 installation) and against a real SSH remote (Isabelle2025-2 on both ends), using a minimal session containing

```isabelle
lemma "(a::int) + b = b + a"
  by (smt (verit))

lemma "(a::int) + b = b + a"
  by (smt (z3))
```

- Before: `smt (verit)` passes, `smt (z3)` fails with `The SMT solver "z3" is not installed`.
- After: the proxied build finishes and the heap is copied back; forwarded env vars go from 111 to 138.

The `ip-test` CI job that exercises the proxy is currently disabled (#263), so no CI covers this path; the loopback script in #273 avoids the Isabelle download that broke that job and could serve as a basis for re-enabling it.

## Licensing

I confirm this contribution is made under the terms of the MIT license of this repository (see LICENSE).
