### PR TITLE
I/P: Support Amazon Linux 2023 remote hosts

### DIFF
--- a/ip/README.md
+++ b/ip/README.md
@@ -90,6 +90,8 @@ I/R appears to be running locally. No user configuration is needed.
 - `setup_ubuntu.sh` — Installs Isabelle on a remote Ubuntu/Debian host (aarch64 or x86_64).
 - `setup_al2.sh` — Installs Isabelle on a remote Amazon Linux 2
    host, building Poly/ML from source (to avoid glibc versioning issue).
+- `setup_al2023.sh` — Installs Isabelle on a remote Amazon Linux 2023
+  host using the packaged Poly/ML binary after a compatibility check.
 
 ## Poly/ML Tuning
 

--- a/ip/configure-remote.py
+++ b/ip/configure-remote.py
@@ -336,23 +336,31 @@ def remote_sha1(host, path):
 
 
 def detect_remote(host):
-    """Detect remote arch and OS. Returns (arch, os_id)."""
+    """Detect remote arch and OS. Returns (arch, os_id, os_version)."""
     arch = ssh_check(host, "uname", "-m")
     if not arch:
         die("Failed to detect remote architecture")
     os_id = ssh_check(host, "bash", "-c",
                        "'source /etc/os-release 2>/dev/null && echo $ID'") or "unknown"
-    return arch, os_id
+    os_version = ssh_check(host, "bash", "-c",
+                           "'source /etc/os-release 2>/dev/null && echo $VERSION_ID'") or "unknown"
+    return arch, os_id, os_version
 
 
-def pick_setup_script(arch, os_id):
+def pick_setup_script(arch, os_id, os_version):
     """Pick the right setup script for the detected system."""
     if os_id in ("ubuntu", "debian"):
         return os.path.join(SCRIPT_DIR, "setup_ubuntu.sh")
-    elif os_id in ("amzn",):
+    elif os_id == "amzn" and os_version == "2":
         return os.path.join(SCRIPT_DIR, "setup_al2.sh")
+    elif os_id == "amzn" and os_version == "2023":
+        return os.path.join(SCRIPT_DIR, "setup_al2023.sh")
+    elif os_id == "amzn":
+        die(f"Unsupported Amazon Linux version: {os_version} "
+            "(supported: 2, 2023)")
     else:
-        die(f"Unsupported OS: {os_id} (supported: Ubuntu/Debian, Amazon Linux 2)")
+        die(f"Unsupported OS: {os_id} "
+            "(supported: Ubuntu/Debian, Amazon Linux 2/2023)")
 
 
 def resolve_local_home(explicit):
@@ -487,7 +495,7 @@ def cmd_setup(args):
         info("Remote Isabelle removed. Re-run setup to reinstall.")
         return
 
-    arch, os_id = detect_remote(host)
+    arch, os_id, os_version = detect_remote(host)
 
     # Early check: if we know the platform name and it exists locally,
     # fail fast before running expensive remote setup.
@@ -511,7 +519,7 @@ def cmd_setup(args):
             step(f"Remote Isabelle already installed with Pure+HOL heaps — skipping setup")
         else:
             step(f"Remote Isabelle installed but heaps missing — rebuilding Pure+HOL")
-            setup_script = pick_setup_script(arch, os_id)
+            setup_script = pick_setup_script(arch, os_id, os_version)
             setup_args = [setup_script, host, remote_home,
                           "64" if args.use_64 else "32"]
             if args.copy_from_local:
@@ -521,7 +529,7 @@ def cmd_setup(args):
                 step_fail("Remote heap build failed")
     else:
         # Full install
-        setup_script = pick_setup_script(arch, os_id)
+        setup_script = pick_setup_script(arch, os_id, os_version)
         step(f"Setting up Isabelle on remote ({os.path.basename(setup_script)})")
         setup_args = [setup_script, host, remote_home,
                       "64" if args.use_64 else "32"]
@@ -689,9 +697,10 @@ def cmd_run(args):
     if ssh_check(host, "true", timeout=10) is None:
         step_fail(f"Cannot connect to {host}")
 
-    arch, os_id = detect_remote(host)
+    arch, os_id, os_version = detect_remote(host)
 
-    step(f"Checking remote Isabelle installation: {remote_home} ({arch} {os_id})")
+    step(f"Checking remote Isabelle installation: {remote_home} "
+         f"({arch} {os_id} {os_version})")
     if ssh_check(host, "test", "-d", remote_home) is None:
         step_fail(f"Isabelle not found at {remote_home} (run 'setup' first)")
 

--- a/ip/setup_al2023.sh
+++ b/ip/setup_al2023.sh
@@ -1,0 +1,99 @@
+#!/usr/bin/env bash
+# Setup Isabelle 2025-2 on a remote Amazon Linux 2023 host (aarch64 or x86_64).
+# Uses the Poly/ML binary shipped with Isabelle after verifying it runs locally.
+# Usage: setup_al2023.sh user@host [install_dir] [64|32] [skip_build]
+set -euo pipefail
+
+REMOTE="${1:?Usage: $0 user@host [install_dir] [64|32] [skip_build]}"
+INSTALL_DIR="${2:-$HOME/Isabelle2025-2}"
+BITS="${3:-64}"
+SKIP_BUILD="${4:-}"
+
+REMOTE_ARCH=$(ssh "$REMOTE" uname -m)
+case "$REMOTE_ARCH" in
+  aarch64)
+    URL="https://isabelle.in.tum.de/website-Isabelle2025-2/dist/Isabelle2025-2_linux_arm.tar.gz"
+    TARBALL="Isabelle2025-2_linux_arm.tar.gz"
+    ;;
+  x86_64)
+    URL="https://isabelle.in.tum.de/website-Isabelle2025-2/dist/Isabelle2025-2_linux.tar.gz"
+    TARBALL="Isabelle2025-2_linux.tar.gz"
+    ;;
+  *)
+    echo "Unsupported architecture: $REMOTE_ARCH" >&2
+    exit 1
+    ;;
+esac
+
+echo "=== Setting up Isabelle on $REMOTE (Amazon Linux 2023, $REMOTE_ARCH, ${BITS}-bit) ==="
+
+ssh "$REMOTE" bash -s "$URL" "$TARBALL" "$INSTALL_DIR" "$BITS" "$SKIP_BUILD" <<'REMOTE_SCRIPT'
+set -euo pipefail
+URL="$1"; TARBALL="$2"; INSTALL_DIR="$3"; BITS="$4"; SKIP_BUILD="${5:-}"
+[[ "$INSTALL_DIR" = /* ]] || { echo "INSTALL_DIR must be an absolute path" >&2; exit 1; }
+[[ "$BITS" = "32" || "$BITS" = "64" ]] || {
+  echo "BITS must be 32 or 64" >&2
+  exit 1
+}
+
+source /etc/os-release
+[[ "$ID" = "amzn" && "$VERSION_ID" = "2023" ]] || {
+  echo "Expected Amazon Linux 2023, found $ID $VERSION_ID" >&2
+  exit 1
+}
+
+# fontconfig is needed by Isabelle's Java/Scala layer.
+sudo dnf install -y fontconfig
+
+if [ -x "$INSTALL_DIR/bin/isabelle" ]; then
+  echo "Already installed: $INSTALL_DIR"
+elif [ -e "$INSTALL_DIR" ]; then
+  echo "Install path exists but is not a valid Isabelle installation: $INSTALL_DIR" >&2
+  exit 1
+else
+  if [ ! -f "/tmp/$TARBALL" ]; then
+    echo "Downloading $URL ..."
+    curl -fSL --retry 5 --retry-all-errors --retry-delay 5 \
+      -o "/tmp/$TARBALL" "$URL"
+  fi
+  echo "Unpacking ..."
+  TMP_DIR=$(mktemp -d /tmp/isabelle-setup.XXXXXX)
+  trap 'rm -rf "$TMP_DIR"' EXIT
+  tar xzf "/tmp/$TARBALL" -C "$TMP_DIR"
+  mkdir -p "$(dirname "$INSTALL_DIR")"
+  mv "$TMP_DIR/Isabelle2025-2" "$INSTALL_DIR"
+  echo "Installed: $INSTALL_DIR"
+fi
+
+PREFS_DIR="$("$INSTALL_DIR"/bin/isabelle getenv -b ISABELLE_HOME_USER)/etc"
+mkdir -p "$PREFS_DIR"
+grep -qxF 'SystemOnTPTP = ""' "$PREFS_DIR/preferences" 2>/dev/null ||
+  echo 'SystemOnTPTP = ""' >> "$PREFS_DIR/preferences"
+
+BASE_PLATFORM=$("$INSTALL_DIR"/bin/isabelle getenv -b ISABELLE_PLATFORM64)
+if [ "$BITS" = "32" ]; then
+  BASE_PLATFORM=${BASE_PLATFORM/x86_64-/x86_64_32-}
+  BASE_PLATFORM=${BASE_PLATFORM/arm64-/arm64_32-}
+fi
+POLY="$INSTALL_DIR/contrib/polyml-5.9.2-2/$BASE_PLATFORM/poly"
+
+echo "Checking packaged Poly/ML on $(getconf GNU_LIBC_VERSION) ..."
+if [ ! -x "$POLY" ] || ! "$POLY" --version </dev/null; then
+  echo "Packaged Poly/ML is incompatible with this host: $POLY" >&2
+  exit 1
+fi
+
+if [ -z "$SKIP_BUILD" ]; then
+  ML_64_OPT=""
+  if [ "$BITS" = "64" ]; then ML_64_OPT="-o ML_system_64=true"; fi
+
+  # Remove pre-built system heaps so isabelle build writes to the user directory.
+  rm -rf "$INSTALL_DIR/heaps"
+  echo "Building Pure + HOL (${BITS}-bit) ..."
+  "$INSTALL_DIR"/bin/isabelle build -b $ML_64_OPT HOL
+else
+  echo "Skipping heap build (--copy-from-local)"
+fi
+
+echo "=== Done ==="
+REMOTE_SCRIPT


### PR DESCRIPTION
`configure-remote.py setup` chooses a remote host's install script from what that host reports in `/etc/os-release`: `ID`, a machine-readable distribution name (`ubuntu`, `debian`, `amzn`), and `VERSION_ID`, its release (`22.04`, `12`, `2`, `2023`). It read `ID` and nothing else. Both Amazon Linux generations answer `amzn`, so both got setup_al2.sh, which builds Poly/ML from source because Amazon Linux 2's glibc predates the one Isabelle's packaged Poly/ML was linked against. AL2023 is recent enough to run that packaged binary, so the source build was a detour it never owed.

Dispatch on the pair instead: `2` keeps setup_al2.sh, `2023` gets the new setup_al2023.sh, and any other Amazon Linux release fails naming the two that are supported rather than taking the AL2 path unannounced. `VERSION_ID` is optional in the os-release spec, so a host that omits it counts as an unsupported release — defaulting it to AL2 is the behaviour this commit exists to remove.

setup_al2023.sh takes the packaged Poly/ML rather than building one, but does not take on faith that it runs: it execs `poly --version` on the host and reports the host's glibc version when that fails, so an incompatible binary surfaces before the HOL build rather than partway through it. Two smaller things it declines to assume — fontconfig, which Isabelle's Java/Scala layer needs and the AL2023 minimal AMI leaves out, is installed rather than expected; and the host's own `ID` and `VERSION_ID` are re-checked before anything is written, so a misdispatch stops at the first command instead of after unpacking a tarball.

`run` prints the release beside the architecture and distribution it printed already, which is what names the Amazon Linux generation in a log.